### PR TITLE
fix: omit codex default profile flag

### DIFF
--- a/packages/adapters/src/__tests__/codex-adapter.test.ts
+++ b/packages/adapters/src/__tests__/codex-adapter.test.ts
@@ -39,7 +39,7 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-test("buildCodexSpawnCommand creates a deterministic codex exec invocation", () => {
+test("buildCodexSpawnCommand omits the profile flag for the default profile", () => {
   const command = buildCodexSpawnCommand({
     executionId: "run-1",
     prompt: "Implement the endpoint",
@@ -49,17 +49,36 @@ test("buildCodexSpawnCommand creates a deterministic codex exec invocation", () 
 
   assert.equal(command.command, "codex");
   assert.equal(command.cwd, "/tmp/specrail/run-1");
-  assert.deepEqual(command.args.slice(0, 6), [
+  assert.deepEqual(command.args.slice(0, 5), [
+    "exec",
+    "--json",
+    "--output-last-message",
+    command.args[3],
+    "--skip-git-repo-check",
+  ]);
+  assert.equal(command.args[5], "Implement the endpoint");
+  assert.ok(!command.args.includes("--profile"));
+  assert.match(command.args[3] ?? "", /run-1-codex\.last-message\.txt$/);
+});
+
+test("buildCodexSpawnCommand preserves explicit non-default profiles", () => {
+  const command = buildCodexSpawnCommand({
+    executionId: "run-2",
+    prompt: "Implement the endpoint",
+    workspacePath: "/tmp/specrail/run-2",
+    profile: "fast-lane",
+  });
+
+  assert.deepEqual(command.args.slice(0, 7), [
     "exec",
     "--json",
     "--output-last-message",
     command.args[3],
     "--skip-git-repo-check",
     "--profile",
+    "fast-lane",
   ]);
-  assert.equal(command.args[6], "default");
   assert.equal(command.args[7], "Implement the endpoint");
-  assert.match(command.args[3] ?? "", /run-1-codex\.last-message\.txt$/);
 });
 
 test("CodexAdapter persists process metadata, parses session id, records runtime events, and fans them out", async () => {

--- a/packages/adapters/src/providers/codex-adapter.stub.ts
+++ b/packages/adapters/src/providers/codex-adapter.stub.ts
@@ -135,16 +135,7 @@ export function buildCodexSpawnCommand(input: SpawnExecutionInput): ExecutorComm
   const sessionRef = `${input.executionId}-codex`;
   return {
     command: "codex",
-    args: [
-      "exec",
-      "--json",
-      "--output-last-message",
-      buildSessionLastMessagePath(path.resolve(process.cwd(), ".specrail-data", "sessions"), sessionRef),
-      "--skip-git-repo-check",
-      "--profile",
-      input.profile,
-      input.prompt,
-    ],
+    args: buildCodexSpawnArgs(input, path.resolve(process.cwd(), ".specrail-data", "sessions"), sessionRef),
     cwd: input.workspacePath,
   };
 }
@@ -153,18 +144,26 @@ function buildCodexSpawnCommandForSessionsDir(input: SpawnExecutionInput, sessio
   const sessionRef = `${input.executionId}-codex`;
   return {
     command: "codex",
-    args: [
-      "exec",
-      "--json",
-      "--output-last-message",
-      buildSessionLastMessagePath(sessionsDir, sessionRef),
-      "--skip-git-repo-check",
-      "--profile",
-      input.profile,
-      input.prompt,
-    ],
+    args: buildCodexSpawnArgs(input, sessionsDir, sessionRef),
     cwd: input.workspacePath,
   };
+}
+
+function buildCodexSpawnArgs(input: SpawnExecutionInput, sessionsDir: string, sessionRef: string): string[] {
+  const args = [
+    "exec",
+    "--json",
+    "--output-last-message",
+    buildSessionLastMessagePath(sessionsDir, sessionRef),
+    "--skip-git-repo-check",
+  ];
+
+  if (input.profile && input.profile !== "default") {
+    args.push("--profile", input.profile);
+  }
+
+  args.push(input.prompt);
+  return args;
 }
 
 function buildCodexResumeCommand(input: ResumeExecutionInput, sessionsDir: string, sessionRef: string): ExecutorCommandSpec {


### PR DESCRIPTION
## Summary
- omit `--profile` when the requested run profile is `default`
- preserve explicit non-default profiles in Codex spawn commands
- add adapter tests covering both default and custom profile cases

## Test plan
- [x] pnpm test
- [x] pnpm check

Closes #26