### PR TITLE
fix: resolve template dir from project root instead of cwd

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,11 @@ import { watch } from "node:fs";
 import { open, readFile, stat } from "node:fs/promises";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
 
 import { CodexAdapter } from "@specrail/adapters";
 import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
@@ -113,7 +117,7 @@ function createDependencies(dataDir: string): DefaultDependencies {
   const artifactRoot = path.join(dataDir, "artifacts");
   const workspaceRoot = path.join(dataDir, "workspaces");
   const sessionsDir = path.join(dataDir, "sessions");
-  const templateDir = path.resolve(process.cwd(), ".specrail-template");
+  const templateDir = path.resolve(PROJECT_ROOT, ".specrail-template");
 
   const eventStore = new JsonlEventStore(stateDir);
   const projectRepository = new FileProjectRepository(stateDir);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@specrail/adapters':
+        specifier: workspace:*
+        version: link:../../packages/adapters
       '@specrail/config':
         specifier: workspace:*
         version: link:../../packages/config


### PR DESCRIPTION
## Summary
- `pnpm --filter`로 API를 실행하면 cwd가 `apps/api/`로 변경되어 `.specrail-template/` 경로를 찾지 못하는 ENOENT 에러 수정
- `process.cwd()` 대신 `import.meta.url` 기반으로 프로젝트 루트를 계산하여 템플릿 디렉토리를 안정적으로 참조

## Test plan
- [x] API 테스트 10개 모두 통과 확인
- [x] `pnpm dev:api` 실행 후 `POST /tracks` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)