### PR TITLE
feat: restore github sync and OpenSpec admin work

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ Current endpoints in `apps/api/src/index.ts`:
   - body: `{ trackId, path, overwrite? }`
 - `POST /admin/openspec/import`
   - preview or import an OpenSpec bundle and create/update the referenced track plus artifacts
-  - body: `{ path, dryRun?, conflictPolicy?, resolution? }`
+  - body: `{ path, dryRun?, conflictPolicy?, resolutionPreset?, resolution? }`
   - `dryRun: true` previews the normalized track and collision status without writing files or track state
   - `conflictPolicy` supports `reject` (default, safe preview-first flow), `overwrite` (replace the whole imported payload), and `resolve` (apply a field/artifact-level `resolution` map where `existing` keeps the current value and `incoming` applies the bundle value)
-  - response now includes `provenance`, `importHistory`, `resolvedArtifacts`, and `conflict.details[]` so callers can inspect source path, bundle metadata, selected resolution choices, and which fields would be replaced
+  - `resolutionPreset` supports `policyDefaults`, `preferIncomingArtifacts`, `preserveWorkflowState`, and `preferIncomingAll`; explicit `resolution` entries override preset defaults field-by-field
+  - source-of-truth defaults treat OpenSpec as authoritative for `title`, `description`, `spec`, `plan`, and `tasks`, while SpecRail remains authoritative for workflow state and local GitHub linkage (`status`, `specStatus`, `planStatus`, `priority`, `githubIssue`, `githubPullRequest`)
+  - response now includes `provenance`, `importHistory`, `resolvedArtifacts`, `resolutionGuide`, and `conflict.details[]` so callers can inspect source path, bundle metadata, available presets, effective choices, policies, and which fields would be replaced
   - applied imports persist `track.openSpecImport` as the latest provenance plus `track.openSpecImportHistory[]` in state and artifact metadata (`track.json`) for auditability
 - `GET /admin/openspec/imports`
   - list persisted OpenSpec import history across tracks

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Current endpoints in `apps/api/src/index.ts`:
 ### Tracks
 - `POST /tracks`
   - create a track
-  - body: `{ title, description, priority? }`
+  - body: `{ title, description, priority?, githubIssue?, githubPullRequest? }`
 - `GET /tracks`
   - list tracks with pagination and explicit sorting
   - default sort: `sortBy=updatedAt&sortOrder=desc`
@@ -75,7 +75,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - return track metadata plus `spec`, `plan`, and `tasks` artifact contents
 - `PATCH /tracks/:trackId`
   - update workflow state
-  - body: any of `{ status, specStatus, planStatus }`
+  - body: any of `{ status, specStatus, planStatus, githubIssue, githubPullRequest }`
 
 ### Runs
 - `POST /runs`
@@ -149,6 +149,7 @@ Notes:
 ### Track
 - lifecycle status: `new | planned | ready | in_progress | blocked | review | done | failed`
 - approval status fields: `specStatus`, `planStatus`
+- optional GitHub linkage fields: `githubIssue`, `githubPullRequest` with `{ number, url }`
 - priority: `low | medium | high`
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ At runtime the API writes under `SPECRAIL_DATA_DIR` (default from config), with 
       <runId>.json
     events/
       <runId>.jsonl
+    github-run-comment-sync/
+      <trackId>.json
   sessions/
     <sessionRef>.json
     <sessionRef>.events.jsonl
@@ -143,6 +145,7 @@ At runtime the API writes under `SPECRAIL_DATA_DIR` (default from config), with 
 Notes:
 - `artifacts/tracks/<trackId>/events.jsonl` is materialized as part of the artifact contract.
 - the current API reads run events from `state/events/<runId>.jsonl`.
+- GitHub run summary sync metadata is persisted under `state/github-run-comment-sync/<trackId>.json`.
 - session-level executor logs are also persisted separately under `sessions/`.
 
 ## Domain model snapshot
@@ -159,6 +162,7 @@ Notes:
 - terminal run states reconcile back into track status with a first-pass policy: `completed -> review`, `failed -> failed`, `cancelled -> blocked`
 - run metadata stores backend, profile, workspace path, branch name, session ref, command metadata, and event summary
 - `@specrail/core` exposes `formatGitHubRunCommentSummary(...)` plus `SpecRailService.publishRunSummary(...)` for deterministic linked issue/PR comment sync
+- published summary sync state stores last comment ids and sync outcomes so retries can reuse known GitHub comments before falling back to marker scans
 
 ### Event types
 Normalized event types currently defined in core:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - web UI, GitHub app/webhooks, or chat integrations
 - artifact editing endpoints
 - automatic track reconciliation from terminal run outcomes beyond the current first-pass policy
-- posting GitHub issue/PR comments or checks from linked run summaries (the formatter now exists, publish flow still pending)
+- GitHub check-run publishing beyond the current linked issue/PR comment sync
 
 ## HTTP API
 
@@ -158,7 +158,7 @@ Notes:
 - current API actively exercises `running`, `completed`, `failed`, and `cancelled`
 - terminal run states reconcile back into track status with a first-pass policy: `completed -> review`, `failed -> failed`, `cancelled -> blocked`
 - run metadata stores backend, profile, workspace path, branch name, session ref, command metadata, and event summary
-- `@specrail/core` now exposes `formatGitHubRunCommentSummary(...)` to turn a track + run + recent events into a deterministic GitHub issue/PR comment body
+- `@specrail/core` exposes `formatGitHubRunCommentSummary(...)` plus `SpecRailService.publishRunSummary(...)` for deterministic linked issue/PR comment sync
 
 ### Event types
 Normalized event types currently defined in core:
@@ -199,6 +199,9 @@ specrail/
 pnpm install
 pnpm test
 pnpm dev:api
+
+# optional: publish linked run summaries back to GitHub via gh auth
+SPECRAIL_GITHUB_PUBLISH=1 pnpm dev:api
 ```
 
 Then call the API locally, for example:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Current endpoints in `apps/api/src/index.ts`:
   - body: `{ path, dryRun?, conflictPolicy? }`
   - `dryRun: true` previews the normalized track and collision status without writing files or track state
   - `conflictPolicy` supports `reject` (default, safe preview-first flow) and `overwrite` (explicitly update an existing track id)
+  - response now includes `provenance` plus `conflict.details[]` so callers can see source path, bundle metadata, and which track/artifact fields would be replaced
+  - applied imports persist `track.openSpecImport` into state and artifact metadata (`track.json`) for auditability
 
 ### Runs
 - `POST /runs`

--- a/README.md
+++ b/README.md
@@ -108,10 +108,13 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /admin/openspec/imports`
   - list persisted OpenSpec import history across tracks
   - query: `trackId?`, `limit?`
+- `GET /admin/openspec/exports`
+  - list persisted OpenSpec export history across tracks
+  - query: `trackId?`, `limit?`
 - `GET /tracks/:trackId/openspec/imports`
-  - return the latest OpenSpec provenance and persisted import history for a single track
+  - return the latest OpenSpec import/export provenance and persisted history for a single track
 - `GET /tracks/:trackId` and `GET /tracks/:trackId/integrations`
-  - now include OpenSpec import inspection data alongside track state and GitHub sync metadata
+  - now include OpenSpec import/export inspection data alongside track state and GitHub sync metadata
 
 ### Terminal admin wrapper
 A terminal wrapper now exposes the same guided OpenSpec admin flow without needing the HTTP admin routes first.
@@ -131,6 +134,9 @@ pnpm --filter @specrail/api openspec:import:help -- --preset policyDefaults
 
 # inspect persisted import history
 pnpm --filter @specrail/api openspec:imports -- --track-id track_123 --limit 10
+
+# inspect persisted export history
+pnpm --filter @specrail/api openspec:exports -- --track-id track_123 --limit 10
 ```
 
 Notes:
@@ -139,6 +145,7 @@ Notes:
 - apply mode auto-selects `conflictPolicy=resolve` when a preset or explicit keep/take overrides are supplied
 - field overrides are available via `--existing track.status,artifacts.plan` and `--incoming track.title`
 - import history can be filtered with `--track-id` and truncated with `--limit`
+- export history can be filtered with `--track-id` and truncated with `--limit`
 - JSON output is available with `--json` for scripting or operator tooling
 
 ### Runs

--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ Current endpoints in `apps/api/src/index.ts`:
   - now include OpenSpec import inspection data alongside track state and GitHub sync metadata
 
 ### Terminal admin wrapper
-A terminal wrapper now exposes the same guided OpenSpec import flow without needing the HTTP admin route first.
+A terminal wrapper now exposes the same guided OpenSpec admin flow without needing the HTTP admin routes first.
 
 ```bash
+# export a track bundle from the terminal
+pnpm --filter @specrail/api openspec:export -- --track-id track_123 --path ./bundle
+
 # preview with operator guidance
 pnpm --filter @specrail/api openspec:import -- --path ./bundle --preview
 
@@ -125,12 +128,17 @@ pnpm --filter @specrail/api openspec:import -- --path ./bundle --apply --preset 
 
 # inspect preset guidance from the terminal
 pnpm --filter @specrail/api openspec:import:help -- --preset policyDefaults
+
+# inspect persisted import history
+pnpm --filter @specrail/api openspec:imports -- --track-id track_123 --limit 10
 ```
 
 Notes:
+- export requires `--track-id` and `--path`; pass `--overwrite` to reuse an existing bundle directory
 - preview mode defaults to `dryRun=true` with `conflictPolicy=reject`
 - apply mode auto-selects `conflictPolicy=resolve` when a preset or explicit keep/take overrides are supplied
 - field overrides are available via `--existing track.status,artifacts.plan` and `--incoming track.title`
+- import history can be filtered with `--track-id` and truncated with `--limit`
 - JSON output is available with `--json` for scripting or operator tooling
 
 ### Runs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - resume and cancel a run
 - expose run events through JSON and SSE APIs
 - list tracks and runs with filtering, pagination, and sorting
-- import/export track artifact bundles through a first OpenSpec file adapter boundary
+- import/export track artifact bundles through a service-wired OpenSpec file adapter flow
 
 ## Current MVP status
 
@@ -48,7 +48,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - SSE event streaming for run events
 - request validation and structured API errors
 - automated API/config/adapter tests
-- file-based OpenSpec bundle import/export scaffold in `@specrail/adapters`
+- file-based OpenSpec bundle import/export scaffold in `@specrail/adapters`, wired into service and admin API flows
 
 ### Not implemented yet
 - authentication and multi-user access control
@@ -87,6 +87,14 @@ Current endpoints in `apps/api/src/index.ts`:
 - `PATCH /tracks/:trackId`
   - update workflow state
   - body: any of `{ status, specStatus, planStatus, githubIssue, githubPullRequest }`
+
+### Admin OpenSpec
+- `POST /admin/openspec/export`
+  - export a track into an OpenSpec file bundle
+  - body: `{ trackId, path, overwrite? }`
+- `POST /admin/openspec/import`
+  - import an OpenSpec bundle and create/update the referenced track plus artifacts
+  - body: `{ path }`
 
 ### Runs
 - `POST /runs`
@@ -266,7 +274,7 @@ Manifest example:
 Notes:
 - the bundle stores full `Track` metadata in `openspec.json`
 - markdown artifacts stay as separate files so they remain reviewable and diff-friendly
-- this is an adapter boundary and scaffold, not yet wired into API routes or sync automation
+- the file adapter is now wired into `SpecRailService` and exposed through admin API import/export routes
 
 ## Verification source of truth
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /tracks/:trackId` and `GET /tracks/:trackId/integrations`
   - now include OpenSpec import inspection data alongside track state and GitHub sync metadata
 
+### Terminal admin wrapper
+A terminal wrapper now exposes the same guided OpenSpec import flow without needing the HTTP admin route first.
+
+```bash
+# preview with operator guidance
+pnpm --filter @specrail/api openspec:import -- --path ./bundle --preview
+
+# apply with the recommended preset-driven resolve flow
+pnpm --filter @specrail/api openspec:import -- --path ./bundle --apply --preset policyDefaults
+
+# inspect preset guidance from the terminal
+pnpm --filter @specrail/api openspec:import:help -- --preset policyDefaults
+```
+
+Notes:
+- preview mode defaults to `dryRun=true` with `conflictPolicy=reject`
+- apply mode auto-selects `conflictPolicy=resolve` when a preset or explicit keep/take overrides are supplied
+- field overrides are available via `--existing track.status,artifacts.plan` and `--incoming track.title`
+- JSON output is available with `--json` for scripting or operator tooling
+
 ### Runs
 - `POST /runs`
   - start a run for a track

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /tracks/:trackId/integrations`
   - lightweight integration inspection route for polling/debug tooling without artifact payloads
   - returns linked GitHub issue/PR references, raw `runCommentSync`, and summary fields like `linkedTargetCount`, `syncedTargetCount`, `lastPublishedAt`, `lastSyncStatus`, and `lastSyncError`
+- `POST /tracks/:trackId/integrations/github/run-comment-sync/retry`
+  - retries the latest failed GitHub run comment sync for the track by reusing the stored `lastRunId` and existing publish flow
+  - returns `{ trackId, runId, results, integrations }`
+  - `409 conflict` when the track has no failed GitHub run comment syncs to retry
 - `PATCH /tracks/:trackId`
   - update workflow state
   - body: any of `{ status, specStatus, planStatus, githubIssue, githubPullRequest }`
@@ -107,6 +111,7 @@ Current endpoints in `apps/api/src/index.ts`:
 ### Error contract
 - `400` for malformed JSON
 - `404` for missing tracks/runs
+- `409` for retry/conflict cases such as retrying a track with no failed GitHub sync state
 - `422` for validation failures
   - includes invalid pagination/sort params
 - `500` for unexpected server errors

--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ Current endpoints in `apps/api/src/index.ts`:
   - `conflictPolicy` supports `reject` (default, safe preview-first flow), `overwrite` (replace the whole imported payload), and `resolve` (apply a field/artifact-level `resolution` map where `existing` keeps the current value and `incoming` applies the bundle value)
   - `resolutionPreset` supports `policyDefaults`, `preferIncomingArtifacts`, `preserveWorkflowState`, and `preferIncomingAll`; explicit `resolution` entries override preset defaults field-by-field
   - source-of-truth defaults treat OpenSpec as authoritative for `title`, `description`, `spec`, `plan`, and `tasks`, while SpecRail remains authoritative for workflow state and local GitHub linkage (`status`, `specStatus`, `planStatus`, `priority`, `githubIssue`, `githubPullRequest`)
-  - response now includes `provenance`, `importHistory`, `resolvedArtifacts`, `resolutionGuide`, and `conflict.details[]` so callers can inspect source path, bundle metadata, available presets, effective choices, policies, and which fields would be replaced
+  - response now includes `provenance`, `importHistory`, `resolvedArtifacts`, `resolutionGuide`, `operatorGuide`, and `conflict.details[]` so callers can inspect source path, bundle metadata, available presets, operator-facing preset guidance, effective choices, policies, and which fields would be replaced
   - applied imports persist `track.openSpecImport` as the latest provenance plus `track.openSpecImportHistory[]` in state and artifact metadata (`track.json`) for auditability
+- `GET /admin/openspec/import/help`
+  - return operator-facing preset selection guidance without requiring a bundle path
+  - query: `resolutionPreset?=policyDefaults|preferIncomingArtifacts|preserveWorkflowState|preferIncomingAll`
+  - response includes `operatorGuide.recommendedFlow`, conflict-policy descriptions, example request payloads, and a human-friendly `selectedPreset`/`effectiveChoices` breakdown for the requested preset
 - `GET /admin/openspec/imports`
   - list persisted OpenSpec import history across tracks
   - query: `trackId?`, `limit?`

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Current endpoints in `apps/api/src/index.ts`:
   - export a track into an OpenSpec file bundle
   - body: `{ trackId, path, overwrite? }`
 - `POST /admin/openspec/import`
-  - import an OpenSpec bundle and create/update the referenced track plus artifacts
-  - body: `{ path }`
+  - preview or import an OpenSpec bundle and create/update the referenced track plus artifacts
+  - body: `{ path, dryRun?, conflictPolicy? }`
+  - `dryRun: true` previews the normalized track and collision status without writing files or track state
+  - `conflictPolicy` supports `reject` (default, safe preview-first flow) and `overwrite` (explicitly update an existing track id)
 
 ### Runs
 - `POST /runs`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - web UI, GitHub app/webhooks, or chat integrations
 - artifact editing endpoints
 - automatic track reconciliation from terminal run outcomes beyond the current first-pass policy
+- posting GitHub issue/PR comments or checks from linked run summaries (the formatter now exists, publish flow still pending)
 
 ## HTTP API
 
@@ -157,6 +158,7 @@ Notes:
 - current API actively exercises `running`, `completed`, `failed`, and `cancelled`
 - terminal run states reconcile back into track status with a first-pass policy: `completed -> review`, `failed -> failed`, `cancelled -> blocked`
 - run metadata stores backend, profile, workspace path, branch name, session ref, command metadata, and event summary
+- `@specrail/core` now exposes `formatGitHubRunCommentSummary(...)` to turn a track + run + recent events into a deterministic GitHub issue/PR comment body
 
 ### Event types
 Normalized event types currently defined in core:

--- a/README.md
+++ b/README.md
@@ -94,11 +94,18 @@ Current endpoints in `apps/api/src/index.ts`:
   - body: `{ trackId, path, overwrite? }`
 - `POST /admin/openspec/import`
   - preview or import an OpenSpec bundle and create/update the referenced track plus artifacts
-  - body: `{ path, dryRun?, conflictPolicy? }`
+  - body: `{ path, dryRun?, conflictPolicy?, resolution? }`
   - `dryRun: true` previews the normalized track and collision status without writing files or track state
-  - `conflictPolicy` supports `reject` (default, safe preview-first flow) and `overwrite` (explicitly update an existing track id)
-  - response now includes `provenance` plus `conflict.details[]` so callers can see source path, bundle metadata, and which track/artifact fields would be replaced
-  - applied imports persist `track.openSpecImport` into state and artifact metadata (`track.json`) for auditability
+  - `conflictPolicy` supports `reject` (default, safe preview-first flow), `overwrite` (replace the whole imported payload), and `resolve` (apply a field/artifact-level `resolution` map where `existing` keeps the current value and `incoming` applies the bundle value)
+  - response now includes `provenance`, `importHistory`, `resolvedArtifacts`, and `conflict.details[]` so callers can inspect source path, bundle metadata, selected resolution choices, and which fields would be replaced
+  - applied imports persist `track.openSpecImport` as the latest provenance plus `track.openSpecImportHistory[]` in state and artifact metadata (`track.json`) for auditability
+- `GET /admin/openspec/imports`
+  - list persisted OpenSpec import history across tracks
+  - query: `trackId?`, `limit?`
+- `GET /tracks/:trackId/openspec/imports`
+  - return the latest OpenSpec provenance and persisted import history for a single track
+- `GET /tracks/:trackId` and `GET /tracks/:trackId/integrations`
+  - now include OpenSpec import inspection data alongside track state and GitHub sync metadata
 
 ### Runs
 - `POST /runs`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - response includes `meta: { page, pageSize, sortBy, sortOrder, total, totalPages, hasNextPage, hasPrevPage }`
 - `GET /tracks/:trackId`
   - return track metadata plus `spec`, `plan`, and `tasks` artifact contents
+  - also returns `githubRunCommentSync`, when present, with persisted target comment ids, last sync status, last sync error, and last published run info
 - `PATCH /tracks/:trackId`
   - update workflow state
   - body: any of `{ status, specStatus, planStatus, githubIssue, githubPullRequest }`
@@ -89,6 +90,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - response includes `meta: { page, pageSize, sortBy, sortOrder, total, totalPages, hasNextPage, hasPrevPage }`
 - `GET /runs/:runId`
   - return persisted run metadata
+  - also returns `githubRunCommentSync` for the parent track and `githubRunCommentSyncForRun` filtered to entries last published for that run
 - `POST /runs/:runId/resume`
   - resume an existing run
   - body: `{ prompt }`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - resume and cancel a run
 - expose run events through JSON and SSE APIs
 - list tracks and runs with filtering, pagination, and sorting
+- import/export track artifact bundles through a first OpenSpec file adapter boundary
 
 ## Current MVP status
 
@@ -47,6 +48,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 - SSE event streaming for run events
 - request validation and structured API errors
 - automated API/config/adapter tests
+- file-based OpenSpec bundle import/export scaffold in `@specrail/adapters`
 
 ### Not implemented yet
 - authentication and multi-user access control
@@ -226,6 +228,46 @@ curl -X POST http://127.0.0.1:3000/tracks \
   -d '{"title":"Executor MVP","description":"Persist command metadata and launch runs.","priority":"high"}'
 ```
 
+## OpenSpec adapter boundary
+
+`@specrail/adapters` now exposes a transport-neutral `OpenSpecAdapter` contract plus a first `FileOpenSpecAdapter` implementation.
+
+Current file bundle shape:
+
+```text
+<bundle-dir>/
+  openspec.json
+  spec.md
+  plan.md
+  tasks.md
+```
+
+Manifest example:
+
+```json
+{
+  "metadata": {
+    "version": 1,
+    "format": "specrail.openspec.bundle",
+    "exportedAt": "2026-04-10T01:02:03.000Z",
+    "generatedBy": "specrail"
+  },
+  "track": {
+    "id": "track-openspec-1"
+  },
+  "files": {
+    "spec": "spec.md",
+    "plan": "plan.md",
+    "tasks": "tasks.md"
+  }
+}
+```
+
+Notes:
+- the bundle stores full `Track` metadata in `openspec.json`
+- markdown artifacts stay as separate files so they remain reviewable and diff-friendly
+- this is an adapter boundary and scaffold, not yet wired into API routes or sync automation
+
 ## Verification source of truth
 
 The docs above are aligned to the current MVP implementation and tests in:
@@ -234,6 +276,7 @@ The docs above are aligned to the current MVP implementation and tests in:
 - `packages/core/src/services/specrail-service.ts`
 - `packages/config/src/artifacts.ts`
 - `packages/adapters/src/providers/codex-adapter.stub.ts`
+- `packages/adapters/src/providers/file-openspec-adapter.ts`
 
 ## Related research
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /tracks/:trackId`
   - return track metadata plus `spec`, `plan`, and `tasks` artifact contents
   - also returns `githubRunCommentSync`, when present, with persisted target comment ids, last sync status, last sync error, and last published run info
+- `GET /tracks/:trackId/integrations`
+  - lightweight integration inspection route for polling/debug tooling without artifact payloads
+  - returns linked GitHub issue/PR references, raw `runCommentSync`, and summary fields like `linkedTargetCount`, `syncedTargetCount`, `lastPublishedAt`, `lastSyncStatus`, and `lastSyncError`
 - `PATCH /tracks/:trackId`
   - update workflow state
   - body: any of `{ status, specStatus, planStatus, githubIssue, githubPullRequest }`

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "openspec:import": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import",
     "openspec:import:help": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import help",
     "openspec:imports": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec imports",
+    "openspec:exports": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec exports",
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,8 +16,10 @@
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
     "dev": "node --watch --import tsx src/index.ts",
+    "openspec:export": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec export",
     "openspec:import": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import",
     "openspec:import:help": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import help",
+    "openspec:imports": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec imports",
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,10 +9,15 @@
       "default": "./src/index.ts"
     }
   },
+  "bin": {
+    "specrail-admin": "./dist/cli.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
     "dev": "node --watch --import tsx src/index.ts",
+    "openspec:import": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import",
+    "openspec:import:help": "tsx --tsconfig ../../tsconfig.base.json src/cli.ts openspec import help",
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -571,10 +571,17 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     });
     assert.equal(importResponse.status, 200);
 
-    const imported = (await importResponse.json()) as { action: string; applied: boolean; track: { id: string } };
+    const imported = (await importResponse.json()) as {
+      action: string;
+      applied: boolean;
+      provenance: { source: { path: string } };
+      track: { id: string; openSpecImport: { source: { path: string } } };
+    };
     assert.equal(imported.action, "updated");
     assert.equal(imported.applied, true);
     assert.equal(imported.track.id, trackPayload.track.id);
+    assert.equal(imported.provenance.source.path, bundleDir);
+    assert.equal(imported.track.openSpecImport.source.path, bundleDir);
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
@@ -618,13 +625,16 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
       action: string;
       applied: boolean;
       conflictPolicy: string;
-      conflict: { hasConflict: boolean; reason: string | null };
+      provenance: { source: { path: string } };
+      conflict: { hasConflict: boolean; reason: string | null; details: Array<{ field: string }> };
     };
     assert.equal(preview.action, "updated");
     assert.equal(preview.applied, false);
     assert.equal(preview.conflictPolicy, "reject");
+    assert.equal(preview.provenance.source.path, bundleDir);
     assert.equal(preview.conflict.hasConflict, true);
     assert.equal(preview.conflict.reason, "track_id_exists");
+    assert.ok(preview.conflict.details.some((detail) => detail.field === "artifacts.spec"));
 
     const conflictResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
@@ -632,6 +642,8 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
       body: JSON.stringify({ path: bundleDir }),
     });
     assert.equal(conflictResponse.status, 409);
+    const conflictPayload = (await conflictResponse.json()) as { error: { details: Array<{ field: string }> } };
+    assert.ok(conflictPayload.error.details.some((detail) => detail.field === "artifacts.spec"));
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import http from "node:http";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -119,6 +119,120 @@ async function openSseStream(url: string): Promise<{
     request.on("error", reject);
   });
 }
+
+test("API exposes GitHub sync metadata on track and run inspection routes", async () => {
+  await withServer(async (baseUrl, paths) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Sync inspection",
+        description: "Expose persisted GitHub sync state.",
+        githubIssue: {
+          number: 32,
+          url: "https://github.com/yoophi-a/specrail/issues/32",
+        },
+      }),
+    });
+    assert.equal(trackResponse.status, 201);
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const runResponse = await fetch(`${baseUrl}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        prompt: "Inspect sync metadata",
+      }),
+    });
+    assert.equal(runResponse.status, 201);
+    const runPayload = (await runResponse.json()) as { run: { id: string } };
+
+    const syncFilePath = path.join(paths.dataDir, "state", "github-run-comment-sync", `${trackPayload.track.id}.json`);
+    await mkdir(path.dirname(syncFilePath), { recursive: true });
+    await writeFile(
+      syncFilePath,
+      `${JSON.stringify(
+        {
+          id: trackPayload.track.id,
+          trackId: trackPayload.track.id,
+          updatedAt: "2026-04-10T03:00:00.000Z",
+          comments: [
+            {
+              target: {
+                kind: "issue",
+                number: 32,
+                url: "https://github.com/yoophi-a/specrail/issues/32",
+              },
+              commentId: 3201,
+              lastRunId: runPayload.run.id,
+              lastRunStatus: "running",
+              lastPublishedAt: "2026-04-10T02:59:30.000Z",
+              lastSyncStatus: "failed",
+              lastSyncError: "GitHub temporarily unavailable",
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
+    assert.equal(getTrackResponse.status, 200);
+    const getTrackPayload = (await getTrackResponse.json()) as {
+      githubRunCommentSync: {
+        updatedAt: string;
+        comments: Array<{
+          commentId?: number;
+          lastRunId: string;
+          lastRunStatus: string;
+          lastPublishedAt: string;
+          lastSyncStatus: string;
+          lastSyncError?: string;
+        }>;
+      } | null;
+    };
+    assert.equal(getTrackPayload.githubRunCommentSync?.updatedAt, "2026-04-10T03:00:00.000Z");
+    assert.deepEqual(getTrackPayload.githubRunCommentSync?.comments[0], {
+      target: {
+        kind: "issue",
+        number: 32,
+        url: "https://github.com/yoophi-a/specrail/issues/32",
+      },
+      commentId: 3201,
+      lastRunId: runPayload.run.id,
+      lastRunStatus: "running",
+      lastPublishedAt: "2026-04-10T02:59:30.000Z",
+      lastSyncStatus: "failed",
+      lastSyncError: "GitHub temporarily unavailable",
+    });
+
+    const getRunResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}`);
+    assert.equal(getRunResponse.status, 200);
+    const getRunPayload = (await getRunResponse.json()) as {
+      githubRunCommentSync: { comments: Array<{ commentId?: number; lastRunId: string }> } | null;
+      githubRunCommentSyncForRun: Array<{ commentId?: number; lastRunId: string }>;
+    };
+    assert.equal(getRunPayload.githubRunCommentSync?.comments[0]?.commentId, 3201);
+    assert.deepEqual(getRunPayload.githubRunCommentSyncForRun, [
+      {
+        target: {
+          kind: "issue",
+          number: 32,
+          url: "https://github.com/yoophi-a/specrail/issues/32",
+        },
+        commentId: 3201,
+        lastRunId: runPayload.run.id,
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T02:59:30.000Z",
+        lastSyncStatus: "failed",
+        lastSyncError: "GitHub temporarily unavailable",
+      },
+    ]);
+  });
+});
 
 test("API supports creating tracks, starting runs, and listing run events", async () => {
   await withServer(async (baseUrl, paths) => {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -137,6 +137,23 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
     assert.equal(trackResponse.status, 201);
     const trackPayload = (await trackResponse.json()) as { track: { id: string } };
 
+    const emptyIntegrationsResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}/integrations`);
+    assert.equal(emptyIntegrationsResponse.status, 200);
+    assert.deepEqual(await emptyIntegrationsResponse.json(), {
+      trackId: trackPayload.track.id,
+      github: {
+        issue: {
+          number: 32,
+          url: "https://github.com/yoophi-a/specrail/issues/32",
+        },
+        runCommentSync: null,
+        summary: {
+          linkedTargetCount: 1,
+          syncedTargetCount: 0,
+        },
+      },
+    });
+
     const runResponse = await fetch(`${baseUrl}/runs`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -178,6 +195,45 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
       )}\n`,
       "utf8",
     );
+
+    const integrationsResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}/integrations`);
+    assert.equal(integrationsResponse.status, 200);
+    assert.deepEqual(await integrationsResponse.json(), {
+      trackId: trackPayload.track.id,
+      github: {
+        issue: {
+          number: 32,
+          url: "https://github.com/yoophi-a/specrail/issues/32",
+        },
+        runCommentSync: {
+          id: trackPayload.track.id,
+          trackId: trackPayload.track.id,
+          updatedAt: "2026-04-10T03:00:00.000Z",
+          comments: [
+            {
+              target: {
+                kind: "issue",
+                number: 32,
+                url: "https://github.com/yoophi-a/specrail/issues/32",
+              },
+              commentId: 3201,
+              lastRunId: runPayload.run.id,
+              lastRunStatus: "running",
+              lastPublishedAt: "2026-04-10T02:59:30.000Z",
+              lastSyncStatus: "failed",
+              lastSyncError: "GitHub temporarily unavailable",
+            },
+          ],
+        },
+        summary: {
+          linkedTargetCount: 1,
+          syncedTargetCount: 1,
+          lastPublishedAt: "2026-04-10T02:59:30.000Z",
+          lastSyncStatus: "failed",
+          lastSyncError: "GitHub temporarily unavailable",
+        },
+      },
+    });
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     assert.equal(getTrackResponse.status, 200);

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -314,11 +314,26 @@ test("API supports updating track workflow and approval state", async () => {
       body: JSON.stringify({
         title: "Approval workflow",
         description: "Exercise PATCH /tracks/:trackId.",
+        githubIssue: {
+          number: 28,
+          url: "https://github.com/yoophi-a/specrail/issues/28",
+        },
       }),
     });
     const trackPayload = (await trackResponse.json()) as {
-      track: { id: string; status: string; specStatus: string; planStatus: string; updatedAt: string };
+      track: {
+        id: string;
+        status: string;
+        specStatus: string;
+        planStatus: string;
+        updatedAt: string;
+        githubIssue?: { number: number; url: string };
+      };
     };
+    assert.deepEqual(trackPayload.track.githubIssue, {
+      number: 28,
+      url: "https://github.com/yoophi-a/specrail/issues/28",
+    });
 
     const patchResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`, {
       method: "PATCH",
@@ -327,26 +342,60 @@ test("API supports updating track workflow and approval state", async () => {
         status: "review",
         specStatus: "approved",
         planStatus: "pending",
+        githubPullRequest: {
+          number: 31,
+          url: "https://github.com/yoophi-a/specrail/pull/31",
+        },
       }),
     });
 
     assert.equal(patchResponse.status, 200);
     const patchPayload = (await patchResponse.json()) as {
-      track: { id: string; status: string; specStatus: string; planStatus: string; updatedAt: string };
+      track: {
+        id: string;
+        status: string;
+        specStatus: string;
+        planStatus: string;
+        updatedAt: string;
+        githubIssue?: { number: number; url: string };
+        githubPullRequest?: { number: number; url: string };
+      };
     };
     assert.equal(patchPayload.track.id, trackPayload.track.id);
     assert.equal(patchPayload.track.status, "review");
     assert.equal(patchPayload.track.specStatus, "approved");
     assert.equal(patchPayload.track.planStatus, "pending");
+    assert.deepEqual(patchPayload.track.githubIssue, {
+      number: 28,
+      url: "https://github.com/yoophi-a/specrail/issues/28",
+    });
+    assert.deepEqual(patchPayload.track.githubPullRequest, {
+      number: 31,
+      url: "https://github.com/yoophi-a/specrail/pull/31",
+    });
     assert.notEqual(patchPayload.track.updatedAt, trackPayload.track.updatedAt);
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as {
-      track: { status: string; specStatus: string; planStatus: string };
+      track: {
+        status: string;
+        specStatus: string;
+        planStatus: string;
+        githubIssue?: { number: number; url: string };
+        githubPullRequest?: { number: number; url: string };
+      };
     };
     assert.equal(getTrackPayload.track.status, "review");
     assert.equal(getTrackPayload.track.specStatus, "approved");
     assert.equal(getTrackPayload.track.planStatus, "pending");
+    assert.deepEqual(getTrackPayload.track.githubIssue, {
+      number: 28,
+      url: "https://github.com/yoophi-a/specrail/issues/28",
+    });
+    assert.deepEqual(getTrackPayload.track.githubPullRequest, {
+      number: 31,
+      url: "https://github.com/yoophi-a/specrail/pull/31",
+    });
   });
 });
 
@@ -572,6 +621,13 @@ test("API validates track updates and returns 404 for missing tracks", async () 
       body: JSON.stringify({ planStatus: "oops" }),
     });
     assert.equal(invalidPlanStatusResponse.status, 422);
+
+    const invalidGitHubIssueResponse = await fetch(`${baseUrl}/tracks/missing`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ githubIssue: { number: 0, url: "https://example.com/not-github" } }),
+    });
+    assert.equal(invalidGitHubIssueResponse.status, 422);
   });
 });
 
@@ -584,6 +640,7 @@ test("API returns structured validation and bad-request errors", async () => {
         title: "",
         description: 123,
         priority: "urgent",
+        githubPullRequest: { number: -1, url: "wat" },
       }),
     });
     assert.equal(invalidTrackResponse.status, 422);
@@ -593,7 +650,7 @@ test("API returns structured validation and bad-request errors", async () => {
     assert.equal(invalidTrackPayload.error.code, "validation_error");
     assert.deepEqual(
       invalidTrackPayload.error.details.map((detail) => detail.field),
-      ["title", "description", "priority"],
+      ["title", "description", "priority", "githubPullRequest.number", "githubPullRequest.url"],
     );
 
     const invalidRunResponse = await fetch(`${baseUrl}/runs`, {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -656,6 +656,7 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
       applied: boolean;
       conflictPolicy: string;
       provenance: { source: { path: string } };
+      operatorGuide: { examples: Array<{ id: string }> };
       conflict: { hasConflict: boolean; reason: string | null; details: Array<{ field: string }> };
     };
     assert.equal(preview.action, "updated");
@@ -665,6 +666,7 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
     assert.equal(preview.conflict.hasConflict, true);
     assert.equal(preview.conflict.reason, "track_id_exists");
     assert.ok(preview.conflict.details.some((detail) => detail.field === "artifacts.spec"));
+    assert.ok(preview.operatorGuide.examples.some((example) => example.id === "reject-preview"));
 
     const conflictResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
@@ -678,6 +680,25 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
     assert.notEqual(getTrackPayload.artifacts.spec, "# Preview only\n");
+  });
+});
+
+test("API exposes OpenSpec import help for preset discovery", async () => {
+  await withServer(async (baseUrl) => {
+    const helpResponse = await fetch(`${baseUrl}/admin/openspec/import/help?resolutionPreset=policyDefaults`);
+    assert.equal(helpResponse.status, 200);
+    const help = (await helpResponse.json()) as {
+      operatorGuide: {
+        selectedPreset: { name: string; choices: Array<{ field: string; choice: string }> } | null;
+        recommendedFlow: string[];
+        examples: Array<{ id: string }>;
+      };
+    };
+
+    assert.equal(help.operatorGuide.selectedPreset?.name, "policyDefaults");
+    assert.ok(help.operatorGuide.selectedPreset?.choices.some((choice) => choice.field === "status" && choice.choice === "existing"));
+    assert.ok(help.operatorGuide.recommendedFlow.includes("Preview with dryRun=true first."));
+    assert.ok(help.operatorGuide.examples.some((example) => example.id === "preset-with-override"));
   });
 });
 
@@ -731,6 +752,7 @@ test("API resolves OpenSpec conflicts with selective keep-existing choices", asy
       };
       resolvedArtifacts: { spec: string; plan: string };
       resolutionGuide: { presetApplied: string; effectiveResolution: { track: { status: string } }; policies: Array<{ field: string }>; presets: Array<{ name: string }> };
+      operatorGuide: { selectedPreset: { name: string } | null; effectiveChoices: Array<{ field: string; choice: string }> };
     };
     assert.equal(resolved.track.title, "Existing resolve track");
     assert.equal(resolved.track.description, "Incoming description");
@@ -742,6 +764,8 @@ test("API resolves OpenSpec conflicts with selective keep-existing choices", asy
     assert.equal(resolved.resolutionGuide.effectiveResolution.track.status, "existing");
     assert.ok(resolved.resolutionGuide.policies.some((policy) => policy.field === "status"));
     assert.ok(resolved.resolutionGuide.presets.some((preset) => preset.name === "preserveWorkflowState"));
+    assert.equal(resolved.operatorGuide.selectedPreset?.name, "policyDefaults");
+    assert.ok(resolved.operatorGuide.effectiveChoices.some((choice) => choice.field === "plan" && choice.choice === "incoming"));
     assert.notEqual(resolved.resolvedArtifacts.spec, "# Keep existing spec\n");
     assert.equal(resolved.resolvedArtifacts.plan, "# Incoming plan\n");
 

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -262,6 +262,8 @@ test("API retries failed GitHub run comment syncs from the integrations route", 
         openSpec: {
           latestImport: null,
           importHistory: [],
+          latestExport: null,
+          exportHistory: [],
         },
         github: {
           issue: { number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
@@ -321,6 +323,8 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
       openSpec: {
         latestImport: null,
         importHistory: [],
+        latestExport: null,
+        exportHistory: [],
       },
       github: {
         issue: {
@@ -384,6 +388,8 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
       openSpec: {
         latestImport: null,
         importHistory: [],
+        latestExport: null,
+        exportHistory: [],
       },
       github: {
         issue: {
@@ -562,7 +568,7 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     assert.equal(exportResponse.status, 200);
 
     const exported = (await exportResponse.json()) as {
-      package: { track: { id: string } };
+      package: { metadata: { exportedAt: string }; track: { id: string } };
       target: { path: string; overwrite: boolean };
     };
     assert.equal(exported.package.track.id, trackPayload.track.id);
@@ -600,11 +606,19 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as {
       artifacts: { spec: string };
-      openSpecImports: { latestImport: { source: { path: string } }; importHistory: Array<unknown> };
+      openSpecImports: {
+        latestImport: { source: { path: string } };
+        importHistory: Array<unknown>;
+        latestExport: { target: { path: string }; exportedAt: string };
+        exportHistory: Array<unknown>;
+      };
     };
     assert.equal(getTrackPayload.artifacts.spec, "# Imported spec\n");
     assert.equal(getTrackPayload.openSpecImports.latestImport.source.path, bundleDir);
     assert.equal(getTrackPayload.openSpecImports.importHistory.length, 1);
+    assert.equal(getTrackPayload.openSpecImports.latestExport.target.path, bundleDir);
+    assert.equal(getTrackPayload.openSpecImports.latestExport.exportedAt, exported.package.metadata.exportedAt);
+    assert.equal(getTrackPayload.openSpecImports.exportHistory.length, 1);
 
     const trackImportsResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}/openspec/imports`);
     assert.equal(trackImportsResponse.status, 200);
@@ -616,6 +630,12 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     const adminImports = (await adminImportsResponse.json()) as { imports: Array<{ provenance: { source: { path: string } } }> };
     assert.equal(adminImports.imports.length, 1);
     assert.equal(adminImports.imports[0]?.provenance.source.path, bundleDir);
+
+    const adminExportsResponse = await fetch(`${baseUrl}/admin/openspec/exports?trackId=${trackPayload.track.id}`);
+    assert.equal(adminExportsResponse.status, 200);
+    const adminExports = (await adminExportsResponse.json()) as { exports: Array<{ exportRecord: { target: { path: string } } }> };
+    assert.equal(adminExports.exports.length, 1);
+    assert.equal(adminExports.exports[0]?.exportRecord.target.path, bundleDir);
   });
 });
 

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -715,6 +715,7 @@ test("API resolves OpenSpec conflicts with selective keep-existing choices", asy
       body: JSON.stringify({
         path: bundleDir,
         conflictPolicy: "resolve",
+        resolutionPreset: "policyDefaults",
         resolution: {
           track: { title: "existing" },
           artifacts: { spec: "existing", plan: "incoming" },
@@ -723,13 +724,24 @@ test("API resolves OpenSpec conflicts with selective keep-existing choices", asy
     });
     assert.equal(resolveResponse.status, 200);
     const resolved = (await resolveResponse.json()) as {
-      track: { title: string; description: string; openSpecImport: { conflictPolicy: string; resolution: { track: { title: string } } } };
+      track: {
+        title: string;
+        description: string;
+        openSpecImport: { conflictPolicy: string; resolutionPreset: string; resolution: { track: { title: string; status: string } } };
+      };
       resolvedArtifacts: { spec: string; plan: string };
+      resolutionGuide: { presetApplied: string; effectiveResolution: { track: { status: string } }; policies: Array<{ field: string }>; presets: Array<{ name: string }> };
     };
     assert.equal(resolved.track.title, "Existing resolve track");
     assert.equal(resolved.track.description, "Incoming description");
     assert.equal(resolved.track.openSpecImport.conflictPolicy, "resolve");
+    assert.equal(resolved.track.openSpecImport.resolutionPreset, "policyDefaults");
     assert.equal(resolved.track.openSpecImport.resolution.track.title, "existing");
+    assert.equal(resolved.track.openSpecImport.resolution.track.status, "existing");
+    assert.equal(resolved.resolutionGuide.presetApplied, "policyDefaults");
+    assert.equal(resolved.resolutionGuide.effectiveResolution.track.status, "existing");
+    assert.ok(resolved.resolutionGuide.policies.some((policy) => policy.field === "status"));
+    assert.ok(resolved.resolutionGuide.presets.some((preset) => preset.name === "preserveWorkflowState"));
     assert.notEqual(resolved.resolvedArtifacts.spec, "# Keep existing spec\n");
     assert.equal(resolved.resolvedArtifacts.plan, "# Incoming plan\n");
 
@@ -1263,7 +1275,7 @@ test("API returns structured validation and bad-request errors", async () => {
     const invalidOpenSpecImportResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ path: "", dryRun: "yes", conflictPolicy: "merge", resolution: { artifacts: { spec: "later" } } }),
+      body: JSON.stringify({ path: "", dryRun: "yes", conflictPolicy: "merge", resolutionPreset: "unknownPreset", resolution: { artifacts: { spec: "later" } } }),
     });
     assert.equal(invalidOpenSpecImportResponse.status, 422);
   });

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -524,6 +524,63 @@ test("API supports creating tracks, starting runs, and listing run events", asyn
   });
 });
 
+test("API exports and imports OpenSpec bundles through admin routes", async () => {
+  await withServer(async (baseUrl) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "OpenSpec track",
+        description: "Export and re-import OpenSpec bundles.",
+      }),
+    });
+    assert.equal(trackResponse.status, 201);
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const bundleDir = await mkdtemp(path.join(os.tmpdir(), "specrail-api-openspec-bundle-"));
+    const exportResponse = await fetch(`${baseUrl}/admin/openspec/export`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        path: bundleDir,
+        overwrite: true,
+      }),
+    });
+    assert.equal(exportResponse.status, 200);
+
+    const exported = (await exportResponse.json()) as {
+      package: { track: { id: string } };
+      target: { path: string; overwrite: boolean };
+    };
+    assert.equal(exported.package.track.id, trackPayload.track.id);
+    assert.equal(exported.target.path, bundleDir);
+    assert.equal(exported.target.overwrite, true);
+
+    const manifest = JSON.parse(await readFile(path.join(bundleDir, "openspec.json"), "utf8")) as {
+      track: { id: string };
+    };
+    assert.equal(manifest.track.id, trackPayload.track.id);
+
+    await writeFile(path.join(bundleDir, "spec.md"), "# Imported spec\n", "utf8");
+
+    const importResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: bundleDir }),
+    });
+    assert.equal(importResponse.status, 200);
+
+    const imported = (await importResponse.json()) as { action: string; track: { id: string } };
+    assert.equal(imported.action, "updated");
+    assert.equal(imported.track.id, trackPayload.track.id);
+
+    const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
+    const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
+    assert.equal(getTrackPayload.artifacts.spec, "# Imported spec\n");
+  });
+});
+
 test("API supports streaming run events over SSE", async () => {
   await withServer(async (baseUrl) => {
     const trackResponse = await fetch(`${baseUrl}/tracks`, {
@@ -1036,6 +1093,20 @@ test("API returns structured validation and bad-request errors", async () => {
       error: { code: string; message: string };
     };
     assert.equal(malformedJsonPayload.error.code, "bad_request");
+
+    const invalidOpenSpecExportResponse = await fetch(`${baseUrl}/admin/openspec/export`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ trackId: "", path: 123, overwrite: "yes" }),
+    });
+    assert.equal(invalidOpenSpecExportResponse.status, 422);
+
+    const invalidOpenSpecImportResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "" }),
+    });
+    assert.equal(invalidOpenSpecImportResponse.status, 422);
   });
 });
 

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -5,7 +5,16 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createDefaultServer } from "../index.js";
+import {
+  FileExecutionRepository,
+  FileGitHubRunCommentSyncStore,
+  FileProjectRepository,
+  FileTrackRepository,
+  JsonlEventStore,
+  SpecRailService,
+} from "@specrail/core";
+
+import { createDefaultServer, createSpecRailHttpServer } from "../index.js";
 
 async function withServer(
   run: (baseUrl: string, paths: { dataDir: string; repoArtifactDir: string }) => Promise<void>,
@@ -119,6 +128,170 @@ async function openSseStream(url: string): Promise<{
     request.on("error", reject);
   });
 }
+
+test("API retries failed GitHub run comment syncs from the integrations route", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "specrail-api-retry-"));
+  const artifactRoot = path.join(dataDir, "repo-visible");
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(dataDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(dataDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(dataDir, "state")),
+    eventStore: new JsonlEventStore(path.join(dataDir, "state")),
+    githubRunCommentSyncStore: new FileGitHubRunCommentSyncStore(path.join(dataDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary(input) {
+        return [
+          {
+            action: input.syncState ? "updated" : "created",
+            target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+            body: `summary:${input.run.status}`,
+            commentId: 3401,
+          },
+        ];
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(dataDir, "workspaces"),
+    now: (() => {
+      const values = [
+        "2026-04-10T03:00:00.000Z",
+        "2026-04-10T03:00:01.000Z",
+        "2026-04-10T03:00:02.000Z",
+        "2026-04-10T03:00:03.000Z",
+      ];
+      return () => values.shift() ?? "2026-04-10T03:00:03.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-retry-route", "run-retry-route"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const server = createSpecRailHttpServer({
+    artifactRoot,
+    eventLogDir: path.join(dataDir, "state", "events"),
+    service,
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to bind retry test server");
+  }
+
+  try {
+    const track = await service.createTrack({
+      title: "Retry integration sync",
+      description: "Retry failed GitHub comment syncs.",
+      githubIssue: { number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+    });
+    const run = await service.startRun({ trackId: track.id, prompt: "retry failed sync" });
+
+    await writeFile(
+      path.join(dataDir, "state", "github-run-comment-sync", `${track.id}.json`),
+      `${JSON.stringify(
+        {
+          id: track.id,
+          trackId: track.id,
+          updatedAt: "2026-04-10T03:00:02.000Z",
+          comments: [
+            {
+              target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+              commentId: 3401,
+              lastRunId: run.id,
+              lastRunStatus: run.status,
+              lastPublishedAt: "2026-04-10T03:00:02.000Z",
+              lastCommentBody: "summary:running",
+              lastSyncStatus: "failed",
+              lastSyncError: "GitHub temporarily unavailable",
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const retryResponse = await fetch(
+      `http://127.0.0.1:${address.port}/tracks/${track.id}/integrations/github/run-comment-sync/retry`,
+      { method: "POST" },
+    );
+    assert.equal(retryResponse.status, 200);
+    assert.deepEqual(await retryResponse.json(), {
+      trackId: track.id,
+      runId: run.id,
+      results: [
+        {
+          action: "updated",
+          target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+          body: "summary:running",
+          commentId: 3401,
+        },
+      ],
+      integrations: {
+        trackId: track.id,
+        github: {
+          issue: { number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+          runCommentSync: {
+            id: track.id,
+            trackId: track.id,
+            updatedAt: "2026-04-10T03:00:03.000Z",
+            comments: [
+              {
+                target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+                commentId: 3401,
+                lastRunId: run.id,
+                lastRunStatus: "running",
+                lastPublishedAt: "2026-04-10T03:00:03.000Z",
+                lastCommentBody: "summary:running",
+                lastSyncStatus: "success",
+              },
+            ],
+          },
+          summary: {
+            linkedTargetCount: 1,
+            syncedTargetCount: 1,
+            lastPublishedAt: "2026-04-10T03:00:03.000Z",
+            lastSyncStatus: "success",
+          },
+        },
+      },
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
 
 test("API exposes GitHub sync metadata on track and run inspection routes", async () => {
   await withServer(async (baseUrl, paths) => {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -259,6 +259,10 @@ test("API retries failed GitHub run comment syncs from the integrations route", 
       ],
       integrations: {
         trackId: track.id,
+        openSpec: {
+          latestImport: null,
+          importHistory: [],
+        },
         github: {
           issue: { number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
           runCommentSync: {
@@ -314,6 +318,10 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
     assert.equal(emptyIntegrationsResponse.status, 200);
     assert.deepEqual(await emptyIntegrationsResponse.json(), {
       trackId: trackPayload.track.id,
+      openSpec: {
+        latestImport: null,
+        importHistory: [],
+      },
       github: {
         issue: {
           number: 32,
@@ -373,6 +381,10 @@ test("API exposes GitHub sync metadata on track and run inspection routes", asyn
     assert.equal(integrationsResponse.status, 200);
     assert.deepEqual(await integrationsResponse.json(), {
       trackId: trackPayload.track.id,
+      openSpec: {
+        latestImport: null,
+        importHistory: [],
+      },
       github: {
         issue: {
           number: 32,
@@ -575,6 +587,7 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
       action: string;
       applied: boolean;
       provenance: { source: { path: string } };
+      importHistory: Array<{ source: { path: string } }>;
       track: { id: string; openSpecImport: { source: { path: string } } };
     };
     assert.equal(imported.action, "updated");
@@ -582,10 +595,27 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     assert.equal(imported.track.id, trackPayload.track.id);
     assert.equal(imported.provenance.source.path, bundleDir);
     assert.equal(imported.track.openSpecImport.source.path, bundleDir);
+    assert.equal(imported.importHistory.length, 1);
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
-    const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
+    const getTrackPayload = (await getTrackResponse.json()) as {
+      artifacts: { spec: string };
+      openSpecImports: { latestImport: { source: { path: string } }; importHistory: Array<unknown> };
+    };
     assert.equal(getTrackPayload.artifacts.spec, "# Imported spec\n");
+    assert.equal(getTrackPayload.openSpecImports.latestImport.source.path, bundleDir);
+    assert.equal(getTrackPayload.openSpecImports.importHistory.length, 1);
+
+    const trackImportsResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}/openspec/imports`);
+    assert.equal(trackImportsResponse.status, 200);
+    const trackImports = (await trackImportsResponse.json()) as { importHistory: Array<{ source: { path: string } }> };
+    assert.equal(trackImports.importHistory.length, 1);
+
+    const adminImportsResponse = await fetch(`${baseUrl}/admin/openspec/imports?trackId=${trackPayload.track.id}`);
+    assert.equal(adminImportsResponse.status, 200);
+    const adminImports = (await adminImportsResponse.json()) as { imports: Array<{ provenance: { source: { path: string } } }> };
+    assert.equal(adminImports.imports.length, 1);
+    assert.equal(adminImports.imports[0]?.provenance.source.path, bundleDir);
   });
 });
 
@@ -648,6 +678,65 @@ test("API previews OpenSpec imports and reports collisions before overwrite", as
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
     assert.notEqual(getTrackPayload.artifacts.spec, "# Preview only\n");
+  });
+});
+
+test("API resolves OpenSpec conflicts with selective keep-existing choices", async () => {
+  await withServer(async (baseUrl) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Existing resolve track",
+        description: "Keep some fields from the current track.",
+      }),
+    });
+    assert.equal(trackResponse.status, 201);
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const bundleDir = await mkdtemp(path.join(os.tmpdir(), "specrail-api-openspec-resolve-"));
+    await fetch(`${baseUrl}/admin/openspec/export`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ trackId: trackPayload.track.id, path: bundleDir, overwrite: true }),
+    });
+
+    const manifestPath = path.join(bundleDir, "openspec.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { track: { title: string; description: string } };
+    manifest.track.title = "Incoming title";
+    manifest.track.description = "Incoming description";
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await writeFile(path.join(bundleDir, "spec.md"), "# Keep existing spec\n", "utf8");
+    await writeFile(path.join(bundleDir, "plan.md"), "# Incoming plan\n", "utf8");
+
+    const resolveResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: bundleDir,
+        conflictPolicy: "resolve",
+        resolution: {
+          track: { title: "existing" },
+          artifacts: { spec: "existing", plan: "incoming" },
+        },
+      }),
+    });
+    assert.equal(resolveResponse.status, 200);
+    const resolved = (await resolveResponse.json()) as {
+      track: { title: string; description: string; openSpecImport: { conflictPolicy: string; resolution: { track: { title: string } } } };
+      resolvedArtifacts: { spec: string; plan: string };
+    };
+    assert.equal(resolved.track.title, "Existing resolve track");
+    assert.equal(resolved.track.description, "Incoming description");
+    assert.equal(resolved.track.openSpecImport.conflictPolicy, "resolve");
+    assert.equal(resolved.track.openSpecImport.resolution.track.title, "existing");
+    assert.notEqual(resolved.resolvedArtifacts.spec, "# Keep existing spec\n");
+    assert.equal(resolved.resolvedArtifacts.plan, "# Incoming plan\n");
+
+    const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
+    const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string; plan: string } };
+    assert.notEqual(getTrackPayload.artifacts.spec, "# Keep existing spec\n");
+    assert.equal(getTrackPayload.artifacts.plan, "# Incoming plan\n");
   });
 });
 
@@ -1174,7 +1263,7 @@ test("API returns structured validation and bad-request errors", async () => {
     const invalidOpenSpecImportResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ path: "", dryRun: "yes", conflictPolicy: "merge" }),
+      body: JSON.stringify({ path: "", dryRun: "yes", conflictPolicy: "merge", resolution: { artifacts: { spec: "later" } } }),
     });
     assert.equal(invalidOpenSpecImportResponse.status, 422);
   });

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -567,17 +567,75 @@ test("API exports and imports OpenSpec bundles through admin routes", async () =
     const importResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ path: bundleDir }),
+      body: JSON.stringify({ path: bundleDir, conflictPolicy: "overwrite" }),
     });
     assert.equal(importResponse.status, 200);
 
-    const imported = (await importResponse.json()) as { action: string; track: { id: string } };
+    const imported = (await importResponse.json()) as { action: string; applied: boolean; track: { id: string } };
     assert.equal(imported.action, "updated");
+    assert.equal(imported.applied, true);
     assert.equal(imported.track.id, trackPayload.track.id);
 
     const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
     const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
     assert.equal(getTrackPayload.artifacts.spec, "# Imported spec\n");
+  });
+});
+
+test("API previews OpenSpec imports and reports collisions before overwrite", async () => {
+  await withServer(async (baseUrl) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "OpenSpec preview track",
+        description: "Preview import behavior.",
+      }),
+    });
+    assert.equal(trackResponse.status, 201);
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const bundleDir = await mkdtemp(path.join(os.tmpdir(), "specrail-api-openspec-preview-"));
+    await fetch(`${baseUrl}/admin/openspec/export`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        path: bundleDir,
+        overwrite: true,
+      }),
+    });
+
+    await writeFile(path.join(bundleDir, "spec.md"), "# Preview only\n", "utf8");
+
+    const previewResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: bundleDir, dryRun: true }),
+    });
+    assert.equal(previewResponse.status, 200);
+    const preview = (await previewResponse.json()) as {
+      action: string;
+      applied: boolean;
+      conflictPolicy: string;
+      conflict: { hasConflict: boolean; reason: string | null };
+    };
+    assert.equal(preview.action, "updated");
+    assert.equal(preview.applied, false);
+    assert.equal(preview.conflictPolicy, "reject");
+    assert.equal(preview.conflict.hasConflict, true);
+    assert.equal(preview.conflict.reason, "track_id_exists");
+
+    const conflictResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: bundleDir }),
+    });
+    assert.equal(conflictResponse.status, 409);
+
+    const getTrackResponse = await fetch(`${baseUrl}/tracks/${trackPayload.track.id}`);
+    const getTrackPayload = (await getTrackResponse.json()) as { artifacts: { spec: string } };
+    assert.notEqual(getTrackPayload.artifacts.spec, "# Preview only\n");
   });
 });
 
@@ -1104,7 +1162,7 @@ test("API returns structured validation and bad-request errors", async () => {
     const invalidOpenSpecImportResponse = await fetch(`${baseUrl}/admin/openspec/import`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ path: "" }),
+      body: JSON.stringify({ path: "", dryRun: "yes", conflictPolicy: "merge" }),
     });
     assert.equal(invalidOpenSpecImportResponse.status, 422);
   });

--- a/apps/api/src/__tests__/cli.test.ts
+++ b/apps/api/src/__tests__/cli.test.ts
@@ -17,6 +17,53 @@ async function createService(rootDir: string): Promise<SpecRailService> {
   return new SpecRailService(dependencies.serviceDependencies);
 }
 
+test("CLI exports OpenSpec bundles and lists import history", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-cli-openspec-export-"));
+  const service = await createService(rootDir);
+
+  const track = await service.createTrack({
+    title: "CLI export source",
+    description: "Source track for CLI export",
+  });
+
+  const bundleDir = path.join(rootDir, "bundle");
+  const exportResult = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "export", "--track-id", track.id, "--path", bundleDir, "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "repo-visible"),
+    },
+  });
+  const exportPayload = JSON.parse(exportResult.stdout) as {
+    result: { target: { path: string }; package: { track: { id: string } } };
+  };
+  assert.equal(exportPayload.result.package.track.id, track.id);
+  assert.equal(exportPayload.result.target.path, bundleDir);
+
+  await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: bundleDir },
+    conflictPolicy: "resolve",
+    resolutionPreset: "policyDefaults",
+  });
+
+  const historyResult = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "imports", "--track-id", track.id, "--limit", "1", "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "repo-visible"),
+    },
+  });
+  const historyPayload = JSON.parse(historyResult.stdout) as {
+    result: Array<{ trackId: string; provenance: { source: { path: string }; resolutionPreset?: string } }>;
+  };
+  assert.equal(historyPayload.result.length, 1);
+  assert.equal(historyPayload.result[0]?.trackId, track.id);
+  assert.equal(historyPayload.result[0]?.provenance.source.path, bundleDir);
+  assert.equal(historyPayload.result[0]?.provenance.resolutionPreset, "policyDefaults");
+});
+
 test("CLI previews and applies guided OpenSpec imports", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-cli-openspec-"));
   const sourceService = await createService(path.join(rootDir, "source"));

--- a/apps/api/src/__tests__/cli.test.ts
+++ b/apps/api/src/__tests__/cli.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { SpecRailService } from "@specrail/core";
+
+import { createDependencies } from "../runtime.js";
+
+const execFileAsync = promisify(execFile);
+
+async function createService(rootDir: string): Promise<SpecRailService> {
+  const dependencies = createDependencies(path.join(rootDir, "data"), path.join(rootDir, "repo-visible"));
+  return new SpecRailService(dependencies.serviceDependencies);
+}
+
+test("CLI previews and applies guided OpenSpec imports", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-cli-openspec-"));
+  const sourceService = await createService(path.join(rootDir, "source"));
+  const targetService = await createService(path.join(rootDir, "target"));
+
+  const track = await sourceService.createTrack({
+    title: "CLI import source",
+    description: "Source track for CLI import",
+  });
+
+  const bundleDir = path.join(rootDir, "bundle");
+  await sourceService.exportTrackToOpenSpec({
+    trackId: track.id,
+    target: { kind: "file", path: bundleDir },
+  });
+
+  const preview = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "import", "--path", bundleDir, "--preset", "policyDefaults", "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "target", "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "target", "repo-visible"),
+    },
+  });
+  const previewPayload = JSON.parse(preview.stdout) as {
+    result: { applied: boolean; conflictPolicy: string; operatorGuide: { selectedPreset: { name: string } | null } };
+  };
+  assert.equal(previewPayload.result.applied, false);
+  assert.equal(previewPayload.result.conflictPolicy, "reject");
+  assert.equal(previewPayload.result.operatorGuide.selectedPreset?.name, "policyDefaults");
+
+  const apply = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "import", "--path", bundleDir, "--apply", "--preset", "policyDefaults", "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "target", "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "target", "repo-visible"),
+    },
+  });
+  const applyPayload = JSON.parse(apply.stdout) as {
+    result: { applied: boolean; conflictPolicy: string; track: { id: string; openSpecImport?: { resolutionPreset?: string } } };
+  };
+  assert.equal(applyPayload.result.applied, true);
+  assert.equal(applyPayload.result.conflictPolicy, "resolve");
+  assert.equal(applyPayload.result.track.openSpecImport?.resolutionPreset, "policyDefaults");
+
+  const importedTrack = await targetService.getTrack(track.id);
+  assert.equal(importedTrack?.title, "CLI import source");
+
+  const spec = await readFile(path.join(rootDir, "target", "data", "artifacts", "tracks", track.id, "spec.md"), "utf8");
+  assert.ok(spec.includes("CLI import source"));
+});
+
+test("CLI exposes import help in JSON mode", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-cli-openspec-help-"));
+
+  const result = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "import", "help", "--preset", "policyDefaults", "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "repo-visible"),
+    },
+  });
+
+  const payload = JSON.parse(result.stdout) as {
+    operatorGuide: { selectedPreset: { name: string } | null; examples: Array<{ id: string }> };
+  };
+  assert.equal(payload.operatorGuide.selectedPreset?.name, "policyDefaults");
+  assert.ok(payload.operatorGuide.examples.some((example) => example.id === "preset-with-override"));
+});

--- a/apps/api/src/__tests__/cli.test.ts
+++ b/apps/api/src/__tests__/cli.test.ts
@@ -17,7 +17,7 @@ async function createService(rootDir: string): Promise<SpecRailService> {
   return new SpecRailService(dependencies.serviceDependencies);
 }
 
-test("CLI exports OpenSpec bundles and lists import history", async () => {
+test("CLI exports OpenSpec bundles and lists import/export history", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-cli-openspec-export-"));
   const service = await createService(rootDir);
 
@@ -40,6 +40,21 @@ test("CLI exports OpenSpec bundles and lists import history", async () => {
   };
   assert.equal(exportPayload.result.package.track.id, track.id);
   assert.equal(exportPayload.result.target.path, bundleDir);
+
+  const exportHistoryResult = await execFileAsync("pnpm", ["exec", "tsx", "--tsconfig", "../../tsconfig.base.json", "src/cli.ts", "openspec", "exports", "--track-id", track.id, "--limit", "1", "--json"], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: {
+      ...process.env,
+      SPECRAIL_DATA_DIR: path.join(rootDir, "data"),
+      SPECRAIL_REPO_ARTIFACT_DIR: path.join(rootDir, "repo-visible"),
+    },
+  });
+  const exportHistoryPayload = JSON.parse(exportHistoryResult.stdout) as {
+    result: Array<{ trackId: string; exportRecord: { target: { path: string } } }>;
+  };
+  assert.equal(exportHistoryPayload.result.length, 1);
+  assert.equal(exportHistoryPayload.result[0]?.trackId, track.id);
+  assert.equal(exportHistoryPayload.result[0]?.exportRecord.target.path, bundleDir);
 
   await service.importTrackFromOpenSpec({
     source: { kind: "file", path: bundleDir },

--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -22,7 +22,7 @@ type OpenSpecImportField =
   | "artifacts.tasks";
 
 interface ParsedArgs {
-  command: "openspec-export" | "openspec-import" | "openspec-import-help" | "openspec-imports" | null;
+  command: "openspec-export" | "openspec-import" | "openspec-import-help" | "openspec-imports" | "openspec-exports" | null;
   path?: string;
   trackId?: string;
   overwrite: boolean;
@@ -58,6 +58,7 @@ Usage:
   specrail-admin openspec import --path <bundle-dir> [--preview] [--apply] [--preset <name>] [--conflict-policy <reject|overwrite|resolve>] [--incoming <field[,field...]>] [--existing <field[,field...]>] [--json]
   specrail-admin openspec import help [--preset <name>] [--json]
   specrail-admin openspec imports [--track-id <track-id>] [--limit <count>] [--json]
+  specrail-admin openspec exports [--track-id <track-id>] [--limit <count>] [--json]
 
 Examples:
   specrail-admin openspec export --track-id track_123 --path ./bundle
@@ -66,6 +67,7 @@ Examples:
   specrail-admin openspec import --path ./bundle --apply --preset policyDefaults --existing artifacts.plan
   specrail-admin openspec import help --preset policyDefaults
   specrail-admin openspec imports --track-id track_123 --limit 5
+  specrail-admin openspec exports --track-id track_123 --limit 5
 `);
 }
 
@@ -134,6 +136,9 @@ function parseArgs(argv: string[]): ParsedArgs {
   } else if (group === "openspec" && action === "imports") {
     args.command = "openspec-imports";
     rest.unshift(subaction);
+  } else if (group === "openspec" && action === "exports") {
+    args.command = "openspec-exports";
+    rest.unshift(subaction);
   } else {
     throw new Error(`Unknown command: ${argv.join(" ")}`);
   }
@@ -201,6 +206,20 @@ function parseArgs(argv: string[]): ParsedArgs {
   }
 
   return args;
+}
+
+function printExportHistory(entries: Awaited<ReturnType<ReturnType<typeof createDefaultService>["listOpenSpecExportHistory"]>>): void {
+  if (entries.length === 0) {
+    console.log("No OpenSpec export history found");
+    return;
+  }
+
+  console.log("OpenSpec export history");
+  for (const entry of entries) {
+    console.log(`- ${entry.exportRecord.exportedAt} ${entry.trackId} (${entry.trackTitle})`);
+    console.log(`  - target: ${entry.exportRecord.target.path}`);
+    console.log(`  - overwrite: ${entry.exportRecord.target.overwrite ? "true" : "false"}`);
+  }
 }
 
 function inferConflictPolicy(args: ParsedArgs): "reject" | "overwrite" | "resolve" | undefined {
@@ -350,6 +369,18 @@ async function run(): Promise<void> {
     }
 
     printImportHistory(result);
+    return;
+  }
+
+  if (args.command === "openspec-exports") {
+    const result = await service.listOpenSpecExportHistory({ trackId: args.trackId, limit: args.limit });
+
+    if (args.json) {
+      console.log(JSON.stringify({ config: loadConfig(), result }, null, 2));
+      return;
+    }
+
+    printExportHistory(result);
     return;
   }
 

--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+import { loadConfig } from "@specrail/config";
+import {
+  OPENSPEC_RESOLUTION_PRESETS,
+  type OpenSpecImportResolution,
+  type OpenSpecImportResolutionChoice,
+  type OpenSpecImportResolutionPresetName,
+} from "@specrail/core";
+import { createDefaultService } from "./runtime.js";
+
+type OpenSpecImportField =
+  | "track.title"
+  | "track.description"
+  | "track.status"
+  | "track.specStatus"
+  | "track.planStatus"
+  | "track.priority"
+  | "track.githubIssue"
+  | "track.githubPullRequest"
+  | "artifacts.spec"
+  | "artifacts.plan"
+  | "artifacts.tasks";
+
+interface ParsedArgs {
+  command: "openspec-import" | "openspec-import-help" | null;
+  path?: string;
+  preview: boolean;
+  apply: boolean;
+  json: boolean;
+  conflictPolicy?: "reject" | "overwrite" | "resolve";
+  preset?: OpenSpecImportResolutionPresetName;
+  incoming: OpenSpecImportField[];
+  existing: OpenSpecImportField[];
+}
+
+const VALID_FIELDS = new Set<OpenSpecImportField>([
+  "track.title",
+  "track.description",
+  "track.status",
+  "track.specStatus",
+  "track.planStatus",
+  "track.priority",
+  "track.githubIssue",
+  "track.githubPullRequest",
+  "artifacts.spec",
+  "artifacts.plan",
+  "artifacts.tasks",
+]);
+
+function printUsage(): void {
+  console.log(`SpecRail admin CLI
+
+Usage:
+  specrail-admin openspec import --path <bundle-dir> [--preview] [--apply] [--preset <name>] [--conflict-policy <reject|overwrite|resolve>] [--incoming <field[,field...]>] [--existing <field[,field...]>] [--json]
+  specrail-admin openspec import help [--preset <name>] [--json]
+
+Examples:
+  specrail-admin openspec import --path ./bundle --preview
+  specrail-admin openspec import --path ./bundle --apply --preset policyDefaults
+  specrail-admin openspec import --path ./bundle --apply --preset policyDefaults --existing artifacts.plan
+  specrail-admin openspec import help --preset policyDefaults
+`);
+}
+
+function parseFieldList(raw: string): OpenSpecImportField[] {
+  const values = raw.split(",").map((value) => value.trim()).filter(Boolean) as OpenSpecImportField[];
+  for (const value of values) {
+    if (!VALID_FIELDS.has(value)) {
+      throw new Error(`Unknown resolution field: ${value}`);
+    }
+  }
+  return values;
+}
+
+function applyFieldChoice(
+  resolution: OpenSpecImportResolution,
+  field: OpenSpecImportField,
+  choice: OpenSpecImportResolutionChoice,
+): void {
+  const [group, key] = field.split(".") as ["track" | "artifacts", string];
+  if (group === "track") {
+    resolution.track = { ...(resolution.track ?? {}), [key]: choice };
+    return;
+  }
+
+  resolution.artifacts = { ...(resolution.artifacts ?? {}), [key]: choice };
+}
+
+function buildResolution(input: Pick<ParsedArgs, "incoming" | "existing">): OpenSpecImportResolution | undefined {
+  const resolution: OpenSpecImportResolution = {};
+
+  for (const field of input.incoming) {
+    applyFieldChoice(resolution, field, "incoming");
+  }
+
+  for (const field of input.existing) {
+    applyFieldChoice(resolution, field, "existing");
+  }
+
+  return Object.keys(resolution).length > 0 ? resolution : undefined;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    return { command: null, preview: false, apply: false, json: false, incoming: [], existing: [] };
+  }
+
+  const [group, action, subaction, ...rest] = argv;
+  const args: ParsedArgs = {
+    command: null,
+    preview: false,
+    apply: false,
+    json: false,
+    incoming: [],
+    existing: [],
+  };
+
+  if (group === "openspec" && action === "import" && subaction === "help") {
+    args.command = "openspec-import-help";
+  } else if (group === "openspec" && action === "import") {
+    args.command = "openspec-import";
+    rest.unshift(subaction);
+  } else {
+    throw new Error(`Unknown command: ${argv.join(" ")}`);
+  }
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token) {
+      continue;
+    }
+
+    switch (token) {
+      case "--path":
+        args.path = rest[++index];
+        break;
+      case "--preview":
+        args.preview = true;
+        break;
+      case "--apply":
+        args.apply = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--preset": {
+        const value = rest[++index] as OpenSpecImportResolutionPresetName | undefined;
+        if (!value || !OPENSPEC_RESOLUTION_PRESETS.some((preset) => preset.name === value)) {
+          throw new Error(`Unknown preset: ${value ?? ""}`);
+        }
+        args.preset = value;
+        break;
+      }
+      case "--conflict-policy": {
+        const value = rest[++index];
+        if (value !== "reject" && value !== "overwrite" && value !== "resolve") {
+          throw new Error(`Unknown conflict policy: ${value ?? ""}`);
+        }
+        args.conflictPolicy = value;
+        break;
+      }
+      case "--incoming":
+        args.incoming.push(...parseFieldList(rest[++index] ?? ""));
+        break;
+      case "--existing":
+        args.existing.push(...parseFieldList(rest[++index] ?? ""));
+        break;
+      case undefined:
+        break;
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+  }
+
+  return args;
+}
+
+function inferConflictPolicy(args: ParsedArgs): "reject" | "overwrite" | "resolve" | undefined {
+  if (args.conflictPolicy) {
+    return args.conflictPolicy;
+  }
+  if (!args.apply) {
+    return "reject";
+  }
+  if (args.preset || args.incoming.length > 0 || args.existing.length > 0) {
+    return "resolve";
+  }
+  return undefined;
+}
+
+function formatNextCommand(args: ParsedArgs, result: { conflict: { hasConflict: boolean } }): string | null {
+  if (!args.path || !result.conflict.hasConflict) {
+    return null;
+  }
+
+  const tokens = ["specrail-admin", "openspec", "import", "--path", JSON.stringify(args.path), "--apply"];
+  if (args.preset) {
+    tokens.push("--preset", args.preset);
+  }
+  if (args.existing.length > 0) {
+    tokens.push("--existing", args.existing.join(","));
+  }
+  if (args.incoming.length > 0) {
+    tokens.push("--incoming", args.incoming.join(","));
+  }
+
+  const policy = inferConflictPolicy({ ...args, apply: true, preview: false });
+  if (policy) {
+    tokens.push("--conflict-policy", policy);
+  }
+
+  return tokens.join(" ");
+}
+
+function printImportSummary(args: ParsedArgs, result: Awaited<ReturnType<ReturnType<typeof createDefaultService>["importTrackFromOpenSpec"]>>): void {
+  console.log(`${result.applied ? "Applied" : "Previewed"} OpenSpec import`);
+  console.log(`- track: ${result.track.id}`);
+  console.log(`- action: ${result.action}`);
+  console.log(`- conflictPolicy: ${result.conflictPolicy}`);
+  console.log(`- conflict: ${result.conflict.hasConflict ? result.conflict.reason : "none"}`);
+  if (result.provenance.resolutionPreset) {
+    console.log(`- preset: ${result.provenance.resolutionPreset}`);
+  }
+  if (result.conflict.details.length > 0) {
+    console.log("- changed fields:");
+    for (const detail of result.conflict.details) {
+      console.log(`  - ${detail.field}: ${detail.message}`);
+    }
+  }
+  console.log("- recommended flow:");
+  for (const step of result.operatorGuide.recommendedFlow) {
+    console.log(`  - ${step}`);
+  }
+  const nextCommand = !args.apply ? formatNextCommand(args, result) : null;
+  if (nextCommand) {
+    console.log(`- next apply command: ${nextCommand}`);
+  }
+}
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === null) {
+    printUsage();
+    process.exitCode = 0;
+    return;
+  }
+
+  const service = createDefaultService();
+
+  if (args.command === "openspec-import-help") {
+    const operatorGuide = service.getOpenSpecImportHelp({ resolutionPreset: args.preset, resolution: buildResolution(args) });
+    if (args.json) {
+      console.log(JSON.stringify({ config: loadConfig(), operatorGuide }, null, 2));
+      return;
+    }
+
+    console.log("OpenSpec import help");
+    console.log(`- selected preset: ${operatorGuide.selectedPreset?.name ?? "none"}`);
+    console.log("- recommended flow:");
+    for (const step of operatorGuide.recommendedFlow) {
+      console.log(`  - ${step}`);
+    }
+    console.log("- example requests:");
+    for (const example of operatorGuide.examples) {
+      console.log(`  - ${example.id}: ${example.label}`);
+    }
+    return;
+  }
+
+  if (!args.path) {
+    throw new Error("Missing required option: --path");
+  }
+
+  const resolution = buildResolution(args);
+  const result = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: args.path },
+    dryRun: args.apply ? false : true,
+    conflictPolicy: inferConflictPolicy(args),
+    resolutionPreset: args.preset,
+    resolution,
+  });
+
+  if (args.json) {
+    console.log(JSON.stringify({ config: loadConfig(), result }, null, 2));
+    return;
+  }
+
+  printImportSummary(args, result);
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -22,11 +22,14 @@ type OpenSpecImportField =
   | "artifacts.tasks";
 
 interface ParsedArgs {
-  command: "openspec-import" | "openspec-import-help" | null;
+  command: "openspec-export" | "openspec-import" | "openspec-import-help" | "openspec-imports" | null;
   path?: string;
+  trackId?: string;
+  overwrite: boolean;
   preview: boolean;
   apply: boolean;
   json: boolean;
+  limit?: number;
   conflictPolicy?: "reject" | "overwrite" | "resolve";
   preset?: OpenSpecImportResolutionPresetName;
   incoming: OpenSpecImportField[];
@@ -51,14 +54,18 @@ function printUsage(): void {
   console.log(`SpecRail admin CLI
 
 Usage:
+  specrail-admin openspec export --track-id <track-id> --path <bundle-dir> [--overwrite] [--json]
   specrail-admin openspec import --path <bundle-dir> [--preview] [--apply] [--preset <name>] [--conflict-policy <reject|overwrite|resolve>] [--incoming <field[,field...]>] [--existing <field[,field...]>] [--json]
   specrail-admin openspec import help [--preset <name>] [--json]
+  specrail-admin openspec imports [--track-id <track-id>] [--limit <count>] [--json]
 
 Examples:
+  specrail-admin openspec export --track-id track_123 --path ./bundle
   specrail-admin openspec import --path ./bundle --preview
   specrail-admin openspec import --path ./bundle --apply --preset policyDefaults
   specrail-admin openspec import --path ./bundle --apply --preset policyDefaults --existing artifacts.plan
   specrail-admin openspec import help --preset policyDefaults
+  specrail-admin openspec imports --track-id track_123 --limit 5
 `);
 }
 
@@ -102,12 +109,13 @@ function buildResolution(input: Pick<ParsedArgs, "incoming" | "existing">): Open
 
 function parseArgs(argv: string[]): ParsedArgs {
   if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
-    return { command: null, preview: false, apply: false, json: false, incoming: [], existing: [] };
+    return { command: null, overwrite: false, preview: false, apply: false, json: false, incoming: [], existing: [] };
   }
 
   const [group, action, subaction, ...rest] = argv;
   const args: ParsedArgs = {
     command: null,
+    overwrite: false,
     preview: false,
     apply: false,
     json: false,
@@ -115,10 +123,16 @@ function parseArgs(argv: string[]): ParsedArgs {
     existing: [],
   };
 
-  if (group === "openspec" && action === "import" && subaction === "help") {
+  if (group === "openspec" && action === "export") {
+    args.command = "openspec-export";
+    rest.unshift(subaction);
+  } else if (group === "openspec" && action === "import" && subaction === "help") {
     args.command = "openspec-import-help";
   } else if (group === "openspec" && action === "import") {
     args.command = "openspec-import";
+    rest.unshift(subaction);
+  } else if (group === "openspec" && action === "imports") {
+    args.command = "openspec-imports";
     rest.unshift(subaction);
   } else {
     throw new Error(`Unknown command: ${argv.join(" ")}`);
@@ -133,6 +147,12 @@ function parseArgs(argv: string[]): ParsedArgs {
     switch (token) {
       case "--path":
         args.path = rest[++index];
+        break;
+      case "--track-id":
+        args.trackId = rest[++index];
+        break;
+      case "--overwrite":
+        args.overwrite = true;
         break;
       case "--preview":
         args.preview = true;
@@ -157,6 +177,14 @@ function parseArgs(argv: string[]): ParsedArgs {
           throw new Error(`Unknown conflict policy: ${value ?? ""}`);
         }
         args.conflictPolicy = value;
+        break;
+      }
+      case "--limit": {
+        const value = Number.parseInt(rest[++index] ?? "", 10);
+        if (!Number.isInteger(value) || value < 1) {
+          throw new Error(`Invalid limit: ${rest[index] ?? ""}`);
+        }
+        args.limit = value;
         break;
       }
       case "--incoming":
@@ -212,6 +240,30 @@ function formatNextCommand(args: ParsedArgs, result: { conflict: { hasConflict: 
   return tokens.join(" ");
 }
 
+function printExportSummary(result: Awaited<ReturnType<ReturnType<typeof createDefaultService>["exportTrackToOpenSpec"]>>): void {
+  console.log("Exported OpenSpec bundle");
+  console.log(`- track: ${result.package.track.id}`);
+  console.log(`- path: ${result.target.path}`);
+  console.log(`- exportedAt: ${result.package.metadata.exportedAt}`);
+}
+
+function printImportHistory(entries: Awaited<ReturnType<ReturnType<typeof createDefaultService>["listOpenSpecImportHistory"]>>): void {
+  if (entries.length === 0) {
+    console.log("No OpenSpec import history found");
+    return;
+  }
+
+  console.log("OpenSpec import history");
+  for (const entry of entries) {
+    console.log(`- ${entry.provenance.importedAt} ${entry.trackId} (${entry.trackTitle})`);
+    console.log(`  - source: ${entry.provenance.source.path}`);
+    console.log(`  - conflictPolicy: ${entry.provenance.conflictPolicy}`);
+    if (entry.provenance.resolutionPreset) {
+      console.log(`  - preset: ${entry.provenance.resolutionPreset}`);
+    }
+  }
+}
+
 function printImportSummary(args: ParsedArgs, result: Awaited<ReturnType<ReturnType<typeof createDefaultService>["importTrackFromOpenSpec"]>>): void {
   console.log(`${result.applied ? "Applied" : "Previewed"} OpenSpec import`);
   console.log(`- track: ${result.track.id}`);
@@ -247,6 +299,28 @@ async function run(): Promise<void> {
 
   const service = createDefaultService();
 
+  if (args.command === "openspec-export") {
+    if (!args.path) {
+      throw new Error("Missing required option: --path");
+    }
+    if (!args.trackId) {
+      throw new Error("Missing required option: --track-id");
+    }
+
+    const result = await service.exportTrackToOpenSpec({
+      trackId: args.trackId,
+      target: { kind: "file", path: args.path, overwrite: args.overwrite },
+    });
+
+    if (args.json) {
+      console.log(JSON.stringify({ config: loadConfig(), result }, null, 2));
+      return;
+    }
+
+    printExportSummary(result);
+    return;
+  }
+
   if (args.command === "openspec-import-help") {
     const operatorGuide = service.getOpenSpecImportHelp({ resolutionPreset: args.preset, resolution: buildResolution(args) });
     if (args.json) {
@@ -264,6 +338,18 @@ async function run(): Promise<void> {
     for (const example of operatorGuide.examples) {
       console.log(`  - ${example.id}: ${example.label}`);
     }
+    return;
+  }
+
+  if (args.command === "openspec-imports") {
+    const result = await service.listOpenSpecImportHistory({ trackId: args.trackId, limit: args.limit });
+
+    if (args.json) {
+      console.log(JSON.stringify({ config: loadConfig(), result }, null, 2));
+      return;
+    }
+
+    printImportHistory(result);
     return;
   }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,8 @@ import {
   TRACK_STATUSES,
   type ExecutionEvent,
   type ApprovalStatus,
+  type GitHubIssueReference,
+  type GitHubPullRequestReference,
   type SpecRailServiceDependencies,
   type TrackStatus,
 } from "@specrail/core";
@@ -32,6 +34,8 @@ interface TrackRequestBody {
   title: string;
   description: string;
   priority?: "low" | "medium" | "high";
+  githubIssue?: GitHubIssueReference;
+  githubPullRequest?: GitHubPullRequestReference;
 }
 
 interface RunRequestBody {
@@ -44,6 +48,8 @@ interface UpdateTrackRequestBody {
   status?: TrackStatus;
   specStatus?: ApprovalStatus;
   planStatus?: ApprovalStatus;
+  githubIssue?: GitHubIssueReference;
+  githubPullRequest?: GitHubPullRequestReference;
 }
 
 interface ResumeRunRequestBody {
@@ -274,6 +280,34 @@ function getNonEmptyStringDetail(field: string, value: unknown): ApiErrorDetail 
   return null;
 }
 
+function getGitHubReferenceDetails(
+  field: string,
+  value: unknown,
+): ApiErrorDetail[] {
+  const details: ApiErrorDetail[] = [];
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return [{ field, message: "must be an object" }];
+  }
+
+  const numberValue = (value as { number?: unknown }).number;
+  if (!Number.isInteger(numberValue) || (numberValue as number) < 1) {
+    details.push({ field: `${field}.number`, message: "must be an integer greater than or equal to 1" });
+  }
+
+  const urlDetail = getNonEmptyStringDetail(`${field}.url`, (value as { url?: unknown }).url);
+  if (urlDetail) {
+    details.push(urlDetail);
+  } else {
+    const url = String((value as { url: string }).url).trim();
+    if (!/^https:\/\/github\.com\/.+\/(issues|pull)\/\d+$/u.test(url)) {
+      details.push({ field: `${field}.url`, message: "must be a valid GitHub issue or pull request URL" });
+    }
+  }
+
+  return details;
+}
+
 function assertValidTrackCreateBody(body: TrackRequestBody): void {
   const details: ApiErrorDetail[] = [];
 
@@ -295,6 +329,14 @@ function assertValidTrackCreateBody(body: TrackRequestBody): void {
     details.push({ field: "priority", message: "must be one of low, medium, high" });
   }
 
+  if (body.githubIssue !== undefined) {
+    details.push(...getGitHubReferenceDetails("githubIssue", body.githubIssue));
+  }
+
+  if (body.githubPullRequest !== undefined) {
+    details.push(...getGitHubReferenceDetails("githubPullRequest", body.githubPullRequest));
+  }
+
   if (details.length > 0) {
     throw new RequestValidationError("request validation failed", details);
   }
@@ -303,8 +345,17 @@ function assertValidTrackCreateBody(body: TrackRequestBody): void {
 function assertValidTrackUpdateBody(body: UpdateTrackRequestBody): void {
   const details: ApiErrorDetail[] = [];
 
-  if (body.status === undefined && body.specStatus === undefined && body.planStatus === undefined) {
-    details.push({ field: "body", message: "at least one of status, specStatus, or planStatus is required" });
+  if (
+    body.status === undefined &&
+    body.specStatus === undefined &&
+    body.planStatus === undefined &&
+    body.githubIssue === undefined &&
+    body.githubPullRequest === undefined
+  ) {
+    details.push({
+      field: "body",
+      message: "at least one of status, specStatus, planStatus, githubIssue, or githubPullRequest is required",
+    });
   }
 
   if (body.status !== undefined && !isTrackStatus(body.status)) {
@@ -317,6 +368,14 @@ function assertValidTrackUpdateBody(body: UpdateTrackRequestBody): void {
 
   if (body.planStatus !== undefined && !isApprovalStatus(body.planStatus)) {
     details.push({ field: "planStatus", message: "must be a valid approval status" });
+  }
+
+  if (body.githubIssue !== undefined) {
+    details.push(...getGitHubReferenceDetails("githubIssue", body.githubIssue));
+  }
+
+  if (body.githubPullRequest !== undefined) {
+    details.push(...getGitHubReferenceDetails("githubPullRequest", body.githubPullRequest));
   }
 
   if (details.length > 0) {
@@ -587,6 +646,8 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           status: body.status,
           specStatus: body.specStatus,
           planStatus: body.planStatus,
+          githubIssue: body.githubIssue,
+          githubPullRequest: body.githubPullRequest,
         });
         sendJson(response, 200, { track });
         return;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { CodexAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
 import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
 import {
   APPROVAL_STATUSES,
+  ConflictError,
   FileGitHubRunCommentSyncStore,
   FileExecutionRepository,
   FileProjectRepository,
@@ -640,6 +641,27 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (
+        method === "POST" &&
+        segments.length === 6 &&
+        segments[0] === "tracks" &&
+        segments[2] === "integrations" &&
+        segments[3] === "github" &&
+        segments[4] === "run-comment-sync" &&
+        segments[5] === "retry"
+      ) {
+        const retry = await deps.service.retryGitHubRunCommentSync(segments[1] ?? "");
+        const inspection = await deps.service.getTrackIntegrationsInspection(segments[1] ?? "");
+
+        sendJson(response, 200, {
+          trackId: segments[1] ?? "",
+          runId: retry.runId,
+          results: retry.results,
+          integrations: inspection,
+        });
+        return;
+      }
+
       if (method === "GET" && segments.length === 2 && segments[0] === "tracks") {
         const inspection = await deps.service.getTrackInspection(segments[1] ?? "");
 
@@ -772,6 +794,11 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
 
       if (error instanceof NotFoundError) {
         sendError(response, 404, "not_found", error.message);
+        return;
+      }
+
+      if (error instanceof ConflictError) {
+        sendError(response, 409, "conflict", error.message);
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -77,6 +77,10 @@ interface OpenSpecImportRequestBody {
   };
 }
 
+interface OpenSpecImportHelpQuery {
+  resolutionPreset?: OpenSpecImportResolutionPresetName;
+}
+
 interface TrackListQuery {
   status?: TrackStatus;
   priority?: TrackRequestBody["priority"];
@@ -835,6 +839,22 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           resolution: body.resolution,
         });
         sendJson(response, 200, result);
+        return;
+      }
+
+      if (method === "GET" && segments.length === 4 && segments[0] === "admin" && segments[1] === "openspec" && segments[2] === "import" && segments[3] === "help") {
+        const searchParams = getSearchParams(request);
+        const resolutionPreset = (searchParams.get("resolutionPreset") ?? undefined) as OpenSpecImportHelpQuery["resolutionPreset"];
+
+        if (resolutionPreset !== undefined && !OPENSPEC_RESOLUTION_PRESETS.some((preset) => preset.name === resolutionPreset)) {
+          throw new RequestValidationError("request validation failed", [
+            { field: "resolutionPreset", message: `must be one of ${OPENSPEC_RESOLUTION_PRESETS.map((preset) => preset.name).join(", ")}` },
+          ]);
+        }
+
+        sendJson(response, 200, {
+          operatorGuide: deps.service.getOpenSpecImportHelp({ resolutionPreset }),
+        });
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -628,6 +628,18 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (method === "GET" && segments.length === 3 && segments[0] === "tracks" && segments[2] === "integrations") {
+        const inspection = await deps.service.getTrackIntegrationsInspection(segments[1] ?? "");
+
+        if (!inspection) {
+          sendError(response, 404, "not_found", "track not found");
+          return;
+        }
+
+        sendJson(response, 200, inspection);
+        return;
+      }
+
       if (method === "GET" && segments.length === 2 && segments[0] === "tracks") {
         const inspection = await deps.service.getTrackInspection(segments[1] ?? "");
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,19 +4,12 @@ import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { CodexAdapter, FileOpenSpecAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
-import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
+import { getTrackArtifactPaths, loadConfig } from "@specrail/config";
 import {
   APPROVAL_STATUSES,
   ConflictError,
-  FileGitHubRunCommentSyncStore,
-  FileExecutionRepository,
-  FileProjectRepository,
-  FileTrackRepository,
-  JsonlEventStore,
   NotFoundError,
   OPENSPEC_RESOLUTION_PRESETS,
-  getStatePaths,
   SpecRailService,
   TRACK_STATUSES,
   type ExecutionEvent,
@@ -24,9 +17,9 @@ import {
   type GitHubIssueReference,
   type GitHubPullRequestReference,
   type OpenSpecImportResolutionPresetName,
-  type SpecRailServiceDependencies,
   type TrackStatus,
 } from "@specrail/core";
+import { createDependencies } from "./runtime.js";
 
 interface ApiDeps {
   artifactRoot: string;
@@ -110,12 +103,6 @@ interface ListMeta {
   hasPrevPage: boolean;
 }
 
-interface DefaultDependencies {
-  artifactRoot: string;
-  eventLogDir: string;
-  serviceDependencies: SpecRailServiceDependencies;
-}
-
 interface ApiErrorDetail {
   field: string;
   message: string;
@@ -137,80 +124,6 @@ class RequestValidationError extends Error {
     super(message);
     this.name = "RequestValidationError";
   }
-}
-
-function createDependencies(dataDir: string, repoArtifactRoot: string, githubPublishEnabled = false): DefaultDependencies {
-  const stateDir = path.join(dataDir, "state");
-  const artifactRoot = path.join(dataDir, "artifacts");
-  const workspaceRoot = path.join(dataDir, "workspaces");
-  const sessionsDir = path.join(dataDir, "sessions");
-  const templateDir = path.resolve(process.cwd(), ".specrail-template");
-
-  const eventStore = new JsonlEventStore(stateDir);
-  const githubRunCommentSyncStore = new FileGitHubRunCommentSyncStore(stateDir);
-  const projectRepository = new FileProjectRepository(stateDir);
-  const trackRepository = new FileTrackRepository(stateDir);
-  const executionRepository = new FileExecutionRepository(stateDir);
-  let service: SpecRailService | null = null;
-
-  const serviceDependencies: SpecRailServiceDependencies = {
-    projectRepository,
-    trackRepository,
-    executionRepository,
-    eventStore,
-    artifactWriter: {
-      async write(input) {
-        await materializeTrackArtifacts({
-          rootDir: artifactRoot,
-          repoVisibleRootDir: repoArtifactRoot,
-          templateDir,
-          trackId: input.track.id,
-          projectName: input.project.name,
-          trackTitle: input.track.title,
-          trackDescription: input.track.description,
-          openSpecImport: input.track.openSpecImport,
-          specContent: input.specContent,
-          planContent: input.planContent,
-          tasksContent: input.tasksContent,
-        });
-      },
-    },
-    artifactReader: {
-      async read(trackId) {
-        return readTrackArtifacts(artifactRoot, trackId);
-      },
-    },
-    executor: new CodexAdapter({
-      sessionsDir,
-      onEvent: async (event) => {
-        if (service) {
-          await service.recordExecutionEvent(event);
-          return;
-        }
-
-        await eventStore.append(event);
-      },
-    }),
-    defaultProject: {
-      id: "project-default",
-      name: "SpecRail",
-      repoUrl: "https://github.com/yoophi-a/specrail",
-      localRepoPath: process.cwd(),
-      defaultWorkflowPolicy: "artifact-first-mvp",
-    },
-    workspaceRoot,
-    openSpecAdapter: new FileOpenSpecAdapter(),
-    githubRunCommentPublisher: githubPublishEnabled ? new GitHubRunCommentGhPublisher() : undefined,
-    githubRunCommentSyncStore,
-  };
-
-  service = new SpecRailService(serviceDependencies);
-
-  return {
-    artifactRoot,
-    eventLogDir: getStatePaths(stateDir).eventsDir,
-    serviceDependencies,
-  };
 }
 
 async function readJson<T>(request: IncomingMessage): Promise<T> {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import {
   FileTrackRepository,
   JsonlEventStore,
   NotFoundError,
+  OPENSPEC_RESOLUTION_PRESETS,
   getStatePaths,
   SpecRailService,
   TRACK_STATUSES,
@@ -22,6 +23,7 @@ import {
   type ApprovalStatus,
   type GitHubIssueReference,
   type GitHubPullRequestReference,
+  type OpenSpecImportResolutionPresetName,
   type SpecRailServiceDependencies,
   type TrackStatus,
 } from "@specrail/core";
@@ -68,6 +70,7 @@ interface OpenSpecImportRequestBody {
   path: string;
   dryRun?: boolean;
   conflictPolicy?: "reject" | "overwrite" | "resolve";
+  resolutionPreset?: OpenSpecImportResolutionPresetName;
   resolution?: {
     track?: Partial<Record<"title" | "description" | "status" | "specStatus" | "planStatus" | "priority" | "githubIssue" | "githubPullRequest", "incoming" | "existing">>;
     artifacts?: Partial<Record<"spec" | "plan" | "tasks", "incoming" | "existing">>;
@@ -483,6 +486,10 @@ function assertValidOpenSpecImportBody(body: OpenSpecImportRequestBody): void {
     details.push({ field: "conflictPolicy", message: "must be one of reject, overwrite, resolve" });
   }
 
+  if (body.resolutionPreset !== undefined && !OPENSPEC_RESOLUTION_PRESETS.some((preset) => preset.name === body.resolutionPreset)) {
+    details.push({ field: "resolutionPreset", message: `must be one of ${OPENSPEC_RESOLUTION_PRESETS.map((preset) => preset.name).join(", ")}` });
+  }
+
   for (const [groupKey, group] of Object.entries(body.resolution ?? {})) {
     if (!group || typeof group !== "object" || Array.isArray(group)) {
       details.push({ field: `resolution.${groupKey}`, message: "must be an object" });
@@ -824,6 +831,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           },
           dryRun: body.dryRun,
           conflictPolicy: body.conflictPolicy,
+          resolutionPreset: body.resolutionPreset,
           resolution: body.resolution,
         });
         sendJson(response, 200, result);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -781,6 +781,16 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (method === "GET" && segments.length === 3 && segments[0] === "admin" && segments[1] === "openspec" && segments[2] === "exports") {
+        const searchParams = getSearchParams(request);
+        const trackId = searchParams.get("trackId") ?? undefined;
+        const limit = parsePositiveInteger(searchParams.get("limit"));
+        sendJson(response, 200, {
+          exports: await deps.service.listOpenSpecExportHistory({ trackId, limit }),
+        });
+        return;
+      }
+
       if (method === "GET" && segments.length === 1 && segments[0] === "runs") {
         const searchParams = getSearchParams(request);
         const query: RunListQuery = {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { CodexAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
+import { CodexAdapter, FileOpenSpecAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
 import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
 import {
   APPROVAL_STATUSES,
@@ -56,6 +56,16 @@ interface UpdateTrackRequestBody {
 
 interface ResumeRunRequestBody {
   prompt: string;
+}
+
+interface OpenSpecExportRequestBody {
+  trackId: string;
+  path: string;
+  overwrite?: boolean;
+}
+
+interface OpenSpecImportRequestBody {
+  path: string;
 }
 
 interface TrackListQuery {
@@ -151,6 +161,11 @@ function createDependencies(dataDir: string, repoArtifactRoot: string, githubPub
         });
       },
     },
+    artifactReader: {
+      async read(trackId) {
+        return readTrackArtifacts(artifactRoot, trackId);
+      },
+    },
     executor: new CodexAdapter({
       sessionsDir,
       onEvent: async (event) => {
@@ -170,6 +185,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string, githubPub
       defaultWorkflowPolicy: "artifact-first-mvp",
     },
     workspaceRoot,
+    openSpecAdapter: new FileOpenSpecAdapter(),
     githubRunCommentPublisher: githubPublishEnabled ? new GitHubRunCommentGhPublisher() : undefined,
     githubRunCommentSyncStore,
   };
@@ -418,6 +434,36 @@ function assertValidResumeRunBody(body: ResumeRunRequestBody): void {
 
   if (promptDetail) {
     throw new RequestValidationError("request validation failed", [promptDetail]);
+  }
+}
+
+function assertValidOpenSpecExportBody(body: OpenSpecExportRequestBody): void {
+  const details: ApiErrorDetail[] = [];
+
+  const trackIdDetail = getNonEmptyStringDetail("trackId", body.trackId);
+  if (trackIdDetail) {
+    details.push(trackIdDetail);
+  }
+
+  const pathDetail = getNonEmptyStringDetail("path", body.path);
+  if (pathDetail) {
+    details.push(pathDetail);
+  }
+
+  if (body.overwrite !== undefined && typeof body.overwrite !== "boolean") {
+    details.push({ field: "overwrite", message: "must be a boolean" });
+  }
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
+  }
+}
+
+function assertValidOpenSpecImportBody(body: OpenSpecImportRequestBody): void {
+  const pathDetail = getNonEmptyStringDetail("path", body.path);
+
+  if (pathDetail) {
+    throw new RequestValidationError("request validation failed", [pathDetail]);
   }
 }
 
@@ -701,6 +747,36 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
 
         const run = await deps.service.startRun(body);
         sendJson(response, 201, { run });
+        return;
+      }
+
+      if (method === "POST" && segments.length === 3 && segments[0] === "admin" && segments[1] === "openspec" && segments[2] === "export") {
+        const body = await readJson<OpenSpecExportRequestBody>(request);
+        assertValidOpenSpecExportBody(body);
+
+        const result = await deps.service.exportTrackToOpenSpec({
+          trackId: body.trackId,
+          target: {
+            kind: "file",
+            path: body.path,
+            overwrite: body.overwrite,
+          },
+        });
+        sendJson(response, 200, result);
+        return;
+      }
+
+      if (method === "POST" && segments.length === 3 && segments[0] === "admin" && segments[1] === "openspec" && segments[2] === "import") {
+        const body = await readJson<OpenSpecImportRequestBody>(request);
+        assertValidOpenSpecImportBody(body);
+
+        const result = await deps.service.importTrackFromOpenSpec({
+          source: {
+            kind: "file",
+            path: body.path,
+          },
+        });
+        sendJson(response, 200, result);
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -67,7 +67,11 @@ interface OpenSpecExportRequestBody {
 interface OpenSpecImportRequestBody {
   path: string;
   dryRun?: boolean;
-  conflictPolicy?: "reject" | "overwrite";
+  conflictPolicy?: "reject" | "overwrite" | "resolve";
+  resolution?: {
+    track?: Partial<Record<"title" | "description" | "status" | "specStatus" | "planStatus" | "priority" | "githubIssue" | "githubPullRequest", "incoming" | "existing">>;
+    artifacts?: Partial<Record<"spec" | "plan" | "tasks", "incoming" | "existing">>;
+  };
 }
 
 interface TrackListQuery {
@@ -464,6 +468,7 @@ function assertValidOpenSpecExportBody(body: OpenSpecExportRequestBody): void {
 
 function assertValidOpenSpecImportBody(body: OpenSpecImportRequestBody): void {
   const details: ApiErrorDetail[] = [];
+  const validResolutionValues = ["incoming", "existing"];
   const pathDetail = getNonEmptyStringDetail("path", body.path);
 
   if (pathDetail) {
@@ -474,8 +479,21 @@ function assertValidOpenSpecImportBody(body: OpenSpecImportRequestBody): void {
     details.push({ field: "dryRun", message: "must be a boolean" });
   }
 
-  if (body.conflictPolicy !== undefined && !["reject", "overwrite"].includes(body.conflictPolicy)) {
-    details.push({ field: "conflictPolicy", message: "must be one of reject, overwrite" });
+  if (body.conflictPolicy !== undefined && !["reject", "overwrite", "resolve"].includes(body.conflictPolicy)) {
+    details.push({ field: "conflictPolicy", message: "must be one of reject, overwrite, resolve" });
+  }
+
+  for (const [groupKey, group] of Object.entries(body.resolution ?? {})) {
+    if (!group || typeof group !== "object" || Array.isArray(group)) {
+      details.push({ field: `resolution.${groupKey}`, message: "must be an object" });
+      continue;
+    }
+
+    for (const [field, value] of Object.entries(group)) {
+      if (!validResolutionValues.includes(String(value))) {
+        details.push({ field: `resolution.${groupKey}.${field}`, message: "must be one of incoming, existing" });
+      }
+    }
   }
 
   if (details.length > 0) {
@@ -703,6 +721,18 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (method === "GET" && segments.length === 4 && segments[0] === "tracks" && segments[2] === "openspec" && segments[3] === "imports") {
+        const inspection = await deps.service.getTrackOpenSpecImports(segments[1] ?? "");
+
+        if (!inspection) {
+          sendError(response, 404, "not_found", "track not found");
+          return;
+        }
+
+        sendJson(response, 200, inspection);
+        return;
+      }
+
       if (
         method === "POST" &&
         segments.length === 6 &&
@@ -736,6 +766,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         sendJson(response, 200, {
           track: inspection.track,
           githubRunCommentSync: inspection.githubRunCommentSync,
+          openSpecImports: await deps.service.getTrackOpenSpecImports(inspection.track.id),
           artifacts,
         });
         return;
@@ -793,8 +824,19 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           },
           dryRun: body.dryRun,
           conflictPolicy: body.conflictPolicy,
+          resolution: body.resolution,
         });
         sendJson(response, 200, result);
+        return;
+      }
+
+      if (method === "GET" && segments.length === 3 && segments[0] === "admin" && segments[1] === "openspec" && segments[2] === "imports") {
+        const searchParams = getSearchParams(request);
+        const trackId = searchParams.get("trackId") ?? undefined;
+        const limit = parsePositiveInteger(searchParams.get("limit"));
+        sendJson(response, 200, {
+          imports: await deps.service.listOpenSpecImportHistory({ trackId, limit }),
+        });
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { CodexAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
 import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
 import {
   APPROVAL_STATUSES,
+  FileGitHubRunCommentSyncStore,
   FileExecutionRepository,
   FileProjectRepository,
   FileTrackRepository,
@@ -122,6 +123,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string, githubPub
   const templateDir = path.resolve(process.cwd(), ".specrail-template");
 
   const eventStore = new JsonlEventStore(stateDir);
+  const githubRunCommentSyncStore = new FileGitHubRunCommentSyncStore(stateDir);
   const projectRepository = new FileProjectRepository(stateDir);
   const trackRepository = new FileTrackRepository(stateDir);
   const executionRepository = new FileExecutionRepository(stateDir);
@@ -168,6 +170,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string, githubPub
     },
     workspaceRoot,
     githubRunCommentPublisher: githubPublishEnabled ? new GitHubRunCommentGhPublisher() : undefined,
+    githubRunCommentSyncStore,
   };
 
   service = new SpecRailService(serviceDependencies);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -157,6 +157,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string, githubPub
           projectName: input.project.name,
           trackTitle: input.track.title,
           trackDescription: input.track.description,
+          openSpecImport: input.track.openSpecImport,
           specContent: input.specContent,
           planContent: input.planContent,
           tasksContent: input.tasksContent,
@@ -891,7 +892,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
       }
 
       if (error instanceof ConflictError) {
-        sendError(response, 409, "conflict", error.message);
+        sendError(response, 409, "conflict", error.message, error.details as ApiErrorDetail[] | undefined);
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -629,15 +629,19 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
       }
 
       if (method === "GET" && segments.length === 2 && segments[0] === "tracks") {
-        const track = await deps.service.getTrack(segments[1] ?? "");
+        const inspection = await deps.service.getTrackInspection(segments[1] ?? "");
 
-        if (!track) {
+        if (!inspection) {
           sendError(response, 404, "not_found", "track not found");
           return;
         }
 
-        const artifacts = await readTrackArtifacts(deps.artifactRoot, track.id);
-        sendJson(response, 200, { track, artifacts });
+        const artifacts = await readTrackArtifacts(deps.artifactRoot, inspection.track.id);
+        sendJson(response, 200, {
+          track: inspection.track,
+          githubRunCommentSync: inspection.githubRunCommentSync,
+          artifacts,
+        });
         return;
       }
 
@@ -702,14 +706,18 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
       }
 
       if (method === "GET" && segments.length === 2 && segments[0] === "runs") {
-        const run = await deps.service.getRun(segments[1] ?? "");
+        const inspection = await deps.service.getRunInspection(segments[1] ?? "");
 
-        if (!run) {
+        if (!inspection) {
           sendError(response, 404, "not_found", "run not found");
           return;
         }
 
-        sendJson(response, 200, { run });
+        sendJson(response, 200, {
+          run: inspection.run,
+          githubRunCommentSync: inspection.githubRunCommentSync,
+          githubRunCommentSyncForRun: inspection.githubRunCommentSyncForRun,
+        });
         return;
       }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { CodexAdapter } from "@specrail/adapters";
+import { CodexAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
 import { getTrackArtifactPaths, loadConfig, materializeTrackArtifacts } from "@specrail/config";
 import {
   APPROVAL_STATUSES,
@@ -114,7 +114,7 @@ class RequestValidationError extends Error {
   }
 }
 
-function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultDependencies {
+function createDependencies(dataDir: string, repoArtifactRoot: string, githubPublishEnabled = false): DefaultDependencies {
   const stateDir = path.join(dataDir, "state");
   const artifactRoot = path.join(dataDir, "artifacts");
   const workspaceRoot = path.join(dataDir, "workspaces");
@@ -167,6 +167,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
       defaultWorkflowPolicy: "artifact-first-mvp",
     },
     workspaceRoot,
+    githubRunCommentPublisher: githubPublishEnabled ? new GitHubRunCommentGhPublisher() : undefined,
   };
 
   service = new SpecRailService(serviceDependencies);
@@ -759,7 +760,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
 
 export function createDefaultServer(): http.Server {
   const config = loadConfig();
-  const dependencies = createDependencies(config.dataDir, config.repoArtifactDir);
+  const dependencies = createDependencies(config.dataDir, config.repoArtifactDir, config.githubPublishEnabled);
 
   return createSpecRailHttpServer({
     artifactRoot: dependencies.artifactRoot,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -66,6 +66,8 @@ interface OpenSpecExportRequestBody {
 
 interface OpenSpecImportRequestBody {
   path: string;
+  dryRun?: boolean;
+  conflictPolicy?: "reject" | "overwrite";
 }
 
 interface TrackListQuery {
@@ -460,10 +462,23 @@ function assertValidOpenSpecExportBody(body: OpenSpecExportRequestBody): void {
 }
 
 function assertValidOpenSpecImportBody(body: OpenSpecImportRequestBody): void {
+  const details: ApiErrorDetail[] = [];
   const pathDetail = getNonEmptyStringDetail("path", body.path);
 
   if (pathDetail) {
-    throw new RequestValidationError("request validation failed", [pathDetail]);
+    details.push(pathDetail);
+  }
+
+  if (body.dryRun !== undefined && typeof body.dryRun !== "boolean") {
+    details.push({ field: "dryRun", message: "must be a boolean" });
+  }
+
+  if (body.conflictPolicy !== undefined && !["reject", "overwrite"].includes(body.conflictPolicy)) {
+    details.push({ field: "conflictPolicy", message: "must be one of reject, overwrite" });
+  }
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
   }
 }
 
@@ -775,6 +790,8 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
             kind: "file",
             path: body.path,
           },
+          dryRun: body.dryRun,
+          conflictPolicy: body.conflictPolicy,
         });
         sendJson(response, 200, result);
         return;

--- a/apps/api/src/runtime.ts
+++ b/apps/api/src/runtime.ts
@@ -72,6 +72,7 @@ export function createDependencies(dataDir: string, repoArtifactRoot: string, gi
           trackTitle: input.track.title,
           trackDescription: input.track.description,
           openSpecImport: input.track.openSpecImport,
+          openSpecExport: input.track.openSpecExport,
           specContent: input.specContent,
           planContent: input.planContent,
           tasksContent: input.tasksContent,

--- a/apps/api/src/runtime.ts
+++ b/apps/api/src/runtime.ts
@@ -1,0 +1,123 @@
+import { CodexAdapter, FileOpenSpecAdapter, GitHubRunCommentGhPublisher } from "@specrail/adapters";
+import { loadConfig, materializeTrackArtifacts } from "@specrail/config";
+import {
+  FileExecutionRepository,
+  FileGitHubRunCommentSyncStore,
+  FileProjectRepository,
+  FileTrackRepository,
+  JsonlEventStore,
+  SpecRailService,
+  getStatePaths,
+  type SpecRailServiceDependencies,
+} from "@specrail/core";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface DefaultDependencies {
+  artifactRoot: string;
+  eventLogDir: string;
+  serviceDependencies: SpecRailServiceDependencies;
+}
+
+async function readTrackArtifacts(artifactRoot: string, trackId: string): Promise<{
+  spec: string;
+  plan: string;
+  tasks: string;
+}> {
+  const { readFile } = await import("node:fs/promises");
+  const paths = {
+    spec: path.join(artifactRoot, "tracks", trackId, "spec.md"),
+    plan: path.join(artifactRoot, "tracks", trackId, "plan.md"),
+    tasks: path.join(artifactRoot, "tracks", trackId, "tasks.md"),
+  };
+
+  const [spec, plan, tasks] = await Promise.all([
+    readFile(paths.spec, "utf8"),
+    readFile(paths.plan, "utf8"),
+    readFile(paths.tasks, "utf8"),
+  ]);
+
+  return { spec, plan, tasks };
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+export function createDependencies(dataDir: string, repoArtifactRoot: string, githubPublishEnabled = false): DefaultDependencies {
+  const stateDir = path.join(dataDir, "state");
+  const artifactRoot = path.join(dataDir, "artifacts");
+  const workspaceRoot = path.join(dataDir, "workspaces");
+  const sessionsDir = path.join(dataDir, "sessions");
+  const templateDir = path.join(repoRoot, ".specrail-template");
+
+  const eventStore = new JsonlEventStore(stateDir);
+  const githubRunCommentSyncStore = new FileGitHubRunCommentSyncStore(stateDir);
+  const projectRepository = new FileProjectRepository(stateDir);
+  const trackRepository = new FileTrackRepository(stateDir);
+  const executionRepository = new FileExecutionRepository(stateDir);
+  let service: SpecRailService | null = null;
+
+  const serviceDependencies: SpecRailServiceDependencies = {
+    projectRepository,
+    trackRepository,
+    executionRepository,
+    eventStore,
+    artifactWriter: {
+      async write(input) {
+        await materializeTrackArtifacts({
+          rootDir: artifactRoot,
+          repoVisibleRootDir: repoArtifactRoot,
+          templateDir,
+          trackId: input.track.id,
+          projectName: input.project.name,
+          trackTitle: input.track.title,
+          trackDescription: input.track.description,
+          openSpecImport: input.track.openSpecImport,
+          specContent: input.specContent,
+          planContent: input.planContent,
+          tasksContent: input.tasksContent,
+        });
+      },
+    },
+    artifactReader: {
+      async read(trackId) {
+        return readTrackArtifacts(artifactRoot, trackId);
+      },
+    },
+    executor: new CodexAdapter({
+      sessionsDir,
+      onEvent: async (event) => {
+        if (service) {
+          await service.recordExecutionEvent(event);
+          return;
+        }
+
+        await eventStore.append(event);
+      },
+    }),
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+      repoUrl: "https://github.com/yoophi-a/specrail",
+      localRepoPath: repoRoot,
+      defaultWorkflowPolicy: "artifact-first-mvp",
+    },
+    workspaceRoot,
+    openSpecAdapter: new FileOpenSpecAdapter(),
+    githubRunCommentPublisher: githubPublishEnabled ? new GitHubRunCommentGhPublisher() : undefined,
+    githubRunCommentSyncStore,
+  };
+
+  service = new SpecRailService(serviceDependencies);
+
+  return {
+    artifactRoot,
+    eventLogDir: getStatePaths(stateDir).eventsDir,
+    serviceDependencies,
+  };
+}
+
+export function createDefaultService(): SpecRailService {
+  const config = loadConfig();
+  const dependencies = createDependencies(config.dataDir, config.repoArtifactDir, config.githubPublishEnabled);
+  return new SpecRailService(dependencies.serviceDependencies);
+}

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -318,7 +318,8 @@ That avoids hard-to-debug bidirectional sync too early.
 
 ### Phase 5. Round-trip and policy hardening
 - repeated sync safety
-- conflict workflows
+- [x] conflict workflows (`resolve` with selective keep-existing choices for track/artifact fields)
+- [x] import history inspection endpoints for track and admin APIs
 - source-of-truth policies by field
 - better auditability and operator tools
 

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -314,7 +314,7 @@ That avoids hard-to-debug bidirectional sync too early.
 - [x] import OpenSpec package -> create/update track
 - [x] export track artifacts -> OpenSpec package via API/service wiring
 - [x] add preview/dry-run import flow and first explicit conflict policy (`reject` default, `overwrite` explicit)
-- conflict reporting and provenance metadata
+- [x] conflict reporting and provenance metadata
 
 ### Phase 5. Round-trip and policy hardening
 - repeated sync safety

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -309,9 +309,10 @@ That avoids hard-to-debug bidirectional sync too early.
 - add simple webhook receiver
 
 ### Phase 4. OpenSpec import/export
-- define OpenSpec adapter boundary
-- import OpenSpec package -> create/update track
-- export track artifacts -> OpenSpec package
+- [x] define OpenSpec adapter boundary
+- [x] add first file-bundle scaffold for import/export of track + `spec.md`/`plan.md`/`tasks.md`
+- [ ] import OpenSpec package -> create/update track
+- [ ] export track artifacts -> OpenSpec package via API/service wiring
 - conflict reporting and provenance metadata
 
 ### Phase 5. Round-trip and policy hardening

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -311,8 +311,8 @@ That avoids hard-to-debug bidirectional sync too early.
 ### Phase 4. OpenSpec import/export
 - [x] define OpenSpec adapter boundary
 - [x] add first file-bundle scaffold for import/export of track + `spec.md`/`plan.md`/`tasks.md`
-- [ ] import OpenSpec package -> create/update track
-- [ ] export track artifacts -> OpenSpec package via API/service wiring
+- [x] import OpenSpec package -> create/update track
+- [x] export track artifacts -> OpenSpec package via API/service wiring
 - conflict reporting and provenance metadata
 
 ### Phase 5. Round-trip and policy hardening

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -313,6 +313,7 @@ That avoids hard-to-debug bidirectional sync too early.
 - [x] add first file-bundle scaffold for import/export of track + `spec.md`/`plan.md`/`tasks.md`
 - [x] import OpenSpec package -> create/update track
 - [x] export track artifacts -> OpenSpec package via API/service wiring
+- [x] add preview/dry-run import flow and first explicit conflict policy (`reject` default, `overwrite` explicit)
 - conflict reporting and provenance metadata
 
 ### Phase 5. Round-trip and policy hardening

--- a/docs/architecture/github-speckit-openspec-integration-plan.md
+++ b/docs/architecture/github-speckit-openspec-integration-plan.md
@@ -327,6 +327,9 @@ That avoids hard-to-debug bidirectional sync too early.
 1. Add repo-visible `.specrail/` artifact sync separate from `.specrail-data/`
 2. Add track external reference fields for GitHub issue/PR linkage
 3. Add execution summary publishing format for issue/PR comments
+   - implemented in core as `formatGitHubRunCommentSummary(...)`
+   - current payload includes linked issue/PR refs, run outcome, backend/profile/branch/session metadata, and recent event highlights
+   - next step is wiring this formatter into a GitHub publishing adapter/upsert flow
 4. Add an import/export adapter boundary for OpenSpec-compatible documents
 5. Add sync metadata schema (`sync.json`) and conflict markers
 

--- a/packages/adapters/src/__tests__/file-openspec-adapter.test.ts
+++ b/packages/adapters/src/__tests__/file-openspec-adapter.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { Track } from "@specrail/core";
+
+import { FileOpenSpecAdapter, type OpenSpecTrackPackage } from "../index.js";
+
+function createTrack(): Track {
+  return {
+    id: "track-openspec-1",
+    projectId: "project-default",
+    title: "OpenSpec adapter boundary",
+    description: "Ship a first import/export scaffold.",
+    status: "planned",
+    specStatus: "approved",
+    planStatus: "pending",
+    priority: "high",
+    githubIssue: { number: 35, url: "https://github.com/yoophi-a/specrail/issues/35" },
+    createdAt: "2026-04-10T00:00:00.000Z",
+    updatedAt: "2026-04-10T00:00:00.000Z",
+  };
+}
+
+function createPackage(): OpenSpecTrackPackage {
+  return {
+    metadata: {
+      version: 1,
+      format: "specrail.openspec.bundle",
+      exportedAt: "2026-04-10T00:00:00.000Z",
+      generatedBy: "specrail",
+    },
+    track: createTrack(),
+    files: {
+      spec: "spec.md",
+      plan: "plan.md",
+      tasks: "tasks.md",
+    },
+    artifacts: {
+      spec: "# Spec\n\nProblem statement\n",
+      plan: "# Plan\n\n1. Define contracts\n",
+      tasks: "# Tasks\n\n- [ ] Add adapter\n",
+    },
+  };
+}
+
+test("FileOpenSpecAdapter exports a file bundle with manifest and artifacts", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-openspec-export-"));
+  const targetDir = path.join(rootDir, "bundle");
+  const adapter = new FileOpenSpecAdapter({ now: () => "2026-04-10T01:02:03.000Z" });
+
+  const result = await adapter.exportPackage({
+    package: createPackage(),
+    target: { kind: "file", path: targetDir },
+  });
+
+  assert.equal(result.package.metadata.exportedAt, "2026-04-10T01:02:03.000Z");
+
+  const manifest = JSON.parse(await readFile(path.join(targetDir, "openspec.json"), "utf8")) as {
+    metadata: { format: string; exportedAt: string };
+    track: { id: string };
+    files: { spec: string; plan: string; tasks: string };
+  };
+
+  assert.equal(manifest.metadata.format, "specrail.openspec.bundle");
+  assert.equal(manifest.metadata.exportedAt, "2026-04-10T01:02:03.000Z");
+  assert.equal(manifest.track.id, "track-openspec-1");
+  assert.equal(await readFile(path.join(targetDir, manifest.files.spec), "utf8"), createPackage().artifacts.spec);
+  assert.equal(await readFile(path.join(targetDir, manifest.files.plan), "utf8"), createPackage().artifacts.plan);
+  assert.equal(await readFile(path.join(targetDir, manifest.files.tasks), "utf8"), createPackage().artifacts.tasks);
+});
+
+test("FileOpenSpecAdapter imports a file bundle back into a typed package", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-openspec-import-"));
+  const bundleDir = path.join(rootDir, "bundle");
+  const adapter = new FileOpenSpecAdapter();
+  const pkg = createPackage();
+
+  await adapter.exportPackage({
+    package: pkg,
+    target: { kind: "file", path: bundleDir },
+  });
+
+  const result = await adapter.importPackage({ source: { kind: "file", path: bundleDir } });
+
+  assert.equal(result.package.track.id, pkg.track.id);
+  assert.equal(result.package.track.githubIssue?.number, 35);
+  assert.equal(result.package.artifacts.spec, pkg.artifacts.spec);
+  assert.equal(result.package.artifacts.plan, pkg.artifacts.plan);
+  assert.equal(result.package.artifacts.tasks, pkg.artifacts.tasks);
+  assert.equal(result.package.files.spec, "spec.md");
+});
+
+test("FileOpenSpecAdapter rejects invalid manifests", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-openspec-invalid-"));
+  await writeFile(
+    path.join(rootDir, "openspec.json"),
+    JSON.stringify({ metadata: { version: 1, format: "nope" }, track: { id: "track-1" }, files: {} }),
+    "utf8",
+  );
+
+  const adapter = new FileOpenSpecAdapter();
+
+  await assert.rejects(
+    () => adapter.importPackage({ source: { kind: "file", path: rootDir } }),
+    /Invalid OpenSpec package manifest format/,
+  );
+});
+
+test("FileOpenSpecAdapter does not overwrite an existing export target unless requested", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-openspec-overwrite-"));
+  const targetDir = path.join(rootDir, "bundle");
+  const adapter = new FileOpenSpecAdapter();
+
+  await adapter.exportPackage({
+    package: createPackage(),
+    target: { kind: "file", path: targetDir },
+  });
+
+  await assert.rejects(
+    () =>
+      adapter.exportPackage({
+        package: createPackage(),
+        target: { kind: "file", path: targetDir },
+      }),
+    /already exists/,
+  );
+
+  const overwriteResult = await adapter.exportPackage({
+    package: createPackage(),
+    target: { kind: "file", path: targetDir, overwrite: true },
+  });
+
+  assert.equal(overwriteResult.target.overwrite, true);
+});

--- a/packages/adapters/src/__tests__/github-run-comment-publisher.test.ts
+++ b/packages/adapters/src/__tests__/github-run-comment-publisher.test.ts
@@ -198,3 +198,159 @@ test("GitHubRunCommentGhPublisher updates existing marker-matched comments and n
     1,
   );
 });
+
+test("GitHubRunCommentGhPublisher reuses persisted comment ids before falling back to comment scans", async () => {
+  const client = new FakeGitHubApiClient(async (args) => {
+    if (args[0] === "user") {
+      return { login: "specrail-bot" };
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/comments/3001") {
+      return {
+        id: 3001,
+        body: "<!-- specrail:run-summary track=track-30 run=run-1 status=completed -->\nbody\n",
+        user: { login: "specrail-bot" },
+      };
+    }
+
+    throw new Error(`Unexpected request: ${args.join(" ")}`);
+  });
+
+  const publisher = new GitHubRunCommentGhPublisher({ apiClient: client });
+  const results = await publisher.publishRunSummary({
+    track: {
+      id: "track-30",
+      projectId: "project-default",
+      title: "Publish run summaries",
+      description: "",
+      status: "review",
+      specStatus: "approved",
+      planStatus: "approved",
+      priority: "high",
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-10T00:16:00.000Z",
+      githubIssue: { number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+    },
+    run: {
+      id: "run-1",
+      trackId: "track-30",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-1",
+      branchName: "specrail/run-1",
+      sessionRef: "session:run-1",
+      status: "completed",
+      createdAt: "2026-04-10T00:10:00.000Z",
+      startedAt: "2026-04-10T00:10:00.000Z",
+      finishedAt: "2026-04-10T00:15:00.000Z",
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Run completed",
+        lastEventAt: "2026-04-10T00:15:00.000Z",
+      },
+    },
+    events,
+    syncState: {
+      id: "track-30",
+      trackId: "track-30",
+      updatedAt: "2026-04-10T00:15:00.000Z",
+      comments: [
+        {
+          target: { kind: "issue", number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+          commentId: 3001,
+          lastRunId: "run-1",
+          lastRunStatus: "completed",
+          lastPublishedAt: "2026-04-10T00:15:00.000Z",
+          lastCommentBody: "body",
+          lastSyncStatus: "success",
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(results.map((result) => result.action), ["updated"]);
+  assert.equal(client.calls.some((args) => args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("--paginate")), false);
+});
+
+test("GitHubRunCommentGhPublisher falls back to comment scans when persisted comment id is stale", async () => {
+  const client = new FakeGitHubApiClient(async (args) => {
+    if (args[0] === "user") {
+      return { login: "specrail-bot" };
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/comments/9999") {
+      throw new Error("comment not found");
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("--paginate")) {
+      return [
+        {
+          id: 3001,
+          body: "<!-- specrail:run-summary track=track-30 run=run-1 status=running -->\nold\n",
+          user: { login: "specrail-bot" },
+        },
+      ];
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/comments/3001" && args.includes("PATCH")) {
+      return { id: 3001 };
+    }
+
+    throw new Error(`Unexpected request: ${args.join(" ")}`);
+  });
+
+  const publisher = new GitHubRunCommentGhPublisher({ apiClient: client });
+  const results = await publisher.publishRunSummary({
+    track: {
+      id: "track-30",
+      projectId: "project-default",
+      title: "Publish run summaries",
+      description: "",
+      status: "review",
+      specStatus: "approved",
+      planStatus: "approved",
+      priority: "high",
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-10T00:16:00.000Z",
+      githubIssue: { number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+    },
+    run: {
+      id: "run-1",
+      trackId: "track-30",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-1",
+      branchName: "specrail/run-1",
+      sessionRef: "session:run-1",
+      status: "completed",
+      createdAt: "2026-04-10T00:10:00.000Z",
+      startedAt: "2026-04-10T00:10:00.000Z",
+      finishedAt: "2026-04-10T00:15:00.000Z",
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Run completed",
+        lastEventAt: "2026-04-10T00:15:00.000Z",
+      },
+    },
+    events,
+    syncState: {
+      id: "track-30",
+      trackId: "track-30",
+      updatedAt: "2026-04-10T00:15:00.000Z",
+      comments: [
+        {
+          target: { kind: "issue", number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+          commentId: 9999,
+          lastRunId: "run-0",
+          lastRunStatus: "running",
+          lastPublishedAt: "2026-04-10T00:05:00.000Z",
+          lastCommentBody: "body",
+          lastSyncStatus: "success",
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(results.map((result) => result.action), ["updated"]);
+  assert.equal(client.calls.some((args) => args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("--paginate")), true);
+});

--- a/packages/adapters/src/__tests__/github-run-comment-publisher.test.ts
+++ b/packages/adapters/src/__tests__/github-run-comment-publisher.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Execution, ExecutionEvent, GitHubRunCommentPublishResult, Track } from "@specrail/core";
+
+import { GitHubRunCommentGhPublisher, parseGitHubTarget } from "../providers/github-run-comment-publisher.js";
+
+class FakeGitHubApiClient {
+  readonly calls: string[][] = [];
+
+  constructor(private readonly handler: (args: string[]) => unknown | Promise<unknown>) {}
+
+  async request<T>(args: string[]): Promise<T> {
+    this.calls.push(args);
+    return (await this.handler(args)) as T;
+  }
+}
+
+const events: ExecutionEvent[] = [
+  {
+    id: "run-1:start",
+    executionId: "run-1",
+    type: "task_status_changed",
+    timestamp: "2026-04-10T00:10:00.000Z",
+    source: "codex",
+    summary: "Run started",
+    payload: { status: "running" },
+  },
+  {
+    id: "run-1:done",
+    executionId: "run-1",
+    type: "task_status_changed",
+    timestamp: "2026-04-10T00:15:00.000Z",
+    source: "codex",
+    summary: "Run completed",
+    payload: { status: "completed" },
+  },
+];
+
+test("parseGitHubTarget extracts owner, repo, and number from issue and pull request URLs", () => {
+  assert.deepEqual(parseGitHubTarget({ kind: "issue", number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" }), {
+    owner: "yoophi-a",
+    repo: "specrail",
+    number: 30,
+  });
+  assert.deepEqual(parseGitHubTarget({ kind: "pull_request", number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" }), {
+    owner: "yoophi-a",
+    repo: "specrail",
+    number: 31,
+  });
+  assert.throws(
+    () => parseGitHubTarget({ kind: "issue", number: 1, url: "https://example.com/nope" }),
+    /Unsupported GitHub target URL/,
+  );
+});
+
+test("GitHubRunCommentGhPublisher creates issue and pull request comments for linked targets", async () => {
+  const client = new FakeGitHubApiClient(async (args) => {
+    if (args[0] === "user") {
+      return { login: "specrail-bot" };
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("--paginate")) {
+      return [];
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/31/comments" && args.includes("--paginate")) {
+      return [];
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("POST")) {
+      return { id: 3001 };
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/31/comments" && args.includes("POST")) {
+      return { id: 3101 };
+    }
+
+    throw new Error(`Unexpected request: ${args.join(" ")}`);
+  });
+
+  const publisher = new GitHubRunCommentGhPublisher({ apiClient: client });
+  const results = await publisher.publishRunSummary({
+    track: {
+      id: "track-30",
+      projectId: "project-default",
+      title: "Publish run summaries",
+      description: "",
+      status: "review",
+      specStatus: "approved",
+      planStatus: "approved",
+      priority: "high",
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-10T00:16:00.000Z",
+      githubIssue: { number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+      githubPullRequest: { number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" },
+    },
+    run: {
+      id: "run-1",
+      trackId: "track-30",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-1",
+      branchName: "specrail/run-1",
+      sessionRef: "session:run-1",
+      status: "completed",
+      createdAt: "2026-04-10T00:10:00.000Z",
+      startedAt: "2026-04-10T00:10:00.000Z",
+      finishedAt: "2026-04-10T00:15:00.000Z",
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Run completed",
+        lastEventAt: "2026-04-10T00:15:00.000Z",
+      },
+    },
+    events,
+  });
+
+  assert.deepEqual(
+    results.map((result) => ({ action: result.action, kind: result.target.kind, commentId: result.commentId })),
+    [
+      { action: "created", kind: "issue", commentId: 3001 },
+      { action: "created", kind: "pull_request", commentId: 3101 },
+    ],
+  );
+  assert.equal(client.calls.filter((args) => args[0] === "user").length, 1);
+});
+
+test("GitHubRunCommentGhPublisher updates existing marker-matched comments and noops when the body is unchanged", async () => {
+  let phase: "update" | "noop" = "update";
+  let updatedBody = "";
+  const existingBody = "<!-- specrail:run-summary track=track-30 run=run-1 status=running -->\nold\n";
+  const client: FakeGitHubApiClient = new FakeGitHubApiClient(async (args: string[]): Promise<unknown> => {
+    if (args[0] === "user") {
+      return { login: "specrail-bot" };
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/30/comments" && args.includes("--paginate")) {
+      if (phase === "update") {
+        return [{ id: 3001, body: existingBody, user: { login: "specrail-bot" } }];
+      }
+
+      return [{ id: 3001, body: updatedBody, user: { login: "specrail-bot" } }];
+    }
+
+    if (args[0] === "repos/yoophi-a/specrail/issues/comments/3001" && args.includes("PATCH")) {
+      return { id: 3001 };
+    }
+
+    throw new Error(`Unexpected request: ${args.join(" ")}`);
+  });
+
+  const publisher = new GitHubRunCommentGhPublisher({ apiClient: client });
+  const input: { track: Track; run: Execution; events: ExecutionEvent[] } = {
+    track: {
+      id: "track-30",
+      projectId: "project-default",
+      title: "Publish run summaries",
+      description: "",
+      status: "review",
+      specStatus: "approved",
+      planStatus: "approved",
+      priority: "high",
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-10T00:16:00.000Z",
+      githubIssue: { number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+    },
+    run: {
+      id: "run-1",
+      trackId: "track-30",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-1",
+      branchName: "specrail/run-1",
+      sessionRef: "session:run-1",
+      status: "completed" as const,
+      createdAt: "2026-04-10T00:10:00.000Z",
+      startedAt: "2026-04-10T00:10:00.000Z",
+      finishedAt: "2026-04-10T00:15:00.000Z",
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Run completed",
+        lastEventAt: "2026-04-10T00:15:00.000Z",
+      },
+    },
+    events,
+  };
+
+  const updateResults: GitHubRunCommentPublishResult[] = await publisher.publishRunSummary(input);
+  updatedBody = updateResults[0]?.body ?? "";
+  assert.deepEqual(updateResults.map((result: GitHubRunCommentPublishResult) => result.action), ["updated"]);
+
+  phase = "noop";
+  const noopResults: GitHubRunCommentPublishResult[] = await publisher.publishRunSummary(input);
+  assert.deepEqual(noopResults.map((result: GitHubRunCommentPublishResult) => result.action), ["noop"]);
+  assert.equal(
+    client.calls.filter((args: string[]) => args[0] === "repos/yoophi-a/specrail/issues/comments/3001" && args.includes("PATCH")).length,
+    1,
+  );
+});

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./interfaces/executor-adapter.js";
 export * from "./providers/codex-adapter.stub.js";
+export * from "./providers/github-run-comment-publisher.js";

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./interfaces/executor-adapter.js";
+export * from "./interfaces/openspec-adapter.js";
 export * from "./providers/codex-adapter.stub.js";
+export * from "./providers/file-openspec-adapter.js";
 export * from "./providers/github-run-comment-publisher.js";

--- a/packages/adapters/src/interfaces/openspec-adapter.ts
+++ b/packages/adapters/src/interfaces/openspec-adapter.ts
@@ -1,0 +1,62 @@
+import type { Track } from "@specrail/core";
+
+export interface OpenSpecTrackArtifacts {
+  spec: string;
+  plan: string;
+  tasks: string;
+}
+
+export interface OpenSpecTrackPackageMetadata {
+  version: 1;
+  format: "specrail.openspec.bundle";
+  exportedAt: string;
+  generatedBy: "specrail";
+}
+
+export interface OpenSpecTrackPackageFiles {
+  spec: string;
+  plan: string;
+  tasks: string;
+}
+
+export interface OpenSpecTrackPackage {
+  metadata: OpenSpecTrackPackageMetadata;
+  track: Track;
+  artifacts: OpenSpecTrackArtifacts;
+  files: OpenSpecTrackPackageFiles;
+}
+
+export interface OpenSpecImportSource {
+  kind: "file";
+  path: string;
+}
+
+export interface OpenSpecExportTarget {
+  kind: "file";
+  path: string;
+  overwrite?: boolean;
+}
+
+export interface OpenSpecImportInput {
+  source: OpenSpecImportSource;
+}
+
+export interface OpenSpecExportInput {
+  package: OpenSpecTrackPackage;
+  target: OpenSpecExportTarget;
+}
+
+export interface OpenSpecImportResult {
+  package: OpenSpecTrackPackage;
+}
+
+export interface OpenSpecExportResult {
+  package: OpenSpecTrackPackage;
+  target: OpenSpecExportTarget;
+}
+
+export interface OpenSpecAdapter {
+  readonly name: string;
+  importPackage(input: OpenSpecImportInput): Promise<OpenSpecImportResult>;
+  exportPackage(input: OpenSpecExportInput): Promise<OpenSpecExportResult>;
+}

--- a/packages/adapters/src/providers/file-openspec-adapter.ts
+++ b/packages/adapters/src/providers/file-openspec-adapter.ts
@@ -1,0 +1,144 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  OpenSpecAdapter,
+  OpenSpecExportInput,
+  OpenSpecExportResult,
+  OpenSpecImportInput,
+  OpenSpecImportResult,
+  OpenSpecTrackPackage,
+  OpenSpecTrackPackageFiles,
+} from "../interfaces/openspec-adapter.js";
+
+const MANIFEST_FILE_NAME = "openspec.json";
+
+interface FileOpenSpecAdapterOptions {
+  now?: () => string;
+}
+
+interface PersistedOpenSpecManifest {
+  metadata: OpenSpecTrackPackage["metadata"];
+  track: OpenSpecTrackPackage["track"];
+  files: OpenSpecTrackPackageFiles;
+}
+
+export class FileOpenSpecAdapter implements OpenSpecAdapter {
+  readonly name = "openspec-file";
+
+  private readonly now: () => string;
+
+  constructor(options: FileOpenSpecAdapterOptions = {}) {
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  async importPackage(input: OpenSpecImportInput): Promise<OpenSpecImportResult> {
+    if (input.source.kind !== "file") {
+      throw new Error(`Unsupported OpenSpec import source: ${String((input.source as { kind?: string }).kind)}`);
+    }
+
+    const rootDir = input.source.path;
+    const manifestPath = path.join(rootDir, MANIFEST_FILE_NAME);
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as PersistedOpenSpecManifest;
+    validateManifest(manifest);
+
+    const artifacts = {
+      spec: await readRequiredArtifact(rootDir, manifest.files.spec),
+      plan: await readRequiredArtifact(rootDir, manifest.files.plan),
+      tasks: await readRequiredArtifact(rootDir, manifest.files.tasks),
+    };
+
+    return {
+      package: {
+        metadata: manifest.metadata,
+        track: manifest.track,
+        files: manifest.files,
+        artifacts,
+      },
+    };
+  }
+
+  async exportPackage(input: OpenSpecExportInput): Promise<OpenSpecExportResult> {
+    if (input.target.kind !== "file") {
+      throw new Error(`Unsupported OpenSpec export target: ${String((input.target as { kind?: string }).kind)}`);
+    }
+
+    const rootDir = input.target.path;
+    const overwrite = input.target.overwrite ?? false;
+    const manifestPath = path.join(rootDir, MANIFEST_FILE_NAME);
+
+    if (!overwrite) {
+      await assertPathDoesNotExist(rootDir);
+    }
+
+    await mkdir(rootDir, { recursive: true });
+
+    const pkg: OpenSpecTrackPackage = {
+      ...input.package,
+      metadata: {
+        ...input.package.metadata,
+        exportedAt: this.now(),
+      },
+    };
+
+    const manifest: PersistedOpenSpecManifest = {
+      metadata: pkg.metadata,
+      track: pkg.track,
+      files: pkg.files,
+    };
+
+    await Promise.all([
+      writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8"),
+      writeArtifact(rootDir, pkg.files.spec, pkg.artifacts.spec),
+      writeArtifact(rootDir, pkg.files.plan, pkg.artifacts.plan),
+      writeArtifact(rootDir, pkg.files.tasks, pkg.artifacts.tasks),
+    ]);
+
+    return {
+      package: pkg,
+      target: input.target,
+    };
+  }
+}
+
+async function readRequiredArtifact(rootDir: string, relativePath: string): Promise<string> {
+  return readFile(path.join(rootDir, relativePath), "utf8");
+}
+
+async function writeArtifact(rootDir: string, relativePath: string, content: string): Promise<void> {
+  const targetPath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, "utf8");
+}
+
+async function assertPathDoesNotExist(targetPath: string): Promise<void> {
+  try {
+    await stat(targetPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  throw new Error(`OpenSpec export target already exists: ${targetPath}`);
+}
+
+function validateManifest(manifest: PersistedOpenSpecManifest): void {
+  if (manifest.metadata?.format !== "specrail.openspec.bundle") {
+    throw new Error("Invalid OpenSpec package manifest format");
+  }
+
+  if (manifest.metadata?.version !== 1) {
+    throw new Error("Unsupported OpenSpec package manifest version");
+  }
+
+  if (!manifest.track?.id) {
+    throw new Error("OpenSpec package manifest is missing track.id");
+  }
+
+  if (!manifest.files?.spec || !manifest.files.plan || !manifest.files.tasks) {
+    throw new Error("OpenSpec package manifest is missing artifact file mappings");
+  }
+}

--- a/packages/adapters/src/providers/github-run-comment-publisher.ts
+++ b/packages/adapters/src/providers/github-run-comment-publisher.ts
@@ -7,6 +7,7 @@ import {
   type ExecutionEvent,
   type GitHubRunCommentPublishResult,
   type GitHubRunCommentPublisher,
+  type GitHubRunCommentSyncState,
   type GitHubRunCommentTarget,
   type Track,
 } from "@specrail/core";
@@ -75,7 +76,12 @@ export class GitHubRunCommentGhPublisher implements GitHubRunCommentPublisher {
     this.apiClient = options.apiClient ?? new GhCliApiClient();
   }
 
-  async publishRunSummary(input: { track: Track; run: Execution; events: ExecutionEvent[] }): Promise<GitHubRunCommentPublishResult[]> {
+  async publishRunSummary(input: {
+    track: Track;
+    run: Execution;
+    events: ExecutionEvent[];
+    syncState?: GitHubRunCommentSyncState;
+  }): Promise<GitHubRunCommentPublishResult[]> {
     const body = formatGitHubRunCommentSummary({
       track: input.track,
       run: input.run,
@@ -87,7 +93,12 @@ export class GitHubRunCommentGhPublisher implements GitHubRunCommentPublisher {
 
     for (const target of this.listTargets(input.track)) {
       const { owner, repo, number } = parseGitHubTarget(target);
-      const existing = await this.findExistingComment({ owner, repo, number, markerKey, viewerLogin });
+      const syncRecord = input.syncState?.comments.find(
+        (comment) => comment.target.kind === target.kind && comment.target.url === target.url,
+      );
+      const existing =
+        (await this.findCommentById({ owner, repo, commentId: syncRecord?.commentId, markerKey, viewerLogin })) ??
+        (await this.findExistingComment({ owner, repo, number, markerKey, viewerLogin }));
 
       if (existing && (existing.body ?? "") === body) {
         results.push({ action: "noop", body, target, commentId: existing.id });
@@ -166,6 +177,36 @@ export class GitHubRunCommentGhPublisher implements GitHubRunCommentPublisher {
     return comments.find(
       (comment) => comment.user?.login === input.viewerLogin && typeof comment.body === "string" && comment.body.includes(input.markerKey),
     );
+  }
+
+  private async findCommentById(input: {
+    owner: string;
+    repo: string;
+    commentId: number | undefined;
+    markerKey: string;
+    viewerLogin: string;
+  }): Promise<GitHubCommentRecord | undefined> {
+    if (!input.commentId) {
+      return undefined;
+    }
+
+    try {
+      const comment = await this.apiClient.request<GitHubCommentRecord>([
+        `repos/${input.owner}/${input.repo}/issues/comments/${input.commentId}`,
+      ]);
+
+      if (
+        comment.user?.login === input.viewerLogin &&
+        typeof comment.body === "string" &&
+        comment.body.includes(input.markerKey)
+      ) {
+        return comment;
+      }
+
+      return undefined;
+    } catch {
+      return undefined;
+    }
   }
 }
 

--- a/packages/adapters/src/providers/github-run-comment-publisher.ts
+++ b/packages/adapters/src/providers/github-run-comment-publisher.ts
@@ -1,0 +1,172 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  formatGitHubRunCommentSummary,
+  type Execution,
+  type ExecutionEvent,
+  type GitHubRunCommentPublishResult,
+  type GitHubRunCommentPublisher,
+  type GitHubRunCommentTarget,
+  type Track,
+} from "@specrail/core";
+
+const execFileAsync = promisify(execFile);
+
+interface GitHubCommentRecord {
+  id: number;
+  body?: string;
+  user?: {
+    login?: string;
+  };
+}
+
+interface GitHubApiClient {
+  request<T>(args: string[]): Promise<T>;
+}
+
+class GhCliApiClient implements GitHubApiClient {
+  async request<T>(args: string[]): Promise<T> {
+    const { stdout } = await execFileAsync("gh", ["api", ...args], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+
+    return JSON.parse(stdout) as T;
+  }
+}
+
+export interface GitHubRunCommentPublisherOptions {
+  apiClient?: GitHubApiClient;
+}
+
+function parseGitHubTarget(target: GitHubRunCommentTarget): { owner: string; repo: string; number: number } {
+  const url = new URL(target.url);
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  if (url.hostname !== "github.com" || parts.length < 4) {
+    throw new Error(`Unsupported GitHub target URL: ${target.url}`);
+  }
+
+  const [owner, repo, resource, rawNumber] = parts;
+  const number = Number(rawNumber);
+
+  if ((resource !== "issues" && resource !== "pull") || !Number.isInteger(number) || number <= 0) {
+    throw new Error(`Unsupported GitHub target URL: ${target.url}`);
+  }
+
+  return { owner, repo, number };
+}
+
+function findCommentKey(body: string): string {
+  const match = body.match(/^<!-- specrail:run-summary track=(.+?) run=(.+?) status=.+?-->$/mu);
+  if (!match) {
+    throw new Error("GitHub run summary body is missing its marker");
+  }
+
+  return `<!-- specrail:run-summary track=${match[1]} run=${match[2]}`;
+}
+
+export class GitHubRunCommentGhPublisher implements GitHubRunCommentPublisher {
+  private readonly apiClient: GitHubApiClient;
+  private viewerLoginPromise: Promise<string> | null = null;
+
+  constructor(options: GitHubRunCommentPublisherOptions = {}) {
+    this.apiClient = options.apiClient ?? new GhCliApiClient();
+  }
+
+  async publishRunSummary(input: { track: Track; run: Execution; events: ExecutionEvent[] }): Promise<GitHubRunCommentPublishResult[]> {
+    const body = formatGitHubRunCommentSummary({
+      track: input.track,
+      run: input.run,
+      events: input.events,
+    });
+    const markerKey = findCommentKey(body);
+    const viewerLogin = await this.getViewerLogin();
+    const results: GitHubRunCommentPublishResult[] = [];
+
+    for (const target of this.listTargets(input.track)) {
+      const { owner, repo, number } = parseGitHubTarget(target);
+      const existing = await this.findExistingComment({ owner, repo, number, markerKey, viewerLogin });
+
+      if (existing && (existing.body ?? "") === body) {
+        results.push({ action: "noop", body, target, commentId: existing.id });
+        continue;
+      }
+
+      if (existing) {
+        const updated = await this.apiClient.request<GitHubCommentRecord>([
+          `repos/${owner}/${repo}/issues/comments/${existing.id}`,
+          "--method",
+          "PATCH",
+          "--field",
+          `body=${body}`,
+        ]);
+        results.push({ action: "updated", body, target, commentId: updated.id });
+        continue;
+      }
+
+      const created = await this.apiClient.request<GitHubCommentRecord>([
+        `repos/${owner}/${repo}/issues/${number}/comments`,
+        "--method",
+        "POST",
+        "--field",
+        `body=${body}`,
+      ]);
+      results.push({ action: "created", body, target, commentId: created.id });
+    }
+
+    return results;
+  }
+
+  private listTargets(track: Pick<Track, "githubIssue" | "githubPullRequest">): GitHubRunCommentTarget[] {
+    const targets: GitHubRunCommentTarget[] = [];
+
+    if (track.githubIssue) {
+      targets.push({ kind: "issue", number: track.githubIssue.number, url: track.githubIssue.url });
+    }
+
+    if (track.githubPullRequest) {
+      targets.push({ kind: "pull_request", number: track.githubPullRequest.number, url: track.githubPullRequest.url });
+    }
+
+    return targets.filter(
+      (target, index, all) => all.findIndex((candidate) => candidate.kind === target.kind && candidate.url === target.url) === index,
+    );
+  }
+
+  private async getViewerLogin(): Promise<string> {
+    if (!this.viewerLoginPromise) {
+      this.viewerLoginPromise = this.apiClient
+        .request<{ login: string }>(["user"])
+        .then((response) => {
+          if (!response.login) {
+            throw new Error("Unable to resolve authenticated GitHub user login");
+          }
+
+          return response.login;
+        });
+    }
+
+    return this.viewerLoginPromise;
+  }
+
+  private async findExistingComment(input: {
+    owner: string;
+    repo: string;
+    number: number;
+    markerKey: string;
+    viewerLogin: string;
+  }): Promise<GitHubCommentRecord | undefined> {
+    const comments = await this.apiClient.request<GitHubCommentRecord[]>([
+      `repos/${input.owner}/${input.repo}/issues/${input.number}/comments`,
+      "--paginate",
+    ]);
+
+    return comments.find(
+      (comment) => comment.user?.login === input.viewerLogin && typeof comment.body === "string" && comment.body.includes(input.markerKey),
+    );
+  }
+}
+
+export { parseGitHubTarget };

--- a/packages/config/src/__tests__/artifacts.test.ts
+++ b/packages/config/src/__tests__/artifacts.test.ts
@@ -31,6 +31,17 @@ test("materializeTrackArtifacts creates runtime and repo-visible .specrail files
     trackId: "track-api-bootstrap",
     trackTitle: "Track API bootstrap",
     trackDescription: "Create the first deterministic control-plane artifacts.",
+    openSpecImport: {
+      source: { kind: "file", path: "/tmp/specrail/bundles/bootstrap" },
+      importedAt: "2026-04-10T05:00:00.000Z",
+      conflictPolicy: "overwrite",
+      bundle: {
+        version: 1,
+        format: "specrail.openspec.bundle",
+        exportedAt: "2026-04-10T04:50:00.000Z",
+        generatedBy: "specrail",
+      },
+    },
     specContent: renderSpecDocument({
       title: "Track API bootstrap",
       problem: "The project needs deterministic track artifacts.",
@@ -73,6 +84,17 @@ test("materializeTrackArtifacts creates runtime and repo-visible .specrail files
     title: "Track API bootstrap",
     description: "Create the first deterministic control-plane artifacts.",
     artifactRoot: path.join("tracks", "track-api-bootstrap"),
+    openSpecImport: {
+      source: { kind: "file", path: "/tmp/specrail/bundles/bootstrap" },
+      importedAt: "2026-04-10T05:00:00.000Z",
+      conflictPolicy: "overwrite",
+      bundle: {
+        version: 1,
+        format: "specrail.openspec.bundle",
+        exportedAt: "2026-04-10T04:50:00.000Z",
+        generatedBy: "specrail",
+      },
+    },
   });
   assert.equal(eventsContent, "");
 

--- a/packages/config/src/artifacts.ts
+++ b/packages/config/src/artifacts.ts
@@ -40,12 +40,17 @@ export interface MaterializeTrackArtifactsInput {
   trackTitle: string;
   trackDescription: string;
   openSpecImport?: {
+    id?: string;
     source: {
       kind: "file";
       path: string;
     };
     importedAt: string;
-    conflictPolicy: "reject" | "overwrite";
+    conflictPolicy: "reject" | "overwrite" | "resolve";
+    resolution?: {
+      track?: Partial<Record<"title" | "description" | "status" | "specStatus" | "planStatus" | "priority" | "githubIssue" | "githubPullRequest", "incoming" | "existing">>;
+      artifacts?: Partial<Record<"spec" | "plan" | "tasks", "incoming" | "existing">>;
+    };
     bundle: {
       version: 1;
       format: "specrail.openspec.bundle";

--- a/packages/config/src/artifacts.ts
+++ b/packages/config/src/artifacts.ts
@@ -39,6 +39,20 @@ export interface MaterializeTrackArtifactsInput {
   projectName: string;
   trackTitle: string;
   trackDescription: string;
+  openSpecImport?: {
+    source: {
+      kind: "file";
+      path: string;
+    };
+    importedAt: string;
+    conflictPolicy: "reject" | "overwrite";
+    bundle: {
+      version: 1;
+      format: "specrail.openspec.bundle";
+      exportedAt: string;
+      generatedBy: "specrail";
+    };
+  };
   templateDir: string;
   specContent: string;
   planContent: string;
@@ -131,6 +145,7 @@ export async function materializeTrackArtifacts(input: MaterializeTrackArtifacts
     title: input.trackTitle,
     description: input.trackDescription,
     artifactRoot: path.relative(projectPaths.rootDir, trackPaths.trackDir),
+    ...(input.openSpecImport ? { openSpecImport: input.openSpecImport } : {}),
   };
 
   await Promise.all([

--- a/packages/config/src/artifacts.ts
+++ b/packages/config/src/artifacts.ts
@@ -58,6 +58,21 @@ export interface MaterializeTrackArtifactsInput {
       generatedBy: "specrail";
     };
   };
+  openSpecExport?: {
+    id?: string;
+    target: {
+      kind: "file";
+      path: string;
+      overwrite?: boolean;
+    };
+    exportedAt: string;
+    bundle: {
+      version: 1;
+      format: "specrail.openspec.bundle";
+      exportedAt: string;
+      generatedBy: "specrail";
+    };
+  };
   templateDir: string;
   specContent: string;
   planContent: string;
@@ -151,6 +166,7 @@ export async function materializeTrackArtifacts(input: MaterializeTrackArtifacts
     description: input.trackDescription,
     artifactRoot: path.relative(projectPaths.rootDir, trackPaths.trackDir),
     ...(input.openSpecImport ? { openSpecImport: input.openSpecImport } : {}),
+    ...(input.openSpecExport ? { openSpecExport: input.openSpecExport } : {}),
   };
 
   await Promise.all([

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,6 +4,7 @@ export interface SpecRailConfig {
   port: number;
   dataDir: string;
   repoArtifactDir: string;
+  githubPublishEnabled: boolean;
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): SpecRailConfig {
@@ -11,5 +12,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): SpecRailConfig
     port: Number(env.SPECRAIL_PORT ?? 4000),
     dataDir: env.SPECRAIL_DATA_DIR ?? ".specrail-data",
     repoArtifactDir: env.SPECRAIL_REPO_ARTIFACT_DIR ?? ".specrail",
+    githubPublishEnabled: env.SPECRAIL_GITHUB_PUBLISH === "1" || env.SPECRAIL_GITHUB_PUBLISH === "true",
   };
 }

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -23,6 +23,16 @@ export const APPROVAL_STATUSES = ["draft", "pending", "approved", "rejected"] as
 
 export type ApprovalStatus = "draft" | "pending" | "approved" | "rejected";
 
+export interface GitHubIssueReference {
+  number: number;
+  url: string;
+}
+
+export interface GitHubPullRequestReference {
+  number: number;
+  url: string;
+}
+
 export type ExecutionStatus =
   | "created"
   | "queued"
@@ -47,6 +57,8 @@ export interface Track {
   projectId: string;
   title: string;
   description: string;
+  githubIssue?: GitHubIssueReference;
+  githubPullRequest?: GitHubPullRequestReference;
   status: TrackStatus;
   specStatus: ApprovalStatus;
   planStatus: ApprovalStatus;

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -113,6 +113,48 @@ export interface OpenSpecImportResolutionGuide {
   presets: OpenSpecImportResolutionPreset[];
 }
 
+export interface OpenSpecImportOperatorChoiceSummary {
+  group: OpenSpecImportResolutionFieldGroup;
+  field: OpenSpecImportTrackResolutionField | OpenSpecImportArtifactResolutionField;
+  label: string;
+  choice: OpenSpecImportResolutionChoice;
+  sourceOfTruth: "openspec" | "specrail";
+  rationale: string;
+}
+
+export interface OpenSpecImportPresetSummary {
+  name: OpenSpecImportResolutionPresetName;
+  label: string;
+  description: string;
+  highlights: string[];
+  choices: OpenSpecImportOperatorChoiceSummary[];
+}
+
+export interface OpenSpecImportOperatorExample {
+  id: "reject-preview" | "overwrite-apply" | "policy-defaults-resolve" | "preset-with-override";
+  label: string;
+  description: string;
+  request: {
+    dryRun?: boolean;
+    conflictPolicy?: OpenSpecImportConflictPolicy;
+    resolutionPreset?: OpenSpecImportResolutionPresetName;
+    resolution?: OpenSpecImportResolution;
+  };
+  explanation: string[];
+}
+
+export interface OpenSpecImportOperatorGuide {
+  recommendedFlow: string[];
+  conflictPolicies: Array<{
+    name: OpenSpecImportConflictPolicy;
+    label: string;
+    description: string;
+  }>;
+  selectedPreset: OpenSpecImportPresetSummary | null;
+  effectiveChoices: OpenSpecImportOperatorChoiceSummary[];
+  examples: OpenSpecImportOperatorExample[];
+}
+
 export interface OpenSpecImportRecord {
   id: string;
   source: {

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -173,6 +173,22 @@ export interface OpenSpecImportRecord {
   };
 }
 
+export interface OpenSpecExportRecord {
+  id: string;
+  target: {
+    kind: "file";
+    path: string;
+    overwrite?: boolean;
+  };
+  exportedAt: string;
+  bundle: {
+    version: 1;
+    format: "specrail.openspec.bundle";
+    exportedAt: string;
+    generatedBy: "specrail";
+  };
+}
+
 export interface GitHubIntegrationSummary {
   linkedTargetCount: number;
   syncedTargetCount: number;
@@ -186,6 +202,8 @@ export interface TrackIntegrationsInspection {
   openSpec: {
     latestImport: OpenSpecImportRecord | null;
     importHistory: OpenSpecImportRecord[];
+    latestExport: OpenSpecExportRecord | null;
+    exportHistory: OpenSpecExportRecord[];
   };
   github: {
     issue?: GitHubIssueReference;
@@ -233,6 +251,8 @@ export interface Track {
   priority: "low" | "medium" | "high";
   openSpecImport?: OpenSpecImportRecord;
   openSpecImportHistory?: OpenSpecImportRecord[];
+  openSpecExport?: OpenSpecExportRecord;
+  openSpecExportHistory?: OpenSpecExportRecord[];
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -33,6 +33,30 @@ export interface GitHubPullRequestReference {
   url: string;
 }
 
+export interface GitHubRunCommentSyncTarget {
+  kind: "issue" | "pull_request";
+  number: number;
+  url: string;
+}
+
+export interface GitHubRunCommentSyncRecord {
+  target: GitHubRunCommentSyncTarget;
+  commentId?: number;
+  lastRunId: string;
+  lastRunStatus: ExecutionStatus;
+  lastPublishedAt: string;
+  lastCommentBody?: string;
+  lastSyncStatus: "success" | "failed";
+  lastSyncError?: string;
+}
+
+export interface GitHubRunCommentSyncState {
+  id: string;
+  trackId: string;
+  updatedAt: string;
+  comments: GitHubRunCommentSyncRecord[];
+}
+
 export type ExecutionStatus =
   | "created"
   | "queued"

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -116,6 +116,20 @@ export interface Track {
   specStatus: ApprovalStatus;
   planStatus: ApprovalStatus;
   priority: "low" | "medium" | "high";
+  openSpecImport?: {
+    source: {
+      kind: "file";
+      path: string;
+    };
+    importedAt: string;
+    conflictPolicy: "reject" | "overwrite";
+    bundle: {
+      version: 1;
+      format: "specrail.openspec.bundle";
+      exportedAt: string;
+      generatedBy: "specrail";
+    };
+  };
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -66,9 +66,51 @@ export type OpenSpecImportConflictPolicy = "reject" | "overwrite" | "resolve";
 
 export type OpenSpecImportResolutionChoice = "incoming" | "existing";
 
+export type OpenSpecImportResolutionFieldGroup = "track" | "artifacts";
+
+export type OpenSpecImportTrackResolutionField =
+  | "title"
+  | "description"
+  | "status"
+  | "specStatus"
+  | "planStatus"
+  | "priority"
+  | "githubIssue"
+  | "githubPullRequest";
+
+export type OpenSpecImportArtifactResolutionField = "spec" | "plan" | "tasks";
+
+export type OpenSpecImportResolutionPresetName =
+  | "policyDefaults"
+  | "preferIncomingArtifacts"
+  | "preserveWorkflowState"
+  | "preferIncomingAll";
+
 export interface OpenSpecImportResolution {
-  track?: Partial<Record<"title" | "description" | "status" | "specStatus" | "planStatus" | "priority" | "githubIssue" | "githubPullRequest", OpenSpecImportResolutionChoice>>;
-  artifacts?: Partial<Record<"spec" | "plan" | "tasks", OpenSpecImportResolutionChoice>>;
+  track?: Partial<Record<OpenSpecImportTrackResolutionField, OpenSpecImportResolutionChoice>>;
+  artifacts?: Partial<Record<OpenSpecImportArtifactResolutionField, OpenSpecImportResolutionChoice>>;
+}
+
+export interface OpenSpecSourceOfTruthPolicy {
+  group: OpenSpecImportResolutionFieldGroup;
+  field: OpenSpecImportTrackResolutionField | OpenSpecImportArtifactResolutionField;
+  sourceOfTruth: "openspec" | "specrail";
+  defaultChoice: OpenSpecImportResolutionChoice;
+  rationale: string;
+}
+
+export interface OpenSpecImportResolutionPreset {
+  name: OpenSpecImportResolutionPresetName;
+  label: string;
+  description: string;
+  resolution: OpenSpecImportResolution;
+}
+
+export interface OpenSpecImportResolutionGuide {
+  presetApplied: OpenSpecImportResolutionPresetName | null;
+  effectiveResolution: OpenSpecImportResolution;
+  policies: OpenSpecSourceOfTruthPolicy[];
+  presets: OpenSpecImportResolutionPreset[];
 }
 
 export interface OpenSpecImportRecord {
@@ -79,6 +121,7 @@ export interface OpenSpecImportRecord {
   };
   importedAt: string;
   conflictPolicy: OpenSpecImportConflictPolicy;
+  resolutionPreset?: OpenSpecImportResolutionPresetName;
   resolution?: OpenSpecImportResolution;
   bundle: {
     version: 1;

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -62,6 +62,32 @@ export interface TrackInspection {
   githubRunCommentSync: GitHubRunCommentSyncState | null;
 }
 
+export type OpenSpecImportConflictPolicy = "reject" | "overwrite" | "resolve";
+
+export type OpenSpecImportResolutionChoice = "incoming" | "existing";
+
+export interface OpenSpecImportResolution {
+  track?: Partial<Record<"title" | "description" | "status" | "specStatus" | "planStatus" | "priority" | "githubIssue" | "githubPullRequest", OpenSpecImportResolutionChoice>>;
+  artifacts?: Partial<Record<"spec" | "plan" | "tasks", OpenSpecImportResolutionChoice>>;
+}
+
+export interface OpenSpecImportRecord {
+  id: string;
+  source: {
+    kind: "file";
+    path: string;
+  };
+  importedAt: string;
+  conflictPolicy: OpenSpecImportConflictPolicy;
+  resolution?: OpenSpecImportResolution;
+  bundle: {
+    version: 1;
+    format: "specrail.openspec.bundle";
+    exportedAt: string;
+    generatedBy: "specrail";
+  };
+}
+
 export interface GitHubIntegrationSummary {
   linkedTargetCount: number;
   syncedTargetCount: number;
@@ -72,6 +98,10 @@ export interface GitHubIntegrationSummary {
 
 export interface TrackIntegrationsInspection {
   trackId: string;
+  openSpec: {
+    latestImport: OpenSpecImportRecord | null;
+    importHistory: OpenSpecImportRecord[];
+  };
   github: {
     issue?: GitHubIssueReference;
     pullRequest?: GitHubPullRequestReference;
@@ -116,20 +146,8 @@ export interface Track {
   specStatus: ApprovalStatus;
   planStatus: ApprovalStatus;
   priority: "low" | "medium" | "high";
-  openSpecImport?: {
-    source: {
-      kind: "file";
-      path: string;
-    };
-    importedAt: string;
-    conflictPolicy: "reject" | "overwrite";
-    bundle: {
-      version: 1;
-      format: "specrail.openspec.bundle";
-      exportedAt: string;
-      generatedBy: "specrail";
-    };
-  };
+  openSpecImport?: OpenSpecImportRecord;
+  openSpecImportHistory?: OpenSpecImportRecord[];
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -62,6 +62,24 @@ export interface TrackInspection {
   githubRunCommentSync: GitHubRunCommentSyncState | null;
 }
 
+export interface GitHubIntegrationSummary {
+  linkedTargetCount: number;
+  syncedTargetCount: number;
+  lastPublishedAt?: string;
+  lastSyncStatus?: "success" | "failed" | "mixed";
+  lastSyncError?: string;
+}
+
+export interface TrackIntegrationsInspection {
+  trackId: string;
+  github: {
+    issue?: GitHubIssueReference;
+    pullRequest?: GitHubPullRequestReference;
+    runCommentSync: GitHubRunCommentSyncState | null;
+    summary: GitHubIntegrationSummary;
+  };
+}
+
 export interface RunInspection {
   run: Execution;
   githubRunCommentSync: GitHubRunCommentSyncState | null;

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -57,6 +57,17 @@ export interface GitHubRunCommentSyncState {
   comments: GitHubRunCommentSyncRecord[];
 }
 
+export interface TrackInspection {
+  track: Track;
+  githubRunCommentSync: GitHubRunCommentSyncState | null;
+}
+
+export interface RunInspection {
+  run: Execution;
+  githubRunCommentSync: GitHubRunCommentSyncState | null;
+  githubRunCommentSyncForRun: GitHubRunCommentSyncRecord[];
+}
+
 export type ExecutionStatus =
   | "created"
   | "queued"

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -7,6 +7,13 @@ export class SpecRailError extends Error {
 
 export class NotFoundError extends SpecRailError {}
 
-export class ConflictError extends SpecRailError {}
+export class ConflictError extends SpecRailError {
+  constructor(
+    message: string,
+    readonly details?: Array<Record<string, unknown>>,
+  ) {
+    super(message);
+  }
+}
 
 export class ValidationError extends SpecRailError {}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,5 +2,6 @@ export * from "./domain/artifacts.js";
 export * from "./domain/types.js";
 export * from "./errors.js";
 export * from "./services/file-repositories.js";
+export * from "./services/github-comment-summary.js";
 export * from "./services/ports.js";
 export * from "./services/specrail-service.js";

--- a/packages/core/src/services/__tests__/file-repositories.test.ts
+++ b/packages/core/src/services/__tests__/file-repositories.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import type { Execution, ExecutionEvent, Project, Track } from "../../domain/types.js";
 import {
+  FileGitHubRunCommentSyncStore,
   FileExecutionRepository,
   FileProjectRepository,
   FileTrackRepository,
@@ -122,4 +123,44 @@ test("jsonl event store appends and lists events in order", async () => {
 
   assert.deepEqual(await eventStore.listByExecution("execution-1"), events);
   assert.deepEqual(await eventStore.listByExecution("missing-execution"), []);
+});
+
+test("github run comment sync store persists comment metadata by track id", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-github-sync-"));
+  const syncStore = new FileGitHubRunCommentSyncStore(rootDir);
+
+  await syncStore.upsert({
+    id: "track-1",
+    trackId: "track-1",
+    updatedAt: "2026-04-10T00:20:00.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+        commentId: 3101,
+        lastRunId: "run-1",
+        lastRunStatus: "completed",
+        lastPublishedAt: "2026-04-10T00:20:00.000Z",
+        lastCommentBody: "summary",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+
+  assert.deepEqual(await syncStore.getByTrackId("track-1"), {
+    id: "track-1",
+    trackId: "track-1",
+    updatedAt: "2026-04-10T00:20:00.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+        commentId: 3101,
+        lastRunId: "run-1",
+        lastRunStatus: "completed",
+        lastPublishedAt: "2026-04-10T00:20:00.000Z",
+        lastCommentBody: "summary",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+  assert.equal(await syncStore.getByTrackId("missing-track"), null);
 });

--- a/packages/core/src/services/__tests__/file-repositories.test.ts
+++ b/packages/core/src/services/__tests__/file-repositories.test.ts
@@ -34,6 +34,8 @@ test("file repositories persist and reload project/track/execution state", async
     projectId: project.id,
     title: "Persist run state",
     description: "Add file-backed repositories.",
+    githubIssue: { number: 28, url: "https://github.com/yoophi-a/specrail/issues/28" },
+    githubPullRequest: { number: 29, url: "https://github.com/yoophi-a/specrail/pull/29" },
     status: "planned",
     specStatus: "approved",
     planStatus: "approved",

--- a/packages/core/src/services/__tests__/github-comment-summary.test.ts
+++ b/packages/core/src/services/__tests__/github-comment-summary.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatGitHubRunCommentSummary } from "../github-comment-summary.js";
+
+const baseTrack = {
+  id: "track-track-29",
+  title: "Publish execution summaries back to GitHub",
+  status: "review" as const,
+  githubIssue: { number: 29, url: "https://github.com/yoophi-a/specrail/issues/29" },
+  githubPullRequest: { number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" },
+};
+
+test("formatGitHubRunCommentSummary renders a completed run for GitHub comments", () => {
+  const comment = formatGitHubRunCommentSummary({
+    track: baseTrack,
+    run: {
+      id: "run-run-29",
+      status: "completed",
+      backend: "codex",
+      profile: "default",
+      branchName: "feat/run-comment-summary",
+      workspacePath: "/tmp/specrail/run-run-29",
+      sessionRef: "session:run-run-29",
+      startedAt: "2026-04-10T00:00:00.000Z",
+      finishedAt: "2026-04-10T00:15:00.000Z",
+      summary: {
+        eventCount: 4,
+        lastEventSummary: "Run completed",
+        lastEventAt: "2026-04-10T00:15:00.000Z",
+      },
+    },
+    events: [
+      {
+        timestamp: "2026-04-10T00:00:00.000Z",
+        type: "task_status_changed",
+        summary: "Run started",
+      },
+      {
+        timestamp: "2026-04-10T00:01:00.000Z",
+        type: "shell_command",
+        summary: "Prepared Codex command",
+      },
+      {
+        timestamp: "2026-04-10T00:14:00.000Z",
+        type: "test_result",
+        summary: "Verification passed",
+      },
+      {
+        timestamp: "2026-04-10T00:15:00.000Z",
+        type: "task_status_changed",
+        summary: "Run completed",
+      },
+    ],
+  });
+
+  assert.match(comment, /<!-- specrail:run-summary track=track-track-29 run=run-run-29 status=completed -->/);
+  assert.match(comment, /\*\*Outcome:\*\* ✅ Completed/);
+  assert.match(comment, /- Issue: \[#29\]\(https:\/\/github.com\/yoophi-a\/specrail\/issues\/29\)/);
+  assert.match(comment, /- Pull request: \[#31\]\(https:\/\/github.com\/yoophi-a\/specrail\/pull\/31\)/);
+  assert.match(comment, /- Branch: `feat\/run-comment-summary`/);
+  assert.match(comment, /- Events: 4/);
+  assert.match(comment, /- 2026-04-10T00:14:00.000Z · \*\*test_result\*\* · Verification passed/);
+  assert.match(comment, /- 2026-04-10T00:15:00.000Z · \*\*task_status_changed\*\* · Run completed/);
+});
+
+test("formatGitHubRunCommentSummary renders a waiting approval run with blocker note", () => {
+  const comment = formatGitHubRunCommentSummary({
+    track: {
+      ...baseTrack,
+      githubPullRequest: undefined,
+    },
+    run: {
+      id: "run-approval",
+      status: "waiting_approval",
+      backend: "codex",
+      profile: "review",
+      branchName: "feat/approval-gate",
+      workspacePath: "/tmp/specrail/run-approval",
+      sessionRef: "session:run-approval",
+      startedAt: "2026-04-10T01:00:00.000Z",
+      finishedAt: undefined,
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Approval requested",
+        lastEventAt: "2026-04-10T01:05:00.000Z",
+      },
+    },
+    events: [
+      {
+        timestamp: "2026-04-10T01:00:00.000Z",
+        type: "task_status_changed",
+        summary: "Run started",
+      },
+      {
+        timestamp: "2026-04-10T01:05:00.000Z",
+        type: "approval_requested",
+        summary: "Approval requested",
+      },
+    ],
+  });
+
+  assert.match(comment, /\*\*Outcome:\*\* ⏸️ Waiting for approval/);
+  assert.match(comment, /- Pull request: none linked/i);
+  assert.match(comment, /> Approval is currently blocking this run\./);
+});
+
+test("formatGitHubRunCommentSummary renders failed and cancelled terminal states deterministically", () => {
+  const failedComment = formatGitHubRunCommentSummary({
+    track: baseTrack,
+    run: {
+      id: "run-failed",
+      status: "failed",
+      backend: "codex",
+      profile: "default",
+      branchName: "feat/failure",
+      workspacePath: "/tmp/specrail/run-failed",
+      sessionRef: "session:run-failed",
+      startedAt: "2026-04-10T02:00:00.000Z",
+      finishedAt: "2026-04-10T02:03:00.000Z",
+      summary: {
+        eventCount: 3,
+        lastEventSummary: "Failed Codex session session:run-failed",
+        lastEventAt: "2026-04-10T02:03:00.000Z",
+      },
+    },
+    events: [
+      {
+        timestamp: "2026-04-10T02:00:00.000Z",
+        type: "task_status_changed",
+        summary: "Run started",
+      },
+      {
+        timestamp: "2026-04-10T02:02:00.000Z",
+        type: "message",
+        summary: "STDERR session:run-failed",
+      },
+      {
+        timestamp: "2026-04-10T02:03:00.000Z",
+        type: "task_status_changed",
+        summary: "Failed Codex session session:run-failed",
+      },
+    ],
+  });
+
+  const cancelledComment = formatGitHubRunCommentSummary({
+    track: baseTrack,
+    run: {
+      id: "run-cancelled",
+      status: "cancelled",
+      backend: "codex",
+      profile: "default",
+      branchName: "feat/cancelled",
+      workspacePath: "/tmp/specrail/run-cancelled",
+      sessionRef: "session:run-cancelled",
+      startedAt: "2026-04-10T03:00:00.000Z",
+      finishedAt: "2026-04-10T03:01:00.000Z",
+      summary: {
+        eventCount: 2,
+        lastEventSummary: "Run cancelled",
+        lastEventAt: "2026-04-10T03:01:00.000Z",
+      },
+    },
+    events: [
+      {
+        timestamp: "2026-04-10T03:00:00.000Z",
+        type: "task_status_changed",
+        summary: "Run started",
+      },
+      {
+        timestamp: "2026-04-10T03:01:00.000Z",
+        type: "task_status_changed",
+        summary: "Run cancelled",
+      },
+    ],
+    options: {
+      maxHighlights: 1,
+    },
+  });
+
+  assert.match(failedComment, /\*\*Outcome:\*\* ❌ Failed/);
+  assert.match(failedComment, /Failed Codex session session:run-failed/);
+  assert.match(cancelledComment, /\*\*Outcome:\*\* 🛑 Cancelled/);
+  assert.doesNotMatch(cancelledComment, /Run started/);
+  assert.match(cancelledComment, /Run cancelled/);
+});

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -126,10 +126,12 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
     title: "Build executor MVP",
     description: "Create enough state and artifacts to start a run.",
     priority: "high",
+    githubIssue: { number: 28, url: "https://github.com/yoophi-a/specrail/issues/28" },
   });
 
   assert.equal(track.id, "track-track-a");
   assert.equal(track.projectId, "project-default");
+  assert.deepEqual(track.githubIssue, { number: 28, url: "https://github.com/yoophi-a/specrail/issues/28" });
 
   const specContent = await readFile(path.join(artifactRoot, track.id, "spec.md"), "utf8");
   assert.match(specContent, /# Spec — Build executor MVP/);
@@ -502,11 +504,15 @@ test("SpecRailService updates track workflow and approval state", async () => {
     status: "review",
     specStatus: "approved",
     planStatus: "pending",
+    githubIssue: { number: 28, url: "https://github.com/yoophi-a/specrail/issues/28" },
+    githubPullRequest: { number: 30, url: "https://github.com/yoophi-a/specrail/pull/30" },
   });
 
   assert.equal(updated.status, "review");
   assert.equal(updated.specStatus, "approved");
   assert.equal(updated.planStatus, "pending");
+  assert.deepEqual(updated.githubIssue, { number: 28, url: "https://github.com/yoophi-a/specrail/issues/28" });
+  assert.deepEqual(updated.githubPullRequest, { number: 30, url: "https://github.com/yoophi-a/specrail/pull/30" });
   assert.equal(updated.updatedAt, "2026-04-09T04:05:00.000Z");
 
   const persisted = await service.getTrack(track.id);

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1691,8 +1691,10 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
 
   const created = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
+    conflictPolicy: "overwrite",
   });
   assert.equal(created.action, "created");
+  assert.equal(created.applied, true);
   assert.equal(created.track.id, importedTrack.id);
   assert.equal(created.track.projectId, importedTrack.projectId);
   assert.equal(created.track.title, "Imported track");
@@ -1701,8 +1703,10 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
 
   const updated = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
+    conflictPolicy: "overwrite",
   });
   assert.equal(updated.action, "updated");
+  assert.equal(updated.applied, true);
   assert.equal(updated.track.createdAt, "2026-04-09T00:00:00.000Z");
   assert.equal(updated.track.updatedAt, "2026-04-10T04:10:00.000Z");
 
@@ -1720,4 +1724,112 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
       tasks: "# Imported tasks",
     },
   ]);
+});
+
+test("SpecRailService previews OpenSpec imports and rejects collisions unless overwrite is explicit", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-import-preview-"));
+  const writes: Array<{ trackId: string; spec: string; plan: string; tasks: string }> = [];
+  const importedTrack = {
+    id: "track-openspec-preview",
+    projectId: "project-foreign",
+    title: "Imported preview",
+    description: "Imported preview description",
+    status: "ready" as const,
+    specStatus: "approved" as const,
+    planStatus: "pending" as const,
+    priority: "medium" as const,
+    githubIssue: null,
+    githubPullRequest: null,
+    createdAt: "2026-04-09T00:00:00.000Z",
+    updatedAt: "2026-04-09T00:00:00.000Z",
+  };
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: {
+      async write(input) {
+        writes.push({
+          trackId: input.track.id,
+          spec: input.specContent,
+          plan: input.planContent,
+          tasks: input.tasksContent,
+        });
+      },
+    },
+    executor: {
+      name: "codex",
+      async spawn() { throw new Error("should not be called"); },
+      async resume() { throw new Error("should not be called"); },
+      async cancel() { throw new Error("should not be called"); },
+    },
+    openSpecAdapter: {
+      name: "openspec-file",
+      async importPackage() {
+        return {
+          package: {
+            metadata: {
+              version: 1,
+              format: "specrail.openspec.bundle",
+              exportedAt: "2026-04-10T04:00:00.000Z",
+              generatedBy: "specrail",
+            },
+            track: importedTrack,
+            artifacts: {
+              spec: "# Preview spec",
+              plan: "# Preview plan",
+              tasks: "# Preview tasks",
+            },
+            files: {
+              spec: "spec.md",
+              plan: "plan.md",
+              tasks: "tasks.md",
+            },
+          },
+        };
+      },
+      async exportPackage() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: () => "2026-04-10T04:00:00.000Z",
+  });
+
+  const preview = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+    dryRun: true,
+  });
+  assert.equal(preview.action, "created");
+  assert.equal(preview.applied, false);
+  assert.equal(preview.conflict.hasConflict, false);
+
+  await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+    conflictPolicy: "overwrite",
+  });
+
+  await assert.rejects(
+    () =>
+      service.importTrackFromOpenSpec({
+        source: { kind: "file", path: path.join(rootDir, "bundle") },
+      }),
+    /Retry with conflictPolicy=overwrite or dryRun=true/,
+  );
+
+  const collisionPreview = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+    dryRun: true,
+  });
+  assert.equal(collisionPreview.action, "updated");
+  assert.equal(collisionPreview.applied, false);
+  assert.equal(collisionPreview.conflict.hasConflict, true);
+  assert.equal(collisionPreview.conflict.reason, "track_id_exists");
+  assert.equal(writes.length, 1);
 });

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1222,6 +1222,10 @@ test("SpecRailService exposes empty GitHub integration inspection summaries with
 
   assert.deepEqual(await service.getTrackIntegrationsInspection(track.id), {
     trackId: track.id,
+    openSpec: {
+      latestImport: null,
+      importHistory: [],
+    },
     github: {
       issue: { number: 33, url: "https://github.com/yoophi-a/specrail/issues/33" },
       pullRequest: { number: 34, url: "https://github.com/yoophi-a/specrail/pull/34" },
@@ -1699,6 +1703,10 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
       name: "SpecRail",
     },
     workspaceRoot: path.join(rootDir, "workspaces"),
+    idGenerator: (() => {
+      const values = ["import-1", "import-2"];
+      return () => values.shift() ?? "import-tail";
+    })(),
     now: (() => {
       const values = ["2026-04-10T04:00:00.000Z", "2026-04-10T04:05:00.000Z", "2026-04-10T04:10:00.000Z"];
       return () => values.shift() ?? "2026-04-10T04:10:00.000Z";
@@ -1717,6 +1725,7 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
   assert.equal(created.track.description, "Imported description");
   assert.equal(created.track.updatedAt, "2026-04-10T04:05:00.000Z");
   assert.deepEqual(created.provenance, {
+    id: "openspec-import-import-1",
     source: { kind: "file", path: path.join(rootDir, "bundle") },
     importedAt: "2026-04-10T04:05:00.000Z",
     conflictPolicy: "overwrite",
@@ -1727,6 +1736,8 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
       generatedBy: "specrail",
     },
   });
+  assert.equal(created.importHistory.length, 1);
+  assert.equal(created.resolvedArtifacts.spec, "# Imported spec");
 
   const updated = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
@@ -1738,6 +1749,7 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
   assert.equal(updated.track.updatedAt, "2026-04-10T04:10:00.000Z");
   assert.equal(updated.conflict.details[0]?.field, "track.id");
   assert.equal(updated.track.openSpecImport?.source.path, path.join(rootDir, "bundle"));
+  assert.equal(updated.importHistory.length, 2);
 
   assert.deepEqual(writes, [
     {
@@ -1882,4 +1894,127 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
   assert.ok(collisionPreview.conflict.details.some((detail) => detail.field === "artifacts.spec"));
   assert.equal(collisionPreview.provenance.source.path, path.join(rootDir, "bundle"));
   assert.equal(writes.length, 1);
+});
+
+test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing choices and lists import history", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-resolve-"));
+  const existingArtifacts = new Map<string, { spec: string; plan: string; tasks: string }>();
+  const importedPackage = {
+    metadata: {
+      version: 1 as const,
+      format: "specrail.openspec.bundle" as const,
+      exportedAt: "2026-04-10T06:00:00.000Z",
+      generatedBy: "specrail" as const,
+    },
+    track: {
+      id: "track-placeholder",
+      projectId: "project-foreign",
+      title: "Incoming title",
+      description: "Incoming description",
+      status: "ready" as const,
+      specStatus: "approved" as const,
+      planStatus: "approved" as const,
+      priority: "high" as const,
+      githubIssue: { number: 39, url: "https://github.com/yoophi-a/specrail/issues/39" },
+      createdAt: "2026-04-09T00:00:00.000Z",
+      updatedAt: "2026-04-09T00:00:00.000Z",
+    },
+    artifacts: {
+      spec: "# Incoming spec\n",
+      plan: "# Incoming plan\n",
+      tasks: "# Incoming tasks\n",
+    },
+    files: {
+      spec: "spec.md",
+      plan: "plan.md",
+      tasks: "tasks.md",
+    },
+  };
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: {
+      async write(input) {
+        existingArtifacts.set(input.track.id, {
+          spec: input.specContent,
+          plan: input.planContent,
+          tasks: input.tasksContent,
+        });
+      },
+    },
+    artifactReader: {
+      async read(trackId) {
+        const artifacts = existingArtifacts.get(trackId);
+        if (!artifacts) {
+          throw new Error(`missing artifacts for ${trackId}`);
+        }
+
+        return artifacts;
+      },
+    },
+    executor: {
+      name: "codex",
+      async spawn() { throw new Error("should not be called"); },
+      async resume() { throw new Error("should not be called"); },
+      async cancel() { throw new Error("should not be called"); },
+    },
+    openSpecAdapter: {
+      name: "openspec-file",
+      async importPackage() {
+        return { package: importedPackage };
+      },
+      async exportPackage() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    idGenerator: () => "resolve-1",
+    now: () => "2026-04-10T06:05:00.000Z",
+  });
+
+  const created = await service.createTrack({ title: "Existing title", description: "Existing description" });
+  existingArtifacts.set(created.id, {
+    spec: "# Existing spec\n",
+    plan: "# Existing plan\n",
+    tasks: "# Existing tasks\n",
+  });
+  await service.updateTrack({ trackId: created.id, status: "planned" });
+  importedPackage.track.id = created.id;
+
+  const result = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+    conflictPolicy: "resolve",
+    resolution: {
+      track: { title: "existing" },
+      artifacts: { spec: "existing", plan: "incoming", tasks: "existing" },
+    },
+  });
+
+  assert.equal(result.track.title, "Existing title");
+  assert.equal(result.track.description, "Incoming description");
+  assert.equal(result.track.status, "ready");
+  assert.equal(result.resolvedArtifacts.spec, "# Existing spec\n");
+  assert.equal(result.resolvedArtifacts.plan, "# Incoming plan\n");
+  assert.equal(result.resolvedArtifacts.tasks, "# Existing tasks\n");
+  assert.equal(result.provenance.conflictPolicy, "resolve");
+  assert.deepEqual(result.provenance.resolution, {
+    track: { title: "existing" },
+    artifacts: { spec: "existing", plan: "incoming", tasks: "existing" },
+  });
+
+  const importInspection = await service.getTrackOpenSpecImports(created.id);
+  assert.ok(importInspection);
+  assert.equal(importInspection.latestImport?.conflictPolicy, "resolve");
+  assert.equal(importInspection.importHistory.length, 1);
+
+  const adminHistory = await service.listOpenSpecImportHistory();
+  assert.equal(adminHistory.length, 1);
+  assert.equal(adminHistory[0]?.trackId, created.id);
 });

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1328,6 +1328,126 @@ test("SpecRailService persists GitHub run comment sync metadata and passes it ba
   });
 });
 
+test("SpecRailService retries failed GitHub run comment syncs using the latest failed run", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-retry-sync-"));
+  const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));
+  const publishCalls: Array<{ runId: string; syncCommentId?: number }> = [];
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    githubRunCommentSyncStore: syncStore,
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary(input) {
+        publishCalls.push({
+          runId: input.run.id,
+          syncCommentId: input.syncState?.comments[0]?.commentId,
+        });
+        return [
+          {
+            action: "updated",
+            target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+            body: `summary:${input.run.status}`,
+            commentId: 3401,
+          },
+        ];
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = [
+        "2026-04-10T02:00:00.000Z",
+        "2026-04-10T02:00:01.000Z",
+        "2026-04-10T02:00:02.000Z",
+        "2026-04-10T02:00:03.000Z",
+      ];
+      return () => values.shift() ?? "2026-04-10T02:00:03.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-retry", "run-retry-old", "run-retry-new"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Retry sync failures",
+    description: "Reuse the publish flow for failed GitHub syncs.",
+    githubIssue: { number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+  });
+
+  const olderRun = await service.startRun({ trackId: track.id, prompt: "older run" });
+  const newerRun = await service.startRun({ trackId: track.id, prompt: "newer run" });
+
+  await syncStore.upsert({
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T02:00:02.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+        commentId: 3401,
+        lastRunId: newerRun.id,
+        lastRunStatus: newerRun.status,
+        lastPublishedAt: "2026-04-10T02:00:02.000Z",
+        lastCommentBody: "summary:running",
+        lastSyncStatus: "failed",
+        lastSyncError: "GitHub temporarily unavailable",
+      },
+      {
+        target: { kind: "pull_request", number: 35, url: "https://github.com/yoophi-a/specrail/pull/35" },
+        commentId: 3501,
+        lastRunId: olderRun.id,
+        lastRunStatus: olderRun.status,
+        lastPublishedAt: "2026-04-10T02:00:01.000Z",
+        lastCommentBody: "summary:running",
+        lastSyncStatus: "failed",
+        lastSyncError: "GitHub temporarily unavailable",
+      },
+    ],
+  });
+
+  assert.deepEqual(await service.retryGitHubRunCommentSync(track.id), {
+    runId: newerRun.id,
+    results: [
+      {
+        action: "updated",
+        target: { kind: "issue", number: 34, url: "https://github.com/yoophi-a/specrail/issues/34" },
+        body: "summary:running",
+        commentId: 3401,
+      },
+    ],
+  });
+  assert.deepEqual(publishCalls.at(-1), { runId: newerRun.id, syncCommentId: 3401 });
+});
+
 test("SpecRailService records failed GitHub run summary sync attempts", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-failure-"));
   const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1041,6 +1041,120 @@ test("SpecRailService skips GitHub publishing when a track has no linked targets
   assert.equal(publishCount, 0);
 });
 
+test("SpecRailService exposes track and run inspections with persisted GitHub sync metadata", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-inspection-sync-"));
+  const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    githubRunCommentSyncStore: syncStore,
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: () => "2026-04-10T00:00:00.000Z",
+    idGenerator: (() => {
+      const values = ["track-inspection", "run-inspection"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Inspect sync state",
+    description: "Surface persisted GitHub sync metadata.",
+    githubIssue: { number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+  });
+  const run = await service.startRun({ trackId: track.id, prompt: "inspect" });
+
+  await syncStore.upsert({
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T00:30:00.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+        commentId: 3201,
+        lastRunId: run.id,
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T00:25:00.000Z",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+
+  const trackInspection = await service.getTrackInspection(track.id);
+  assert.equal(trackInspection?.track.id, track.id);
+  assert.deepEqual(trackInspection?.githubRunCommentSync, {
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T00:30:00.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+        commentId: 3201,
+        lastRunId: run.id,
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T00:25:00.000Z",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+
+  const runInspection = await service.getRunInspection(run.id);
+  assert.equal(runInspection?.run.id, run.id);
+  assert.deepEqual(runInspection?.githubRunCommentSync, {
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T00:30:00.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+        commentId: 3201,
+        lastRunId: run.id,
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T00:25:00.000Z",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+  assert.deepEqual(runInspection?.githubRunCommentSyncForRun, [
+    {
+      target: { kind: "issue", number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+      commentId: 3201,
+      lastRunId: run.id,
+      lastRunStatus: "running",
+      lastPublishedAt: "2026-04-10T00:25:00.000Z",
+      lastSyncStatus: "success",
+    },
+  ]);
+});
+
 test("SpecRailService persists GitHub run comment sync metadata and passes it back on republish", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-sync-"));
   const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import type { ExecutionEvent } from "../../domain/types.js";
 import {
+  FileGitHubRunCommentSyncStore,
   FileExecutionRepository,
   FileProjectRepository,
   FileTrackRepository,
@@ -1038,4 +1039,178 @@ test("SpecRailService skips GitHub publishing when a track has no linked targets
 
   await service.startRun({ trackId: track.id, prompt: "Do the work" });
   assert.equal(publishCount, 0);
+});
+
+test("SpecRailService persists GitHub run comment sync metadata and passes it back on republish", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-sync-"));
+  const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));
+  const syncStates: Array<number | undefined> = [];
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    githubRunCommentSyncStore: syncStore,
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary(input) {
+        syncStates.push(input.syncState?.comments[0]?.commentId);
+        return [
+          {
+            action: input.syncState ? "updated" : "created",
+            target: { kind: "issue", number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+            body: `summary:${input.run.status}`,
+            commentId: 3101,
+          },
+        ];
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = [
+        "2026-04-10T00:00:00.000Z",
+        "2026-04-10T00:00:01.000Z",
+        "2026-04-10T00:00:02.000Z",
+        "2026-04-10T00:00:03.000Z",
+      ];
+      return () => values.shift() ?? "2026-04-10T00:00:03.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-sync", "run-sync"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Persist summary sync",
+    description: "Remember published comment ids.",
+    githubIssue: { number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+  });
+
+  const run = await service.startRun({ trackId: track.id, prompt: "publish" });
+  await service.publishRunSummary(run.id);
+
+  assert.deepEqual(syncStates, [undefined, 3101]);
+  assert.deepEqual(await syncStore.getByTrackId(track.id), {
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T00:00:03.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+        commentId: 3101,
+        lastRunId: run.id,
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T00:00:03.000Z",
+        lastCommentBody: "summary:running",
+        lastSyncStatus: "success",
+      },
+    ],
+  });
+});
+
+test("SpecRailService records failed GitHub run summary sync attempts", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-failure-"));
+  const syncStore = new FileGitHubRunCommentSyncStore(path.join(rootDir, "state"));
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    githubRunCommentSyncStore: syncStore,
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary() {
+        throw new Error("GitHub temporarily unavailable");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = ["2026-04-10T01:00:00.000Z", "2026-04-10T01:00:01.000Z"];
+      return () => values.shift() ?? "2026-04-10T01:00:01.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-failure", "run-failure"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Handle sync failures",
+    description: "Persist failure metadata for retry visibility.",
+    githubIssue: { number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+  });
+
+  await assert.rejects(
+    () => service.startRun({ trackId: track.id, prompt: "publish" }),
+    /GitHub temporarily unavailable/,
+  );
+
+  assert.deepEqual(await syncStore.getByTrackId(track.id), {
+    id: track.id,
+    trackId: track.id,
+    updatedAt: "2026-04-10T01:00:01.000Z",
+    comments: [
+      {
+        target: { kind: "issue", number: 31, url: "https://github.com/yoophi-a/specrail/issues/31" },
+        lastRunId: "run-run-failure",
+        lastRunStatus: "running",
+        lastPublishedAt: "2026-04-10T01:00:01.000Z",
+        lastSyncStatus: "failed",
+        lastSyncError: "GitHub temporarily unavailable",
+      },
+    ],
+  });
 });

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1153,6 +1153,85 @@ test("SpecRailService exposes track and run inspections with persisted GitHub sy
       lastSyncStatus: "success",
     },
   ]);
+
+  const integrationsInspection = await service.getTrackIntegrationsInspection(track.id);
+  assert.equal(integrationsInspection?.trackId, track.id);
+  assert.deepEqual(integrationsInspection?.github.issue, {
+    number: 32,
+    url: "https://github.com/yoophi-a/specrail/issues/32",
+  });
+  assert.equal(integrationsInspection?.github.pullRequest, undefined);
+  assert.deepEqual(integrationsInspection?.github.runCommentSync, {
+        id: track.id,
+        trackId: track.id,
+        updatedAt: "2026-04-10T00:30:00.000Z",
+        comments: [
+          {
+            target: { kind: "issue", number: 32, url: "https://github.com/yoophi-a/specrail/issues/32" },
+            commentId: 3201,
+            lastRunId: run.id,
+            lastRunStatus: "running",
+            lastPublishedAt: "2026-04-10T00:25:00.000Z",
+            lastSyncStatus: "success",
+          },
+        ],
+      });
+  assert.deepEqual(integrationsInspection?.github.summary, {
+    linkedTargetCount: 1,
+    syncedTargetCount: 1,
+    lastPublishedAt: "2026-04-10T00:25:00.000Z",
+    lastSyncStatus: "success",
+  });
+});
+
+test("SpecRailService exposes empty GitHub integration inspection summaries without sync state", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-integrations-empty-"));
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn() {
+        throw new Error("should not be called");
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: () => "2026-04-10T00:00:00.000Z",
+    idGenerator: () => "track-empty-integrations",
+  });
+
+  const track = await service.createTrack({
+    title: "Inspect empty integration state",
+    description: "Surface linked GitHub references without sync metadata.",
+    githubIssue: { number: 33, url: "https://github.com/yoophi-a/specrail/issues/33" },
+    githubPullRequest: { number: 34, url: "https://github.com/yoophi-a/specrail/pull/34" },
+  });
+
+  assert.deepEqual(await service.getTrackIntegrationsInspection(track.id), {
+    trackId: track.id,
+    github: {
+      issue: { number: 33, url: "https://github.com/yoophi-a/specrail/issues/33" },
+      pullRequest: { number: 34, url: "https://github.com/yoophi-a/specrail/pull/34" },
+      runCommentSync: null,
+      summary: {
+        linkedTargetCount: 2,
+        syncedTargetCount: 0,
+      },
+    },
+  });
 });
 
 test("SpecRailService persists GitHub run comment sync metadata and passes it back on republish", async () => {

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1527,3 +1527,197 @@ test("SpecRailService records failed GitHub run summary sync attempts", async ()
     ],
   });
 });
+
+test("SpecRailService exports a track through the OpenSpec adapter", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-export-"));
+  const exportCalls: Array<{ trackId: string; targetPath: string; overwrite?: boolean; spec: string }> = [];
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    artifactReader: {
+      async read(trackId) {
+        return {
+          spec: `# Spec for ${trackId}`,
+          plan: "# Plan",
+          tasks: "# Tasks",
+        };
+      },
+    },
+    executor: {
+      name: "codex",
+      async spawn() {
+        throw new Error("should not be called");
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    openSpecAdapter: {
+      name: "openspec-file",
+      async importPackage() {
+        throw new Error("should not be called");
+      },
+      async exportPackage(input) {
+        exportCalls.push({
+          trackId: input.package.track.id,
+          targetPath: input.target.path,
+          overwrite: input.target.overwrite,
+          spec: input.package.artifacts.spec,
+        });
+
+        return input;
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: () => "2026-04-10T04:00:00.000Z",
+    idGenerator: () => "track-openspec-export",
+  });
+
+  const track = await service.createTrack({
+    title: "Export OpenSpec bundle",
+    description: "Package track artifacts for external exchange.",
+  });
+
+  const result = await service.exportTrackToOpenSpec({
+    trackId: track.id,
+    target: { kind: "file", path: path.join(rootDir, "bundle"), overwrite: true },
+  });
+
+  assert.equal(result.package.track.id, track.id);
+  assert.deepEqual(exportCalls, [
+    {
+      trackId: track.id,
+      targetPath: path.join(rootDir, "bundle"),
+      overwrite: true,
+      spec: `# Spec for ${track.id}`,
+    },
+  ]);
+});
+
+test("SpecRailService imports OpenSpec bundles into created and existing tracks", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-import-"));
+  const writes: Array<{ trackId: string; spec: string; plan: string; tasks: string }> = [];
+  const importedTrack = {
+    id: "track-openspec-import",
+    projectId: "project-foreign",
+    title: "  Imported track  ",
+    description: "  Imported description  ",
+    status: "ready" as const,
+    specStatus: "approved" as const,
+    planStatus: "pending" as const,
+    priority: "high" as const,
+    githubIssue: { number: 36, url: "https://github.com/yoophi-a/specrail/issues/36" },
+    createdAt: "2026-04-09T00:00:00.000Z",
+    updatedAt: "2026-04-09T00:00:00.000Z",
+  };
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: {
+      async write(input) {
+        writes.push({
+          trackId: input.track.id,
+          spec: input.specContent,
+          plan: input.planContent,
+          tasks: input.tasksContent,
+        });
+      },
+    },
+    executor: {
+      name: "codex",
+      async spawn() {
+        throw new Error("should not be called");
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    openSpecAdapter: {
+      name: "openspec-file",
+      async importPackage() {
+        return {
+          package: {
+            metadata: {
+              version: 1,
+              format: "specrail.openspec.bundle",
+              exportedAt: "2026-04-10T04:00:00.000Z",
+              generatedBy: "specrail",
+            },
+            track: importedTrack,
+            artifacts: {
+              spec: "# Imported spec",
+              plan: "# Imported plan",
+              tasks: "# Imported tasks",
+            },
+            files: {
+              spec: "spec.md",
+              plan: "plan.md",
+              tasks: "tasks.md",
+            },
+          },
+        };
+      },
+      async exportPackage() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = ["2026-04-10T04:00:00.000Z", "2026-04-10T04:05:00.000Z", "2026-04-10T04:10:00.000Z"];
+      return () => values.shift() ?? "2026-04-10T04:10:00.000Z";
+    })(),
+  });
+
+  const created = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+  });
+  assert.equal(created.action, "created");
+  assert.equal(created.track.id, importedTrack.id);
+  assert.equal(created.track.projectId, importedTrack.projectId);
+  assert.equal(created.track.title, "Imported track");
+  assert.equal(created.track.description, "Imported description");
+  assert.equal(created.track.updatedAt, "2026-04-10T04:05:00.000Z");
+
+  const updated = await service.importTrackFromOpenSpec({
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+  });
+  assert.equal(updated.action, "updated");
+  assert.equal(updated.track.createdAt, "2026-04-09T00:00:00.000Z");
+  assert.equal(updated.track.updatedAt, "2026-04-10T04:10:00.000Z");
+
+  assert.deepEqual(writes, [
+    {
+      trackId: importedTrack.id,
+      spec: "# Imported spec",
+      plan: "# Imported plan",
+      tasks: "# Imported tasks",
+    },
+    {
+      trackId: importedTrack.id,
+      spec: "# Imported spec",
+      plan: "# Imported plan",
+      tasks: "# Imported tasks",
+    },
+  ]);
+});

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -518,6 +518,223 @@ test("SpecRailService updates track workflow and approval state", async () => {
   );
 });
 
+test("SpecRailService trims persisted track fields and run prompts before execution", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-trim-"));
+  const spawnCalls: Array<{ prompt: string; profile: string }> = [];
+  const resumeCalls: Array<{ prompt: string; profile: string }> = [];
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        spawnCalls.push({ prompt: input.prompt, profile: input.profile });
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [
+            {
+              id: `${input.executionId}:started`,
+              executionId: input.executionId,
+              type: "task_status_changed",
+              timestamp: "2026-04-09T05:00:00.000Z",
+              source: "codex",
+              summary: "Run started",
+              payload: { status: "running" },
+            },
+          ],
+        };
+      },
+      async resume(input) {
+        resumeCalls.push({ prompt: input.prompt, profile: input.profile });
+        return {
+          sessionRef: input.sessionRef,
+          command: {
+            command: "codex",
+            args: ["exec", "resume", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+            resumeSessionRef: input.sessionRef,
+          },
+          events: [
+            {
+              id: `${input.executionId}:resumed`,
+              executionId: input.executionId,
+              type: "task_status_changed",
+              timestamp: "2026-04-09T05:05:00.000Z",
+              source: "codex",
+              summary: "Run resumed",
+              payload: { status: "running", sessionRef: input.sessionRef },
+            },
+          ],
+        };
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = ["2026-04-09T05:00:00.000Z", "2026-04-09T05:05:00.000Z"];
+      return () => values.shift() ?? "2026-04-09T05:05:00.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-trim", "run-trim"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "  Trim title  ",
+    description: "  Trim description  ",
+  });
+
+  assert.equal(track.title, "Trim title");
+  assert.equal(track.description, "Trim description");
+
+  const run = await service.startRun({
+    trackId: track.id,
+    prompt: "  Run the checks  ",
+    profile: "  default  ",
+  });
+
+  assert.deepEqual(spawnCalls, [{ prompt: "Run the checks", profile: "default" }]);
+  assert.equal(run.profile, "default");
+  assert.equal(run.command?.prompt, "Run the checks");
+
+  const resumedRun = await service.resumeRun({
+    runId: run.id,
+    prompt: "  Continue verifying  ",
+  });
+
+  assert.deepEqual(resumeCalls, [{ prompt: "Continue verifying", profile: "default" }]);
+  assert.equal(resumedRun.command?.prompt, "Continue verifying");
+});
+
+test("SpecRailService derives waiting approval and resumed running state from approval events", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-approval-events-"));
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [
+            {
+              id: `${input.executionId}:started`,
+              executionId: input.executionId,
+              type: "task_status_changed",
+              timestamp: "2026-04-09T06:00:00.000Z",
+              source: "codex",
+              summary: "Run started",
+              payload: { status: "running" },
+            },
+          ],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = ["2026-04-09T06:00:00.000Z", "2026-04-09T06:00:01.000Z", "2026-04-09T06:00:02.000Z"];
+      return () => values.shift() ?? "2026-04-09T06:00:02.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-approval", "run-approval"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Approval-gated run",
+    description: "Reconcile waiting approval from normalized events.",
+  });
+
+  const run = await service.startRun({
+    trackId: track.id,
+    prompt: "Start the gated work",
+  });
+
+  await service.recordExecutionEvent({
+    id: `${run.id}:approval-requested`,
+    executionId: run.id,
+    type: "approval_requested",
+    timestamp: "2026-04-09T06:00:01.000Z",
+    source: "codex",
+    summary: "Approval requested",
+    payload: {
+      gate: "plan",
+    },
+  });
+
+  const waitingRun = await service.getRun(run.id);
+  assert.equal(waitingRun?.status, "waiting_approval");
+  assert.equal(waitingRun?.startedAt, run.startedAt);
+  assert.equal(waitingRun?.finishedAt, undefined);
+  assert.deepEqual(waitingRun?.summary, {
+    eventCount: 2,
+    lastEventSummary: "Approval requested",
+    lastEventAt: "2026-04-09T06:00:01.000Z",
+  });
+
+  await service.recordExecutionEvent({
+    id: `${run.id}:approval-resolved`,
+    executionId: run.id,
+    type: "approval_resolved",
+    timestamp: "2026-04-09T06:00:02.000Z",
+    source: "codex",
+    summary: "Approval resolved",
+    payload: {
+      gate: "plan",
+      resolution: "approved",
+    },
+  });
+
+  const resumedRun = await service.getRun(run.id);
+  assert.equal(resumedRun?.status, "running");
+  assert.equal(resumedRun?.startedAt, run.startedAt);
+  assert.equal(resumedRun?.finishedAt, undefined);
+  assert.deepEqual(resumedRun?.summary, {
+    eventCount: 3,
+    lastEventSummary: "Approval resolved",
+    lastEventAt: "2026-04-09T06:00:02.000Z",
+  });
+});
+
 test("SpecRailService lists tracks and runs with basic filters", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-listing-"));
 

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -857,3 +857,185 @@ test("SpecRailService lists tracks and runs with basic filters", async () => {
     [runTwo.id],
   );
 });
+
+test("SpecRailService publishes GitHub run summaries for linked issue and pull request targets", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-"));
+  const publishCalls: Array<{ trackStatus: string; runStatus: string; eventCount: number }> = [];
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [
+            {
+              id: `${input.executionId}:started`,
+              executionId: input.executionId,
+              type: "task_status_changed",
+              timestamp: "2026-04-09T07:00:00.000Z",
+              source: "codex",
+              summary: "Run started",
+              payload: { status: "running" },
+            },
+          ],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary(input) {
+        publishCalls.push({
+          trackStatus: input.track.status,
+          runStatus: input.run.status,
+          eventCount: input.events.length,
+        });
+        return [
+          {
+            action: "updated",
+            target: { kind: "issue", number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+            body: "summary",
+            commentId: 3001,
+          },
+          {
+            action: "updated",
+            target: { kind: "pull_request", number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" },
+            body: "summary",
+            commentId: 3101,
+          },
+        ];
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = ["2026-04-09T07:00:00.000Z", "2026-04-09T07:00:01.000Z"];
+      return () => values.shift() ?? "2026-04-09T07:00:01.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-publish", "run-publish"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "Publish linked summaries",
+    description: "Push run state to linked GitHub discussions.",
+    githubIssue: { number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+    githubPullRequest: { number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" },
+  });
+
+  const run = await service.startRun({
+    trackId: track.id,
+    prompt: "Ship the publish flow",
+  });
+
+  assert.deepEqual(publishCalls, [{ trackStatus: "new", runStatus: "running", eventCount: 1 }]);
+
+  await service.recordExecutionEvent({
+    id: `${run.id}:completed`,
+    executionId: run.id,
+    type: "task_status_changed",
+    timestamp: "2026-04-09T07:00:01.000Z",
+    source: "codex",
+    summary: "Run completed",
+    payload: { status: "completed" },
+  });
+
+  assert.deepEqual(publishCalls, [
+    { trackStatus: "new", runStatus: "running", eventCount: 1 },
+    { trackStatus: "review", runStatus: "completed", eventCount: 2 },
+  ]);
+
+  assert.equal((await service.getTrack(track.id))?.status, "review");
+  assert.deepEqual(await service.publishRunSummary(run.id), [
+    {
+      action: "updated",
+      target: { kind: "issue", number: 30, url: "https://github.com/yoophi-a/specrail/issues/30" },
+      body: "summary",
+      commentId: 3001,
+    },
+    {
+      action: "updated",
+      target: { kind: "pull_request", number: 31, url: "https://github.com/yoophi-a/specrail/pull/31" },
+      body: "summary",
+      commentId: 3101,
+    },
+  ]);
+});
+
+test("SpecRailService skips GitHub publishing when a track has no linked targets", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-publish-none-"));
+  let publishCount = 0;
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {} },
+    executor: {
+      name: "codex",
+      async spawn(input) {
+        return {
+          sessionRef: `session:${input.executionId}`,
+          command: {
+            command: "codex",
+            args: ["exec", input.prompt],
+            cwd: input.workspacePath,
+            prompt: input.prompt,
+          },
+          events: [],
+        };
+      },
+      async resume() {
+        throw new Error("should not be called");
+      },
+      async cancel() {
+        throw new Error("should not be called");
+      },
+    },
+    githubRunCommentPublisher: {
+      async publishRunSummary() {
+        publishCount += 1;
+        return [];
+      },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    idGenerator: (() => {
+      const values = ["track-unlinked", "run-unlinked"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({
+    title: "No external links",
+    description: "This should not publish anywhere.",
+  });
+
+  await service.startRun({ trackId: track.id, prompt: "Do the work" });
+  assert.equal(publishCount, 0);
+});

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1225,6 +1225,8 @@ test("SpecRailService exposes empty GitHub integration inspection summaries with
     openSpec: {
       latestImport: null,
       importHistory: [],
+      latestExport: null,
+      exportHistory: [],
     },
     github: {
       issue: { number: 33, url: "https://github.com/yoophi-a/specrail/issues/33" },
@@ -1607,6 +1609,15 @@ test("SpecRailService exports a track through the OpenSpec adapter", async () =>
       spec: `# Spec for ${track.id}`,
     },
   ]);
+
+  const exportInspection = await service.getTrackOpenSpecImports(track.id);
+  assert.ok(exportInspection);
+  assert.equal(exportInspection.latestExport?.target.path, path.join(rootDir, "bundle"));
+  assert.equal(exportInspection.exportHistory.length, 1);
+
+  const exportHistory = await service.listOpenSpecExportHistory({ trackId: track.id });
+  assert.equal(exportHistory.length, 1);
+  assert.equal(exportHistory[0]?.exportRecord.target.path, path.join(rootDir, "bundle"));
 });
 
 test("SpecRailService imports OpenSpec bundles into created and existing tracks", async () => {
@@ -2066,6 +2077,8 @@ test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing
   assert.ok(importInspection);
   assert.equal(importInspection.latestImport?.conflictPolicy, "resolve");
   assert.equal(importInspection.importHistory.length, 1);
+  assert.equal(importInspection.latestExport, null);
+  assert.equal(importInspection.exportHistory.length, 0);
 
   const adminHistory = await service.listOpenSpecImportHistory();
   assert.equal(adminHistory.length, 1);

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1991,6 +1991,7 @@ test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing
   const result = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
     conflictPolicy: "resolve",
+    resolutionPreset: "policyDefaults",
     resolution: {
       track: { title: "existing" },
       artifacts: { spec: "existing", plan: "incoming", tasks: "existing" },
@@ -1999,15 +2000,31 @@ test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing
 
   assert.equal(result.track.title, "Existing title");
   assert.equal(result.track.description, "Incoming description");
-  assert.equal(result.track.status, "ready");
+  assert.equal(result.track.status, "planned");
   assert.equal(result.resolvedArtifacts.spec, "# Existing spec\n");
   assert.equal(result.resolvedArtifacts.plan, "# Incoming plan\n");
   assert.equal(result.resolvedArtifacts.tasks, "# Existing tasks\n");
   assert.equal(result.provenance.conflictPolicy, "resolve");
+  assert.equal(result.provenance.resolutionPreset, "policyDefaults");
   assert.deepEqual(result.provenance.resolution, {
-    track: { title: "existing" },
+    track: {
+      title: "existing",
+      description: "incoming",
+      status: "existing",
+      specStatus: "existing",
+      planStatus: "existing",
+      priority: "existing",
+      githubIssue: "existing",
+      githubPullRequest: "existing",
+    },
     artifacts: { spec: "existing", plan: "incoming", tasks: "existing" },
   });
+  assert.equal(result.resolutionGuide.presetApplied, "policyDefaults");
+  assert.equal(result.resolutionGuide.effectiveResolution.track?.status, "existing");
+  assert.equal(result.resolutionGuide.effectiveResolution.track?.title, "existing");
+  assert.equal(result.resolutionGuide.effectiveResolution.artifacts?.plan, "incoming");
+  assert.ok(result.resolutionGuide.policies.some((policy) => policy.field === "status" && policy.defaultChoice === "existing"));
+  assert.ok(result.resolutionGuide.presets.some((preset) => preset.name === "preferIncomingArtifacts"));
 
   const importInspection = await service.getTrackOpenSpecImports(created.id);
   assert.ok(importInspection);

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1608,6 +1608,7 @@ test("SpecRailService exports a track through the OpenSpec adapter", async () =>
 test("SpecRailService imports OpenSpec bundles into created and existing tracks", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-import-"));
   const writes: Array<{ trackId: string; spec: string; plan: string; tasks: string }> = [];
+  const existingArtifacts = new Map<string, { spec: string; plan: string; tasks: string }>();
   const importedTrack = {
     id: "track-openspec-import",
     projectId: "project-foreign",
@@ -1629,12 +1630,27 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
     eventStore: new JsonlEventStore(path.join(rootDir, "state")),
     artifactWriter: {
       async write(input) {
+        existingArtifacts.set(input.track.id, {
+          spec: input.specContent,
+          plan: input.planContent,
+          tasks: input.tasksContent,
+        });
         writes.push({
           trackId: input.track.id,
           spec: input.specContent,
           plan: input.planContent,
           tasks: input.tasksContent,
         });
+      },
+    },
+    artifactReader: {
+      async read(trackId) {
+        const artifacts = existingArtifacts.get(trackId);
+        if (!artifacts) {
+          throw new Error(`missing artifacts for ${trackId}`);
+        }
+
+        return artifacts;
       },
     },
     executor: {
@@ -1700,6 +1716,17 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
   assert.equal(created.track.title, "Imported track");
   assert.equal(created.track.description, "Imported description");
   assert.equal(created.track.updatedAt, "2026-04-10T04:05:00.000Z");
+  assert.deepEqual(created.provenance, {
+    source: { kind: "file", path: path.join(rootDir, "bundle") },
+    importedAt: "2026-04-10T04:05:00.000Z",
+    conflictPolicy: "overwrite",
+    bundle: {
+      version: 1,
+      format: "specrail.openspec.bundle",
+      exportedAt: "2026-04-10T04:00:00.000Z",
+      generatedBy: "specrail",
+    },
+  });
 
   const updated = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
@@ -1709,6 +1736,8 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
   assert.equal(updated.applied, true);
   assert.equal(updated.track.createdAt, "2026-04-09T00:00:00.000Z");
   assert.equal(updated.track.updatedAt, "2026-04-10T04:10:00.000Z");
+  assert.equal(updated.conflict.details[0]?.field, "track.id");
+  assert.equal(updated.track.openSpecImport?.source.path, path.join(rootDir, "bundle"));
 
   assert.deepEqual(writes, [
     {
@@ -1729,6 +1758,12 @@ test("SpecRailService imports OpenSpec bundles into created and existing tracks"
 test("SpecRailService previews OpenSpec imports and rejects collisions unless overwrite is explicit", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-import-preview-"));
   const writes: Array<{ trackId: string; spec: string; plan: string; tasks: string }> = [];
+  const existingArtifacts = new Map<string, { spec: string; plan: string; tasks: string }>();
+  const importedArtifacts = {
+    spec: "# Preview spec",
+    plan: "# Preview plan",
+    tasks: "# Preview tasks",
+  };
   const importedTrack = {
     id: "track-openspec-preview",
     projectId: "project-foreign",
@@ -1751,12 +1786,27 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
     eventStore: new JsonlEventStore(path.join(rootDir, "state")),
     artifactWriter: {
       async write(input) {
+        existingArtifacts.set(input.track.id, {
+          spec: input.specContent,
+          plan: input.planContent,
+          tasks: input.tasksContent,
+        });
         writes.push({
           trackId: input.track.id,
           spec: input.specContent,
           plan: input.planContent,
           tasks: input.tasksContent,
         });
+      },
+    },
+    artifactReader: {
+      async read(trackId) {
+        const artifacts = existingArtifacts.get(trackId);
+        if (!artifacts) {
+          throw new Error(`missing artifacts for ${trackId}`);
+        }
+
+        return artifacts;
       },
     },
     executor: {
@@ -1777,11 +1827,7 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
               generatedBy: "specrail",
             },
             track: importedTrack,
-            artifacts: {
-              spec: "# Preview spec",
-              plan: "# Preview plan",
-              tasks: "# Preview tasks",
-            },
+            artifacts: importedArtifacts,
             files: {
               spec: "spec.md",
               plan: "plan.md",
@@ -1823,6 +1869,8 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
     /Retry with conflictPolicy=overwrite or dryRun=true/,
   );
 
+  importedArtifacts.spec = "# Preview spec updated\n";
+
   const collisionPreview = await service.importTrackFromOpenSpec({
     source: { kind: "file", path: path.join(rootDir, "bundle") },
     dryRun: true,
@@ -1831,5 +1879,7 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
   assert.equal(collisionPreview.applied, false);
   assert.equal(collisionPreview.conflict.hasConflict, true);
   assert.equal(collisionPreview.conflict.reason, "track_id_exists");
+  assert.ok(collisionPreview.conflict.details.some((detail) => detail.field === "artifacts.spec"));
+  assert.equal(collisionPreview.provenance.source.path, path.join(rootDir, "bundle"));
   assert.equal(writes.length, 1);
 });

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1893,7 +1893,41 @@ test("SpecRailService previews OpenSpec imports and rejects collisions unless ov
   assert.equal(collisionPreview.conflict.reason, "track_id_exists");
   assert.ok(collisionPreview.conflict.details.some((detail) => detail.field === "artifacts.spec"));
   assert.equal(collisionPreview.provenance.source.path, path.join(rootDir, "bundle"));
+  assert.equal(collisionPreview.operatorGuide.selectedPreset, null);
+  assert.ok(collisionPreview.operatorGuide.examples.some((example) => example.id === "policy-defaults-resolve"));
   assert.equal(writes.length, 1);
+});
+
+test("SpecRailService exposes operator-facing OpenSpec import help for preset selection", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-openspec-help-"));
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() { throw new Error("should not be called"); } },
+    executor: {
+      name: "codex",
+      async spawn() { throw new Error("should not be called"); },
+      async resume() { throw new Error("should not be called"); },
+      async cancel() { throw new Error("should not be called"); },
+    },
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+  });
+
+  const help = service.getOpenSpecImportHelp({ resolutionPreset: "policyDefaults" });
+  assert.deepEqual(help.recommendedFlow.slice(0, 2), [
+    "Preview with dryRun=true first.",
+    "Pick a named preset that matches the workflow you want.",
+  ]);
+  assert.equal(help.selectedPreset?.name, "policyDefaults");
+  assert.ok(help.selectedPreset?.choices.some((choice) => choice.field === "status" && choice.choice === "existing"));
+  assert.ok(help.examples.some((example) => example.id === "preset-with-override"));
+  assert.ok(help.conflictPolicies.some((policy) => policy.name === "overwrite"));
 });
 
 test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing choices and lists import history", async () => {
@@ -2025,6 +2059,8 @@ test("SpecRailService resolves OpenSpec conflicts with field-level keep-existing
   assert.equal(result.resolutionGuide.effectiveResolution.artifacts?.plan, "incoming");
   assert.ok(result.resolutionGuide.policies.some((policy) => policy.field === "status" && policy.defaultChoice === "existing"));
   assert.ok(result.resolutionGuide.presets.some((preset) => preset.name === "preferIncomingArtifacts"));
+  assert.equal(result.operatorGuide.selectedPreset?.name, "policyDefaults");
+  assert.ok(result.operatorGuide.effectiveChoices.some((choice) => choice.field === "plan" && choice.choice === "incoming"));
 
   const importInspection = await service.getTrackOpenSpecImports(created.id);
   assert.ok(importInspection);

--- a/packages/core/src/services/file-repositories.ts
+++ b/packages/core/src/services/file-repositories.ts
@@ -5,15 +5,18 @@ import type { Execution, ExecutionEvent, Project, Track } from "../domain/types.
 import type {
   EventStore,
   ExecutionRepository,
+  GitHubRunCommentSyncStore,
   ProjectRepository,
   TrackRepository,
 } from "./ports.js";
+import type { GitHubRunCommentSyncState } from "../domain/types.js";
 
 interface FileStatePaths {
   projectsDir: string;
   tracksDir: string;
   executionsDir: string;
   eventsDir: string;
+  githubRunCommentSyncDir: string;
 }
 
 export function getStatePaths(rootDir: string): FileStatePaths {
@@ -22,6 +25,7 @@ export function getStatePaths(rootDir: string): FileStatePaths {
     tracksDir: path.join(rootDir, "tracks"),
     executionsDir: path.join(rootDir, "executions"),
     eventsDir: path.join(rootDir, "events"),
+    githubRunCommentSyncDir: path.join(rootDir, "github-run-comment-sync"),
   };
 }
 
@@ -182,5 +186,21 @@ export class JsonlEventStore implements EventStore {
 
       throw error;
     }
+  }
+}
+
+export class FileGitHubRunCommentSyncStore implements GitHubRunCommentSyncStore {
+  private readonly repository: JsonFileRepository<GitHubRunCommentSyncState>;
+
+  constructor(rootDir: string) {
+    this.repository = new JsonFileRepository<GitHubRunCommentSyncState>(getStatePaths(rootDir).githubRunCommentSyncDir);
+  }
+
+  getByTrackId(trackId: string): Promise<GitHubRunCommentSyncState | null> {
+    return this.repository.getById(trackId);
+  }
+
+  upsert(state: GitHubRunCommentSyncState): Promise<void> {
+    return this.repository.update(state);
   }
 }

--- a/packages/core/src/services/github-comment-summary.ts
+++ b/packages/core/src/services/github-comment-summary.ts
@@ -1,0 +1,110 @@
+import type { Execution, ExecutionEvent, Track } from "../domain/types.js";
+
+export interface FormatGitHubRunCommentInput {
+  track: Pick<Track, "id" | "title" | "status" | "githubIssue" | "githubPullRequest">;
+  run: Pick<
+    Execution,
+    | "id"
+    | "status"
+    | "backend"
+    | "profile"
+    | "branchName"
+    | "workspacePath"
+    | "sessionRef"
+    | "summary"
+    | "startedAt"
+    | "finishedAt"
+  >;
+  events: Array<Pick<ExecutionEvent, "timestamp" | "summary" | "type">>;
+  options?: {
+    maxHighlights?: number;
+  };
+}
+
+const STATUS_LABELS: Record<Execution["status"], string> = {
+  created: "Created",
+  queued: "Queued",
+  running: "Running",
+  waiting_approval: "Waiting for approval",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+const STATUS_EMOJI: Record<Execution["status"], string> = {
+  created: "⚪",
+  queued: "🟡",
+  running: "🟢",
+  waiting_approval: "⏸️",
+  completed: "✅",
+  failed: "❌",
+  cancelled: "🛑",
+};
+
+function formatLink(label: string, value: { number: number; url: string } | undefined): string {
+  if (!value) {
+    return `- ${label}: none linked`;
+  }
+
+  return `- ${label}: [#${value.number}](${value.url})`;
+}
+
+function formatMetadataRow(label: string, value: string | number | undefined): string | null {
+  if (value === undefined || value === "") {
+    return null;
+  }
+
+  return `- ${label}: ${value}`;
+}
+
+function formatCode(value: string | undefined): string | undefined {
+  return value ? `\`${value}\`` : undefined;
+}
+
+function formatHighlight(event: Pick<ExecutionEvent, "timestamp" | "summary" | "type">): string {
+  return `- ${event.timestamp} · **${event.type}** · ${event.summary}`;
+}
+
+export function formatGitHubRunCommentSummary(input: FormatGitHubRunCommentInput): string {
+  const { track, run, events, options } = input;
+  const maxHighlights = options?.maxHighlights ?? 5;
+  const highlights = events.slice(-maxHighlights);
+  const statusLabel = `${STATUS_EMOJI[run.status]} ${STATUS_LABELS[run.status]}`;
+
+  const sections = [
+    `<!-- specrail:run-summary track=${track.id} run=${run.id} status=${run.status} -->`,
+    `## SpecRail run summary`,
+    "",
+    `**Track:** ${track.title} (${formatCode(track.id)})`,
+    `**Run:** ${formatCode(run.id)}  `,
+    `**Outcome:** ${statusLabel}`,
+    "",
+    "### Links",
+    [formatLink("Issue", track.githubIssue), formatLink("Pull request", track.githubPullRequest)].join("\n"),
+    "",
+    "### Run metadata",
+    [
+      formatMetadataRow("Backend", formatCode(run.backend)),
+      formatMetadataRow("Profile", formatCode(run.profile)),
+      formatMetadataRow("Branch", formatCode(run.branchName)),
+      formatMetadataRow("Session", formatCode(run.sessionRef)),
+      formatMetadataRow("Workspace", formatCode(run.workspacePath)),
+      formatMetadataRow("Started", run.startedAt ?? "Not started"),
+      formatMetadataRow("Finished", run.finishedAt),
+      formatMetadataRow("Events", run.summary?.eventCount ?? events.length),
+      formatMetadataRow("Last event", run.summary?.lastEventSummary),
+      formatMetadataRow("Last event at", run.summary?.lastEventAt),
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n"),
+    "",
+    "### Recent highlights",
+    highlights.length > 0 ? highlights.map(formatHighlight).join("\n") : "- No execution events recorded",
+  ];
+
+  if (run.status === "waiting_approval") {
+    sections.push("", "> Approval is currently blocking this run. Resume after the required decision is recorded.");
+  }
+
+  return `${sections.join("\n").trim()}\n`;
+}

--- a/packages/core/src/services/ports.ts
+++ b/packages/core/src/services/ports.ts
@@ -1,5 +1,26 @@
 import type { Execution, ExecutionEvent, Project, Track } from "../domain/types.js";
 
+export interface GitHubRunCommentTarget {
+  kind: "issue" | "pull_request";
+  number: number;
+  url: string;
+}
+
+export interface GitHubRunCommentPublishResult {
+  action: "created" | "updated" | "noop";
+  target: GitHubRunCommentTarget;
+  body: string;
+  commentId?: number;
+}
+
+export interface GitHubRunCommentPublisher {
+  publishRunSummary(input: {
+    track: Track;
+    run: Execution;
+    events: ExecutionEvent[];
+  }): Promise<GitHubRunCommentPublishResult[]>;
+}
+
 export interface ProjectRepository {
   create(project: Project): Promise<void>;
   getById(projectId: string): Promise<Project | null>;

--- a/packages/core/src/services/ports.ts
+++ b/packages/core/src/services/ports.ts
@@ -1,4 +1,4 @@
-import type { Execution, ExecutionEvent, Project, Track } from "../domain/types.js";
+import type { Execution, ExecutionEvent, GitHubRunCommentSyncState, Project, Track } from "../domain/types.js";
 
 export interface GitHubRunCommentTarget {
   kind: "issue" | "pull_request";
@@ -18,7 +18,13 @@ export interface GitHubRunCommentPublisher {
     track: Track;
     run: Execution;
     events: ExecutionEvent[];
+    syncState?: GitHubRunCommentSyncState;
   }): Promise<GitHubRunCommentPublishResult[]>;
+}
+
+export interface GitHubRunCommentSyncStore {
+  getByTrackId(trackId: string): Promise<GitHubRunCommentSyncState | null>;
+  upsert(state: GitHubRunCommentSyncState): Promise<void>;
 }
 
 export interface ProjectRepository {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -17,6 +17,7 @@ import type {
   ExecutionStatus,
   OpenSpecImportArtifactResolutionField,
   OpenSpecImportConflictPolicy,
+  OpenSpecExportRecord,
   OpenSpecImportRecord,
   OpenSpecImportResolution,
   OpenSpecImportResolutionChoice,
@@ -487,6 +488,17 @@ export interface OpenSpecImportHistoryEntry {
   provenance: OpenSpecImportRecord;
 }
 
+export interface OpenSpecExportHistoryListInput {
+  trackId?: string;
+  limit?: number;
+}
+
+export interface OpenSpecExportHistoryEntry {
+  trackId: string;
+  trackTitle: string;
+  exportRecord: OpenSpecExportRecord;
+}
+
 export type SortOrder = "asc" | "desc";
 
 export interface ListTracksInput {
@@ -878,6 +890,8 @@ export class SpecRailService {
       openSpec: {
         latestImport: track.openSpecImport ?? null,
         importHistory: [...(track.openSpecImportHistory ?? [])].sort((left, right) => right.importedAt.localeCompare(left.importedAt)),
+        latestExport: track.openSpecExport ?? null,
+        exportHistory: [...(track.openSpecExportHistory ?? [])].sort((left, right) => right.exportedAt.localeCompare(left.exportedAt)),
       },
       github: {
         issue: track.githubIssue,
@@ -888,7 +902,13 @@ export class SpecRailService {
     };
   }
 
-  async getTrackOpenSpecImports(trackId: string): Promise<{ trackId: string; latestImport: OpenSpecImportRecord | null; importHistory: OpenSpecImportRecord[] } | null> {
+  async getTrackOpenSpecImports(trackId: string): Promise<{
+    trackId: string;
+    latestImport: OpenSpecImportRecord | null;
+    importHistory: OpenSpecImportRecord[];
+    latestExport: OpenSpecExportRecord | null;
+    exportHistory: OpenSpecExportRecord[];
+  } | null> {
     const track = await this.dependencies.trackRepository.getById(trackId);
     if (!track) {
       return null;
@@ -898,6 +918,8 @@ export class SpecRailService {
       trackId: track.id,
       latestImport: track.openSpecImport ?? null,
       importHistory: [...(track.openSpecImportHistory ?? [])].sort((left, right) => right.importedAt.localeCompare(left.importedAt)),
+      latestExport: track.openSpecExport ?? null,
+      exportHistory: [...(track.openSpecExportHistory ?? [])].sort((left, right) => right.exportedAt.localeCompare(left.exportedAt)),
     };
   }
 
@@ -922,6 +944,23 @@ export class SpecRailService {
     );
 
     entries.sort((left, right) => right.provenance.importedAt.localeCompare(left.provenance.importedAt));
+    return entries.slice(0, input.limit ?? entries.length);
+  }
+
+  async listOpenSpecExportHistory(input: OpenSpecExportHistoryListInput = {}): Promise<OpenSpecExportHistoryEntry[]> {
+    const tracks = input.trackId
+      ? [await this.dependencies.trackRepository.getById(input.trackId)].filter((track): track is Track => track !== null)
+      : await this.dependencies.trackRepository.list();
+
+    const entries = tracks.flatMap((track) =>
+      (track.openSpecExportHistory ?? []).map((exportRecord) => ({
+        trackId: track.id,
+        trackTitle: track.title,
+        exportRecord,
+      })),
+    );
+
+    entries.sort((left, right) => right.exportRecord.exportedAt.localeCompare(left.exportRecord.exportedAt));
     return entries.slice(0, input.limit ?? entries.length);
   }
 
@@ -996,13 +1035,14 @@ export class SpecRailService {
     }
 
     const artifacts = await artifactReader.read(track.id);
+    const exportTimestamp = this.now();
 
-    return adapter.exportPackage({
+    const result = await adapter.exportPackage({
       package: {
         metadata: {
           version: 1,
           format: "specrail.openspec.bundle",
-          exportedAt: this.now(),
+          exportedAt: exportTimestamp,
           generatedBy: "specrail",
         },
         track,
@@ -1015,6 +1055,33 @@ export class SpecRailService {
       },
       target: input.target,
     });
+
+    const exportRecord: OpenSpecExportRecord = {
+      id: `openspec-export-${this.idGenerator()}`,
+      target: result.target,
+      exportedAt: exportTimestamp,
+      bundle: result.package.metadata,
+    };
+
+    const updatedTrack: Track = {
+      ...track,
+      openSpecExport: exportRecord,
+      openSpecExportHistory: [...(track.openSpecExportHistory ?? []), exportRecord],
+      updatedAt: exportTimestamp,
+    };
+
+    await this.dependencies.trackRepository.update(updatedTrack);
+
+    const project = (await this.dependencies.projectRepository.getById(updatedTrack.projectId)) ?? (await this.ensureDefaultProject());
+    await this.dependencies.artifactWriter.write({
+      track: updatedTrack,
+      project,
+      specContent: artifacts.spec,
+      planContent: artifacts.plan,
+      tasksContent: artifacts.tasks,
+    });
+
+    return result;
   }
 
   async importTrackFromOpenSpec(input: ImportTrackFromOpenSpecInput): Promise<ImportTrackFromOpenSpecResult> {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -153,21 +153,27 @@ function buildExecutionSummary(events: ExecutionEvent[]): Execution["summary"] {
 }
 
 function readExecutionStatus(event: ExecutionEvent): ExecutionStatus | null {
-  if (event.type !== "task_status_changed") {
-    return null;
+  if (event.type === "approval_requested") {
+    return "waiting_approval";
   }
 
-  const status = event.payload?.status;
-  if (
-    status === "created" ||
-    status === "queued" ||
-    status === "running" ||
-    status === "waiting_approval" ||
-    status === "completed" ||
-    status === "failed" ||
-    status === "cancelled"
-  ) {
-    return status;
+  if (event.type === "approval_resolved") {
+    return "running";
+  }
+
+  if (event.type === "task_status_changed") {
+    const status = event.payload?.status;
+    if (
+      status === "created" ||
+      status === "queued" ||
+      status === "running" ||
+      status === "waiting_approval" ||
+      status === "completed" ||
+      status === "failed" ||
+      status === "cancelled"
+    ) {
+      return status;
+    }
   }
 
   return null;
@@ -234,6 +240,15 @@ function buildListPageResult<T>(items: T[], page: number, pageSize: number): Lis
   };
 }
 
+function normalizeRequiredString(value: string): string {
+  return value.trim();
+}
+
+function normalizeProfile(value: string | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : "default";
+}
+
 export class SpecRailService {
   private readonly now: () => string;
   private readonly idGenerator: () => string;
@@ -249,8 +264,8 @@ export class SpecRailService {
     const track: Track = {
       id: `track-${this.idGenerator()}`,
       projectId: project.id,
-      title: input.title,
-      description: input.description,
+      title: normalizeRequiredString(input.title),
+      description: normalizeRequiredString(input.description),
       status: "new",
       specStatus: "draft",
       planStatus: "draft",
@@ -343,20 +358,22 @@ export class SpecRailService {
     const executionId = `run-${this.idGenerator()}`;
     const createdAt = this.now();
     const workspacePath = path.join(this.dependencies.workspaceRoot, executionId);
+    const prompt = normalizeRequiredString(input.prompt);
+    const profile = normalizeProfile(input.profile);
     await mkdir(workspacePath, { recursive: true });
 
     const launch = await this.dependencies.executor.spawn({
       executionId,
-      prompt: input.prompt,
+      prompt,
       workspacePath,
-      profile: input.profile ?? "default",
+      profile,
     });
 
     const initialExecution: Execution = {
       id: executionId,
       trackId: track.id,
       backend: this.dependencies.executor.name,
-      profile: input.profile ?? "default",
+      profile,
       workspacePath,
       branchName: `specrail/${executionId}`,
       sessionRef: launch.sessionRef,
@@ -392,7 +409,7 @@ export class SpecRailService {
     const launch = await this.dependencies.executor.resume({
       executionId: execution.id,
       sessionRef: execution.sessionRef,
-      prompt: input.prompt,
+      prompt: normalizeRequiredString(input.prompt),
       workspacePath: execution.workspacePath,
       profile: execution.profile,
     });

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -48,6 +48,52 @@ export interface TrackArtifactWriter {
   write(input: TrackArtifactWriterInput): Promise<void>;
 }
 
+export interface OpenSpecTrackArtifacts {
+  spec: string;
+  plan: string;
+  tasks: string;
+}
+
+export interface OpenSpecImportSource {
+  kind: "file";
+  path: string;
+}
+
+export interface OpenSpecExportTarget {
+  kind: "file";
+  path: string;
+  overwrite?: boolean;
+}
+
+export interface OpenSpecTrackPackage {
+  metadata: {
+    version: 1;
+    format: "specrail.openspec.bundle";
+    exportedAt: string;
+    generatedBy: "specrail";
+  };
+  track: Track;
+  artifacts: OpenSpecTrackArtifacts;
+  files: {
+    spec: string;
+    plan: string;
+    tasks: string;
+  };
+}
+
+export interface OpenSpecAdapter {
+  readonly name: string;
+  importPackage(input: { source: OpenSpecImportSource }): Promise<{ package: OpenSpecTrackPackage }>;
+  exportPackage(input: { package: OpenSpecTrackPackage; target: OpenSpecExportTarget }): Promise<{
+    package: OpenSpecTrackPackage;
+    target: OpenSpecExportTarget;
+  }>;
+}
+
+export interface TrackArtifactReader {
+  read(trackId: string): Promise<OpenSpecTrackArtifacts>;
+}
+
 export interface ExecutorLaunchResult {
   sessionRef: string;
   command: Execution["command"];
@@ -83,7 +129,9 @@ export interface SpecRailServiceDependencies {
   executionRepository: ExecutionRepository;
   eventStore: EventStore;
   artifactWriter: TrackArtifactWriter;
+  artifactReader?: TrackArtifactReader;
   executor: ExecutionBackend;
+  openSpecAdapter?: OpenSpecAdapter;
   defaultProject: {
     id: string;
     name: string;
@@ -128,6 +176,15 @@ export interface ResumeRunInput {
 
 export interface CancelRunInput {
   runId: string;
+}
+
+export interface ExportTrackToOpenSpecInput {
+  trackId: string;
+  target: OpenSpecExportTarget;
+}
+
+export interface ImportTrackFromOpenSpecInput {
+  source: OpenSpecImportSource;
 }
 
 export type SortOrder = "asc" | "desc";
@@ -454,6 +511,76 @@ export class SpecRailService {
     await this.dependencies.trackRepository.update(nextTrack);
 
     return nextTrack;
+  }
+
+  async exportTrackToOpenSpec(input: ExportTrackToOpenSpecInput) {
+    const adapter = this.requireOpenSpecAdapter();
+    const artifactReader = this.requireTrackArtifactReader();
+    const track = await this.dependencies.trackRepository.getById(input.trackId);
+
+    if (!track) {
+      throw new NotFoundError(`Track not found: ${input.trackId}`);
+    }
+
+    const artifacts = await artifactReader.read(track.id);
+
+    return adapter.exportPackage({
+      package: {
+        metadata: {
+          version: 1,
+          format: "specrail.openspec.bundle",
+          exportedAt: this.now(),
+          generatedBy: "specrail",
+        },
+        track,
+        artifacts,
+        files: {
+          spec: "spec.md",
+          plan: "plan.md",
+          tasks: "tasks.md",
+        },
+      },
+      target: input.target,
+    });
+  }
+
+  async importTrackFromOpenSpec(input: ImportTrackFromOpenSpecInput): Promise<{ track: Track; action: "created" | "updated" }> {
+    const adapter = this.requireOpenSpecAdapter();
+    const project = await this.ensureDefaultProject();
+    const imported = await adapter.importPackage({ source: input.source });
+    const timestamp = this.now();
+    const importedTrack = imported.package.track;
+    const existingTrack = await this.dependencies.trackRepository.getById(importedTrack.id);
+
+    const track: Track = {
+      ...importedTrack,
+      projectId: existingTrack?.projectId ?? importedTrack.projectId ?? project.id,
+      title: normalizeRequiredString(importedTrack.title),
+      description: normalizeRequiredString(importedTrack.description),
+      githubIssue: normalizeGitHubReference(importedTrack.githubIssue),
+      githubPullRequest: normalizeGitHubReference(importedTrack.githubPullRequest),
+      updatedAt: timestamp,
+      createdAt: existingTrack?.createdAt ?? importedTrack.createdAt ?? timestamp,
+    };
+
+    if (existingTrack) {
+      await this.dependencies.trackRepository.update(track);
+    } else {
+      await this.dependencies.trackRepository.create(track);
+    }
+
+    await this.dependencies.artifactWriter.write({
+      track,
+      project,
+      specContent: imported.package.artifacts.spec,
+      planContent: imported.package.artifacts.plan,
+      tasksContent: imported.package.artifacts.tasks,
+    });
+
+    return {
+      track,
+      action: existingTrack ? "updated" : "created",
+    };
   }
 
   async startRun(input: StartRunInput): Promise<Execution> {
@@ -812,6 +939,22 @@ export class SpecRailService {
 
     await this.dependencies.projectRepository.create(project);
     return project;
+  }
+
+  private requireOpenSpecAdapter(): OpenSpecAdapter {
+    if (!this.dependencies.openSpecAdapter) {
+      throw new Error("OpenSpec adapter is not configured");
+    }
+
+    return this.dependencies.openSpecAdapter;
+  }
+
+  private requireTrackArtifactReader(): TrackArtifactReader {
+    if (!this.dependencies.artifactReader) {
+      throw new Error("Track artifact reader is not configured");
+    }
+
+    return this.dependencies.artifactReader;
   }
 
   private renderDefaultSpec(track: Track): string {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -15,6 +15,10 @@ import type {
   Execution,
   ExecutionEvent,
   ExecutionStatus,
+  OpenSpecImportConflictPolicy,
+  OpenSpecImportRecord,
+  OpenSpecImportResolution,
+  OpenSpecImportResolutionChoice,
   GitHubIssueReference,
   GitHubPullRequestReference,
   GitHubRunCommentSyncState,
@@ -58,8 +62,6 @@ export interface OpenSpecImportSource {
   kind: "file";
   path: string;
 }
-
-export type OpenSpecImportConflictPolicy = "reject" | "overwrite";
 
 export interface OpenSpecExportTarget {
   kind: "file";
@@ -189,6 +191,7 @@ export interface ImportTrackFromOpenSpecInput {
   source: OpenSpecImportSource;
   dryRun?: boolean;
   conflictPolicy?: OpenSpecImportConflictPolicy;
+  resolution?: OpenSpecImportResolution;
 }
 
 export interface ImportTrackFromOpenSpecResult {
@@ -196,7 +199,9 @@ export interface ImportTrackFromOpenSpecResult {
   action: "created" | "updated";
   applied: boolean;
   conflictPolicy: OpenSpecImportConflictPolicy;
-  provenance: NonNullable<Track["openSpecImport"]>;
+  provenance: OpenSpecImportRecord;
+  importHistory: OpenSpecImportRecord[];
+  resolvedArtifacts: OpenSpecTrackArtifacts;
   conflict: {
     hasConflict: boolean;
     reason: "track_id_exists" | null;
@@ -207,6 +212,17 @@ export interface ImportTrackFromOpenSpecResult {
       incomingValue: unknown;
     }>;
   };
+}
+
+export interface OpenSpecImportHistoryListInput {
+  trackId?: string;
+  limit?: number;
+}
+
+export interface OpenSpecImportHistoryEntry {
+  trackId: string;
+  trackTitle: string;
+  provenance: OpenSpecImportRecord;
 }
 
 export type SortOrder = "asc" | "desc";
@@ -432,6 +448,65 @@ function buildOpenSpecConflictDetails(
   return details;
 }
 
+function pickResolvedValue<T>(incoming: T, existing: T, choice?: OpenSpecImportResolutionChoice): T {
+  return choice === "existing" ? existing : incoming;
+}
+
+function buildResolvedOpenSpecTrack(
+  existingTrack: Track | null,
+  importedTrack: Track,
+  projectId: string,
+  timestamp: string,
+  provenance: OpenSpecImportRecord,
+  resolution?: OpenSpecImportResolution,
+): Track {
+  const track = existingTrack
+    ? {
+        ...existingTrack,
+        ...importedTrack,
+      }
+    : importedTrack;
+
+  return {
+    ...track,
+    projectId: existingTrack?.projectId ?? importedTrack.projectId ?? projectId,
+    title: normalizeRequiredString(pickResolvedValue(importedTrack.title, existingTrack?.title ?? importedTrack.title, resolution?.track?.title)),
+    description: normalizeRequiredString(
+      pickResolvedValue(importedTrack.description, existingTrack?.description ?? importedTrack.description, resolution?.track?.description),
+    ),
+    status: pickResolvedValue(importedTrack.status, existingTrack?.status ?? importedTrack.status, resolution?.track?.status),
+    specStatus: pickResolvedValue(importedTrack.specStatus, existingTrack?.specStatus ?? importedTrack.specStatus, resolution?.track?.specStatus),
+    planStatus: pickResolvedValue(importedTrack.planStatus, existingTrack?.planStatus ?? importedTrack.planStatus, resolution?.track?.planStatus),
+    priority: pickResolvedValue(importedTrack.priority, existingTrack?.priority ?? importedTrack.priority, resolution?.track?.priority),
+    githubIssue: normalizeGitHubReference(
+      pickResolvedValue(importedTrack.githubIssue, existingTrack?.githubIssue ?? importedTrack.githubIssue, resolution?.track?.githubIssue),
+    ),
+    githubPullRequest: normalizeGitHubReference(
+      pickResolvedValue(
+        importedTrack.githubPullRequest,
+        existingTrack?.githubPullRequest ?? importedTrack.githubPullRequest,
+        resolution?.track?.githubPullRequest,
+      ),
+    ),
+    openSpecImport: provenance,
+    openSpecImportHistory: [...(existingTrack?.openSpecImportHistory ?? []), provenance],
+    updatedAt: timestamp,
+    createdAt: existingTrack?.createdAt ?? importedTrack.createdAt ?? timestamp,
+  };
+}
+
+function buildResolvedOpenSpecArtifacts(
+  importedArtifacts: OpenSpecTrackArtifacts,
+  existingArtifacts: OpenSpecTrackArtifacts | null,
+  resolution?: OpenSpecImportResolution,
+): OpenSpecTrackArtifacts {
+  return {
+    spec: pickResolvedValue(importedArtifacts.spec, existingArtifacts?.spec ?? importedArtifacts.spec, resolution?.artifacts?.spec),
+    plan: pickResolvedValue(importedArtifacts.plan, existingArtifacts?.plan ?? importedArtifacts.plan, resolution?.artifacts?.plan),
+    tasks: pickResolvedValue(importedArtifacts.tasks, existingArtifacts?.tasks ?? importedArtifacts.tasks, resolution?.artifacts?.tasks),
+  };
+}
+
 function listGitHubRunCommentTargets(track: Pick<Track, "githubIssue" | "githubPullRequest">): GitHubRunCommentSyncState["comments"][number]["target"][] {
   const targets = [] as GitHubRunCommentSyncState["comments"][number]["target"][];
 
@@ -538,6 +613,10 @@ export class SpecRailService {
 
     return {
       trackId: track.id,
+      openSpec: {
+        latestImport: track.openSpecImport ?? null,
+        importHistory: [...(track.openSpecImportHistory ?? [])].sort((left, right) => right.importedAt.localeCompare(left.importedAt)),
+      },
       github: {
         issue: track.githubIssue,
         pullRequest: track.githubPullRequest,
@@ -545,6 +624,36 @@ export class SpecRailService {
         summary: summarizeGitHubIntegration(track, githubRunCommentSync),
       },
     };
+  }
+
+  async getTrackOpenSpecImports(trackId: string): Promise<{ trackId: string; latestImport: OpenSpecImportRecord | null; importHistory: OpenSpecImportRecord[] } | null> {
+    const track = await this.dependencies.trackRepository.getById(trackId);
+    if (!track) {
+      return null;
+    }
+
+    return {
+      trackId: track.id,
+      latestImport: track.openSpecImport ?? null,
+      importHistory: [...(track.openSpecImportHistory ?? [])].sort((left, right) => right.importedAt.localeCompare(left.importedAt)),
+    };
+  }
+
+  async listOpenSpecImportHistory(input: OpenSpecImportHistoryListInput = {}): Promise<OpenSpecImportHistoryEntry[]> {
+    const tracks = input.trackId
+      ? [await this.dependencies.trackRepository.getById(input.trackId)].filter((track): track is Track => track !== null)
+      : await this.dependencies.trackRepository.list();
+
+    const entries = tracks.flatMap((track) =>
+      (track.openSpecImportHistory ?? []).map((provenance) => ({
+        trackId: track.id,
+        trackTitle: track.title,
+        provenance,
+      })),
+    );
+
+    entries.sort((left, right) => right.provenance.importedAt.localeCompare(left.provenance.importedAt));
+    return entries.slice(0, input.limit ?? entries.length);
   }
 
   async listTracks(input: ListTracksInput = {}): Promise<Track[]> {
@@ -650,10 +759,12 @@ export class SpecRailService {
     const existingArtifacts = existingTrack ? await artifactReader.read(existingTrack.id) : null;
     const conflictPolicy = input.conflictPolicy ?? "reject";
     const action = existingTrack ? "updated" : "created";
-    const provenance: NonNullable<Track["openSpecImport"]> = {
+    const provenance: OpenSpecImportRecord = {
+      id: `openspec-import-${this.idGenerator()}`,
       source: input.source,
       importedAt: timestamp,
       conflictPolicy,
+      ...(input.resolution ? { resolution: input.resolution } : {}),
       bundle: imported.package.metadata,
     };
     const conflict = {
@@ -662,17 +773,8 @@ export class SpecRailService {
       details: buildOpenSpecConflictDetails(existingTrack, importedTrack, imported.package.artifacts, existingArtifacts),
     };
 
-    const track: Track = {
-      ...importedTrack,
-      projectId: existingTrack?.projectId ?? importedTrack.projectId ?? project.id,
-      title: normalizeRequiredString(importedTrack.title),
-      description: normalizeRequiredString(importedTrack.description),
-      githubIssue: normalizeGitHubReference(importedTrack.githubIssue),
-      githubPullRequest: normalizeGitHubReference(importedTrack.githubPullRequest),
-      openSpecImport: provenance,
-      updatedAt: timestamp,
-      createdAt: existingTrack?.createdAt ?? importedTrack.createdAt ?? timestamp,
-    };
+    const resolvedArtifacts = buildResolvedOpenSpecArtifacts(imported.package.artifacts, existingArtifacts, input.resolution);
+    const track = buildResolvedOpenSpecTrack(existingTrack, importedTrack, project.id, timestamp, provenance, input.resolution);
 
     if (existingTrack && conflictPolicy === "reject") {
       if (input.dryRun) {
@@ -682,6 +784,8 @@ export class SpecRailService {
           applied: false,
           conflictPolicy,
           provenance,
+          importHistory: track.openSpecImportHistory ?? [],
+          resolvedArtifacts,
           conflict,
         };
       }
@@ -699,6 +803,8 @@ export class SpecRailService {
         applied: false,
         conflictPolicy,
         provenance,
+        importHistory: track.openSpecImportHistory ?? [],
+        resolvedArtifacts,
         conflict,
       };
     }
@@ -712,9 +818,9 @@ export class SpecRailService {
     await this.dependencies.artifactWriter.write({
       track,
       project,
-      specContent: imported.package.artifacts.spec,
-      planContent: imported.package.artifacts.plan,
-      tasksContent: imported.package.artifacts.tasks,
+      specContent: resolvedArtifacts.spec,
+      planContent: resolvedArtifacts.plan,
+      tasksContent: resolvedArtifacts.tasks,
     });
 
     return {
@@ -723,6 +829,8 @@ export class SpecRailService {
       applied: true,
       conflictPolicy,
       provenance,
+      importHistory: track.openSpecImportHistory ?? [],
+      resolvedArtifacts,
       conflict,
     };
   }

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -17,6 +17,7 @@ import type {
   ExecutionStatus,
   GitHubIssueReference,
   GitHubPullRequestReference,
+  GitHubRunCommentSyncState,
   Project,
   Track,
   TrackStatus,
@@ -27,6 +28,7 @@ import type {
   ExecutionRepository,
   GitHubRunCommentPublishResult,
   GitHubRunCommentPublisher,
+  GitHubRunCommentSyncStore,
   ProjectRepository,
   TrackRepository,
 } from "./ports.js";
@@ -88,6 +90,7 @@ export interface SpecRailServiceDependencies {
   };
   workspaceRoot: string;
   githubRunCommentPublisher?: GitHubRunCommentPublisher;
+  githubRunCommentSyncStore?: GitHubRunCommentSyncStore;
   now?: () => string;
   idGenerator?: () => string;
 }
@@ -272,6 +275,22 @@ function normalizeGitHubReference<T extends GitHubIssueReference | GitHubPullReq
     ...value,
     url: value.url.trim(),
   };
+}
+
+function listGitHubRunCommentTargets(track: Pick<Track, "githubIssue" | "githubPullRequest">): GitHubRunCommentSyncState["comments"][number]["target"][] {
+  const targets = [] as GitHubRunCommentSyncState["comments"][number]["target"][];
+
+  if (track.githubIssue) {
+    targets.push({ kind: "issue", number: track.githubIssue.number, url: track.githubIssue.url });
+  }
+
+  if (track.githubPullRequest) {
+    targets.push({ kind: "pull_request", number: track.githubPullRequest.number, url: track.githubPullRequest.url });
+  }
+
+  return targets.filter(
+    (target, index, all) => all.findIndex((candidate) => candidate.kind === target.kind && candidate.url === target.url) === index,
+  );
 }
 
 export class SpecRailService {
@@ -599,11 +618,63 @@ export class SpecRailService {
       return [];
     }
 
-    return this.dependencies.githubRunCommentPublisher.publishRunSummary({
-      track,
-      run: execution,
-      events: await this.dependencies.eventStore.listByExecution(execution.id),
-    });
+    const syncState = await this.dependencies.githubRunCommentSyncStore?.getByTrackId(track.id);
+    const events = await this.dependencies.eventStore.listByExecution(execution.id);
+    let results: GitHubRunCommentPublishResult[];
+
+    try {
+      results = await this.dependencies.githubRunCommentPublisher.publishRunSummary({
+        track,
+        run: execution,
+        events,
+        syncState: syncState ?? undefined,
+      });
+    } catch (error) {
+      if (this.dependencies.githubRunCommentSyncStore) {
+        const timestamp = this.now();
+        const previousComments = syncState?.comments ?? [];
+        await this.dependencies.githubRunCommentSyncStore.upsert({
+          id: track.id,
+          trackId: track.id,
+          updatedAt: timestamp,
+          comments: listGitHubRunCommentTargets(track).map((target) => {
+            const previous = previousComments.find((comment) => comment.target.kind === target.kind && comment.target.url === target.url);
+            return {
+              target,
+              commentId: previous?.commentId,
+              lastRunId: execution.id,
+              lastRunStatus: execution.status,
+              lastPublishedAt: previous?.lastPublishedAt ?? timestamp,
+              lastCommentBody: previous?.lastCommentBody,
+              lastSyncStatus: "failed" as const,
+              lastSyncError: error instanceof Error ? error.message : String(error),
+            };
+          }),
+        });
+      }
+
+      throw error;
+    }
+
+    if (this.dependencies.githubRunCommentSyncStore) {
+      const timestamp = this.now();
+      await this.dependencies.githubRunCommentSyncStore.upsert({
+        id: track.id,
+        trackId: track.id,
+        updatedAt: timestamp,
+        comments: results.map((result) => ({
+          target: result.target,
+          commentId: result.commentId,
+          lastRunId: execution.id,
+          lastRunStatus: execution.status,
+          lastPublishedAt: timestamp,
+          lastCommentBody: result.body,
+          lastSyncStatus: "success",
+        })),
+      } satisfies GitHubRunCommentSyncState);
+    }
+
+    return results;
   }
 
   private async requireRun(runId: string): Promise<Execution> {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -15,10 +15,16 @@ import type {
   Execution,
   ExecutionEvent,
   ExecutionStatus,
+  OpenSpecImportArtifactResolutionField,
   OpenSpecImportConflictPolicy,
   OpenSpecImportRecord,
   OpenSpecImportResolution,
   OpenSpecImportResolutionChoice,
+  OpenSpecImportResolutionGuide,
+  OpenSpecImportResolutionPreset,
+  OpenSpecImportResolutionPresetName,
+  OpenSpecImportTrackResolutionField,
+  OpenSpecSourceOfTruthPolicy,
   GitHubIssueReference,
   GitHubPullRequestReference,
   GitHubRunCommentSyncState,
@@ -39,6 +45,120 @@ import type {
   ProjectRepository,
   TrackRepository,
 } from "./ports.js";
+
+const OPENSPEC_TRACK_RESOLUTION_FIELDS = [
+  "title",
+  "description",
+  "status",
+  "specStatus",
+  "planStatus",
+  "priority",
+  "githubIssue",
+  "githubPullRequest",
+] as const satisfies readonly OpenSpecImportTrackResolutionField[];
+
+const OPENSPEC_ARTIFACT_RESOLUTION_FIELDS = ["spec", "plan", "tasks"] as const satisfies readonly OpenSpecImportArtifactResolutionField[];
+
+export const OPENSPEC_SOURCE_OF_TRUTH_POLICIES: OpenSpecSourceOfTruthPolicy[] = [
+  { group: "track", field: "title", sourceOfTruth: "openspec", defaultChoice: "incoming", rationale: "Imported bundle titles should describe the portable spec as authored." },
+  { group: "track", field: "description", sourceOfTruth: "openspec", defaultChoice: "incoming", rationale: "Bundle descriptions should travel with the imported spec context." },
+  { group: "track", field: "status", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "Execution workflow state belongs to the current SpecRail track lifecycle." },
+  { group: "track", field: "specStatus", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "Spec approval state reflects local review progress inside SpecRail." },
+  { group: "track", field: "planStatus", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "Plan approval state is managed by local operators during execution." },
+  { group: "track", field: "priority", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "Priority is treated as local operational triage in SpecRail." },
+  { group: "track", field: "githubIssue", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "GitHub linkage is tied to the active SpecRail workspace and should not shift silently." },
+  { group: "track", field: "githubPullRequest", sourceOfTruth: "specrail", defaultChoice: "existing", rationale: "Pull request linkage is local execution metadata, not portable bundle data." },
+  { group: "artifacts", field: "spec", sourceOfTruth: "openspec", defaultChoice: "incoming", rationale: "The imported bundle spec artifact is the portable source document." },
+  { group: "artifacts", field: "plan", sourceOfTruth: "openspec", defaultChoice: "incoming", rationale: "The imported bundle plan should normally replace the exported plan artifact." },
+  { group: "artifacts", field: "tasks", sourceOfTruth: "openspec", defaultChoice: "incoming", rationale: "Task breakdown in the imported bundle is treated as the portable source artifact." },
+];
+
+function buildPolicyDefaultResolution(): OpenSpecImportResolution {
+  return {
+    track: Object.fromEntries(
+      OPENSPEC_TRACK_RESOLUTION_FIELDS.map((field) => [field, OPENSPEC_SOURCE_OF_TRUTH_POLICIES.find((policy) => policy.group === "track" && policy.field === field)?.defaultChoice ?? "incoming"]),
+    ) as OpenSpecImportResolution["track"],
+    artifacts: Object.fromEntries(
+      OPENSPEC_ARTIFACT_RESOLUTION_FIELDS.map((field) => [field, OPENSPEC_SOURCE_OF_TRUTH_POLICIES.find((policy) => policy.group === "artifacts" && policy.field === field)?.defaultChoice ?? "incoming"]),
+    ) as OpenSpecImportResolution["artifacts"],
+  };
+}
+
+export const OPENSPEC_RESOLUTION_PRESETS: OpenSpecImportResolutionPreset[] = [
+  {
+    name: "policyDefaults",
+    label: "Policy defaults",
+    description: "Apply the built-in source-of-truth defaults: keep SpecRail workflow metadata, adopt incoming OpenSpec descriptive fields and artifacts.",
+    resolution: buildPolicyDefaultResolution(),
+  },
+  {
+    name: "preferIncomingArtifacts",
+    label: "Prefer incoming artifacts",
+    description: "Only force incoming spec/plan/tasks content. Other fields follow explicit overrides when supplied.",
+    resolution: { artifacts: { spec: "incoming", plan: "incoming", tasks: "incoming" } },
+  },
+  {
+    name: "preserveWorkflowState",
+    label: "Preserve workflow state",
+    description: "Keep SpecRail operational metadata such as workflow statuses, priority, and GitHub links.",
+    resolution: {
+      track: { status: "existing", specStatus: "existing", planStatus: "existing", priority: "existing", githubIssue: "existing", githubPullRequest: "existing" },
+    },
+  },
+  {
+    name: "preferIncomingAll",
+    label: "Prefer incoming everywhere",
+    description: "Resolve all track fields and artifacts in favor of the imported bundle.",
+    resolution: {
+      track: { title: "incoming", description: "incoming", status: "incoming", specStatus: "incoming", planStatus: "incoming", priority: "incoming", githubIssue: "incoming", githubPullRequest: "incoming" },
+      artifacts: { spec: "incoming", plan: "incoming", tasks: "incoming" },
+    },
+  },
+];
+
+function cloneResolution(resolution?: OpenSpecImportResolution): OpenSpecImportResolution {
+  return {
+    ...(resolution?.track ? { track: { ...resolution.track } } : {}),
+    ...(resolution?.artifacts ? { artifacts: { ...resolution.artifacts } } : {}),
+  };
+}
+
+function getResolutionPreset(name?: OpenSpecImportResolutionPresetName): OpenSpecImportResolutionPreset | null {
+  if (!name) {
+    return null;
+  }
+
+  return OPENSPEC_RESOLUTION_PRESETS.find((preset) => preset.name === name) ?? null;
+}
+
+function mergeOpenSpecResolution(
+  base: OpenSpecImportResolution | undefined,
+  override: OpenSpecImportResolution | undefined,
+): OpenSpecImportResolution {
+  return {
+    ...(base?.track || override?.track ? { track: { ...(base?.track ?? {}), ...(override?.track ?? {}) } } : {}),
+    ...(base?.artifacts || override?.artifacts ? { artifacts: { ...(base?.artifacts ?? {}), ...(override?.artifacts ?? {}) } } : {}),
+  };
+}
+
+function normalizeOpenSpecResolution(resolution?: OpenSpecImportResolution): OpenSpecImportResolution {
+  return mergeOpenSpecResolution(undefined, resolution);
+}
+
+function buildOpenSpecResolutionGuide(
+  resolutionPreset?: OpenSpecImportResolutionPresetName,
+  resolution?: OpenSpecImportResolution,
+): OpenSpecImportResolutionGuide {
+  const preset = getResolutionPreset(resolutionPreset);
+  const effectiveResolution = normalizeOpenSpecResolution(mergeOpenSpecResolution(preset?.resolution, resolution));
+
+  return {
+    presetApplied: preset?.name ?? null,
+    effectiveResolution,
+    policies: OPENSPEC_SOURCE_OF_TRUTH_POLICIES.map((policy) => ({ ...policy })),
+    presets: OPENSPEC_RESOLUTION_PRESETS.map((candidate) => ({ ...candidate, resolution: cloneResolution(candidate.resolution) })),
+  };
+}
 
 export interface TrackArtifactWriterInput {
   track: Track;
@@ -191,6 +311,7 @@ export interface ImportTrackFromOpenSpecInput {
   source: OpenSpecImportSource;
   dryRun?: boolean;
   conflictPolicy?: OpenSpecImportConflictPolicy;
+  resolutionPreset?: OpenSpecImportResolutionPresetName;
   resolution?: OpenSpecImportResolution;
 }
 
@@ -202,6 +323,7 @@ export interface ImportTrackFromOpenSpecResult {
   provenance: OpenSpecImportRecord;
   importHistory: OpenSpecImportRecord[];
   resolvedArtifacts: OpenSpecTrackArtifacts;
+  resolutionGuide: OpenSpecImportResolutionGuide;
   conflict: {
     hasConflict: boolean;
     reason: "track_id_exists" | null;
@@ -759,12 +881,14 @@ export class SpecRailService {
     const existingArtifacts = existingTrack ? await artifactReader.read(existingTrack.id) : null;
     const conflictPolicy = input.conflictPolicy ?? "reject";
     const action = existingTrack ? "updated" : "created";
+    const resolutionGuide = buildOpenSpecResolutionGuide(input.resolutionPreset, input.resolution);
     const provenance: OpenSpecImportRecord = {
       id: `openspec-import-${this.idGenerator()}`,
       source: input.source,
       importedAt: timestamp,
       conflictPolicy,
-      ...(input.resolution ? { resolution: input.resolution } : {}),
+      ...(resolutionGuide.presetApplied ? { resolutionPreset: resolutionGuide.presetApplied } : {}),
+      ...(Object.keys(resolutionGuide.effectiveResolution).length > 0 ? { resolution: resolutionGuide.effectiveResolution } : {}),
       bundle: imported.package.metadata,
     };
     const conflict = {
@@ -773,8 +897,8 @@ export class SpecRailService {
       details: buildOpenSpecConflictDetails(existingTrack, importedTrack, imported.package.artifacts, existingArtifacts),
     };
 
-    const resolvedArtifacts = buildResolvedOpenSpecArtifacts(imported.package.artifacts, existingArtifacts, input.resolution);
-    const track = buildResolvedOpenSpecTrack(existingTrack, importedTrack, project.id, timestamp, provenance, input.resolution);
+    const resolvedArtifacts = buildResolvedOpenSpecArtifacts(imported.package.artifacts, existingArtifacts, resolutionGuide.effectiveResolution);
+    const track = buildResolvedOpenSpecTrack(existingTrack, importedTrack, project.id, timestamp, provenance, resolutionGuide.effectiveResolution);
 
     if (existingTrack && conflictPolicy === "reject") {
       if (input.dryRun) {
@@ -786,6 +910,7 @@ export class SpecRailService {
           provenance,
           importHistory: track.openSpecImportHistory ?? [],
           resolvedArtifacts,
+          resolutionGuide,
           conflict,
         };
       }
@@ -805,6 +930,7 @@ export class SpecRailService {
         provenance,
         importHistory: track.openSpecImportHistory ?? [],
         resolvedArtifacts,
+        resolutionGuide,
         conflict,
       };
     }
@@ -831,6 +957,7 @@ export class SpecRailService {
       provenance,
       importHistory: track.openSpecImportHistory ?? [],
       resolvedArtifacts,
+      resolutionGuide,
       conflict,
     };
   }

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -19,7 +19,9 @@ import type {
   GitHubPullRequestReference,
   GitHubRunCommentSyncState,
   Project,
+  RunInspection,
   Track,
+  TrackInspection,
   TrackStatus,
 } from "../domain/types.js";
 import { NotFoundError } from "../errors.js";
@@ -336,6 +338,18 @@ export class SpecRailService {
     return this.dependencies.trackRepository.getById(trackId);
   }
 
+  async getTrackInspection(trackId: string): Promise<TrackInspection | null> {
+    const track = await this.dependencies.trackRepository.getById(trackId);
+    if (!track) {
+      return null;
+    }
+
+    return {
+      track,
+      githubRunCommentSync: (await this.dependencies.githubRunCommentSyncStore?.getByTrackId(track.id)) ?? null,
+    };
+  }
+
   async listTracks(input: ListTracksInput = {}): Promise<Track[]> {
     const result = await this.listTracksPage(input);
     return result.items;
@@ -518,6 +532,21 @@ export class SpecRailService {
 
   getRun(runId: string): Promise<Execution | null> {
     return this.dependencies.executionRepository.getById(runId);
+  }
+
+  async getRunInspection(runId: string): Promise<RunInspection | null> {
+    const run = await this.dependencies.executionRepository.getById(runId);
+    if (!run) {
+      return null;
+    }
+
+    const githubRunCommentSync = (await this.dependencies.githubRunCommentSyncStore?.getByTrackId(run.trackId)) ?? null;
+
+    return {
+      run,
+      githubRunCommentSync,
+      githubRunCommentSyncForRun: githubRunCommentSync?.comments.filter((comment) => comment.lastRunId === run.id) ?? [],
+    };
   }
 
   async listRuns(input: ListRunsInput = {}): Promise<Execution[]> {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -59,6 +59,8 @@ export interface OpenSpecImportSource {
   path: string;
 }
 
+export type OpenSpecImportConflictPolicy = "reject" | "overwrite";
+
 export interface OpenSpecExportTarget {
   kind: "file";
   path: string;
@@ -185,6 +187,19 @@ export interface ExportTrackToOpenSpecInput {
 
 export interface ImportTrackFromOpenSpecInput {
   source: OpenSpecImportSource;
+  dryRun?: boolean;
+  conflictPolicy?: OpenSpecImportConflictPolicy;
+}
+
+export interface ImportTrackFromOpenSpecResult {
+  track: Track;
+  action: "created" | "updated";
+  applied: boolean;
+  conflictPolicy: OpenSpecImportConflictPolicy;
+  conflict: {
+    hasConflict: boolean;
+    reason: "track_id_exists" | null;
+  };
 }
 
 export type SortOrder = "asc" | "desc";
@@ -544,13 +559,19 @@ export class SpecRailService {
     });
   }
 
-  async importTrackFromOpenSpec(input: ImportTrackFromOpenSpecInput): Promise<{ track: Track; action: "created" | "updated" }> {
+  async importTrackFromOpenSpec(input: ImportTrackFromOpenSpecInput): Promise<ImportTrackFromOpenSpecResult> {
     const adapter = this.requireOpenSpecAdapter();
     const project = await this.ensureDefaultProject();
     const imported = await adapter.importPackage({ source: input.source });
     const timestamp = this.now();
     const importedTrack = imported.package.track;
     const existingTrack = await this.dependencies.trackRepository.getById(importedTrack.id);
+    const conflictPolicy = input.conflictPolicy ?? "reject";
+    const action = existingTrack ? "updated" : "created";
+    const conflict = {
+      hasConflict: existingTrack !== null,
+      reason: existingTrack ? ("track_id_exists" as const) : null,
+    };
 
     const track: Track = {
       ...importedTrack,
@@ -562,6 +583,30 @@ export class SpecRailService {
       updatedAt: timestamp,
       createdAt: existingTrack?.createdAt ?? importedTrack.createdAt ?? timestamp,
     };
+
+    if (existingTrack && conflictPolicy === "reject") {
+      if (input.dryRun) {
+        return {
+          track,
+          action,
+          applied: false,
+          conflictPolicy,
+          conflict,
+        };
+      }
+
+      throw new ConflictError(`OpenSpec import would overwrite existing track: ${track.id}. Retry with conflictPolicy=overwrite or dryRun=true.`);
+    }
+
+    if (input.dryRun) {
+      return {
+        track,
+        action,
+        applied: false,
+        conflictPolicy,
+        conflict,
+      };
+    }
 
     if (existingTrack) {
       await this.dependencies.trackRepository.update(track);
@@ -579,7 +624,10 @@ export class SpecRailService {
 
     return {
       track,
-      action: existingTrack ? "updated" : "created",
+      action,
+      applied: true,
+      conflictPolicy,
+      conflict,
     };
   }
 

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -196,9 +196,16 @@ export interface ImportTrackFromOpenSpecResult {
   action: "created" | "updated";
   applied: boolean;
   conflictPolicy: OpenSpecImportConflictPolicy;
+  provenance: NonNullable<Track["openSpecImport"]>;
   conflict: {
     hasConflict: boolean;
     reason: "track_id_exists" | null;
+    details: Array<{
+      field: string;
+      message: string;
+      existingValue: unknown;
+      incomingValue: unknown;
+    }>;
   };
 }
 
@@ -350,6 +357,79 @@ function normalizeGitHubReference<T extends GitHubIssueReference | GitHubPullReq
     ...value,
     url: value.url.trim(),
   };
+}
+
+function summarizeComparableValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+
+  return value;
+}
+
+function normalizeTrackForConflictComparison(track: Track): Record<string, unknown> {
+  return {
+    title: track.title,
+    description: track.description,
+    status: track.status,
+    specStatus: track.specStatus,
+    planStatus: track.planStatus,
+    priority: track.priority,
+    githubIssue: summarizeComparableValue(track.githubIssue),
+    githubPullRequest: summarizeComparableValue(track.githubPullRequest),
+  };
+}
+
+function buildOpenSpecConflictDetails(
+  existingTrack: Track | null,
+  incomingTrack: Track,
+  importedArtifacts: OpenSpecTrackArtifacts,
+  existingArtifacts: OpenSpecTrackArtifacts | null,
+): ImportTrackFromOpenSpecResult["conflict"]["details"] {
+  if (!existingTrack) {
+    return [];
+  }
+
+  const details: ImportTrackFromOpenSpecResult["conflict"]["details"] = [
+    {
+      field: "track.id",
+      message: "An existing track with the same id would be updated.",
+      existingValue: existingTrack.id,
+      incomingValue: incomingTrack.id,
+    },
+  ];
+
+  const existingComparable = normalizeTrackForConflictComparison(existingTrack);
+  const incomingComparable = normalizeTrackForConflictComparison(incomingTrack);
+
+  for (const field of Object.keys(incomingComparable)) {
+    const existingValue = existingComparable[field];
+    const incomingValue = incomingComparable[field];
+
+    if (JSON.stringify(existingValue) !== JSON.stringify(incomingValue)) {
+      details.push({
+        field: `track.${field}`,
+        message: `Import would replace track ${field}.`,
+        existingValue,
+        incomingValue,
+      });
+    }
+  }
+
+  if (existingArtifacts) {
+    for (const field of ["spec", "plan", "tasks"] as const) {
+      if (existingArtifacts[field] !== importedArtifacts[field]) {
+        details.push({
+          field: `artifacts.${field}`,
+          message: `Import would replace ${field}.md content.`,
+          existingValue: { length: existingArtifacts[field].length },
+          incomingValue: { length: importedArtifacts[field].length },
+        });
+      }
+    }
+  }
+
+  return details;
 }
 
 function listGitHubRunCommentTargets(track: Pick<Track, "githubIssue" | "githubPullRequest">): GitHubRunCommentSyncState["comments"][number]["target"][] {
@@ -562,15 +642,24 @@ export class SpecRailService {
   async importTrackFromOpenSpec(input: ImportTrackFromOpenSpecInput): Promise<ImportTrackFromOpenSpecResult> {
     const adapter = this.requireOpenSpecAdapter();
     const project = await this.ensureDefaultProject();
+    const artifactReader = this.requireTrackArtifactReader();
     const imported = await adapter.importPackage({ source: input.source });
     const timestamp = this.now();
     const importedTrack = imported.package.track;
     const existingTrack = await this.dependencies.trackRepository.getById(importedTrack.id);
+    const existingArtifacts = existingTrack ? await artifactReader.read(existingTrack.id) : null;
     const conflictPolicy = input.conflictPolicy ?? "reject";
     const action = existingTrack ? "updated" : "created";
+    const provenance: NonNullable<Track["openSpecImport"]> = {
+      source: input.source,
+      importedAt: timestamp,
+      conflictPolicy,
+      bundle: imported.package.metadata,
+    };
     const conflict = {
       hasConflict: existingTrack !== null,
       reason: existingTrack ? ("track_id_exists" as const) : null,
+      details: buildOpenSpecConflictDetails(existingTrack, importedTrack, imported.package.artifacts, existingArtifacts),
     };
 
     const track: Track = {
@@ -580,6 +669,7 @@ export class SpecRailService {
       description: normalizeRequiredString(importedTrack.description),
       githubIssue: normalizeGitHubReference(importedTrack.githubIssue),
       githubPullRequest: normalizeGitHubReference(importedTrack.githubPullRequest),
+      openSpecImport: provenance,
       updatedAt: timestamp,
       createdAt: existingTrack?.createdAt ?? importedTrack.createdAt ?? timestamp,
     };
@@ -591,11 +681,15 @@ export class SpecRailService {
           action,
           applied: false,
           conflictPolicy,
+          provenance,
           conflict,
         };
       }
 
-      throw new ConflictError(`OpenSpec import would overwrite existing track: ${track.id}. Retry with conflictPolicy=overwrite or dryRun=true.`);
+      throw new ConflictError(
+        `OpenSpec import would overwrite existing track: ${track.id}. Retry with conflictPolicy=overwrite or dryRun=true.`,
+        conflict.details,
+      );
     }
 
     if (input.dryRun) {
@@ -604,6 +698,7 @@ export class SpecRailService {
         action,
         applied: false,
         conflictPolicy,
+        provenance,
         conflict,
       };
     }
@@ -627,6 +722,7 @@ export class SpecRailService {
       action,
       applied: true,
       conflictPolicy,
+      provenance,
       conflict,
     };
   }

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -21,6 +21,10 @@ import type {
   OpenSpecImportResolution,
   OpenSpecImportResolutionChoice,
   OpenSpecImportResolutionGuide,
+  OpenSpecImportOperatorGuide,
+  OpenSpecImportOperatorChoiceSummary,
+  OpenSpecImportOperatorExample,
+  OpenSpecImportPresetSummary,
   OpenSpecImportResolutionPreset,
   OpenSpecImportResolutionPresetName,
   OpenSpecImportTrackResolutionField,
@@ -116,6 +120,38 @@ export const OPENSPEC_RESOLUTION_PRESETS: OpenSpecImportResolutionPreset[] = [
   },
 ];
 
+const OPENSPEC_CONFLICT_POLICY_GUIDANCE: OpenSpecImportOperatorGuide["conflictPolicies"] = [
+  {
+    name: "reject",
+    label: "Preview first",
+    description: "Safe default. Use dryRun=true to inspect conflicts before writing anything.",
+  },
+  {
+    name: "overwrite",
+    label: "Replace everything",
+    description: "Apply the imported bundle directly when you trust it as the new source of truth.",
+  },
+  {
+    name: "resolve",
+    label: "Preset + overrides",
+    description: "Start from a named preset, then keep specific existing fields or artifacts when needed.",
+  },
+];
+
+const OPENSPEC_FIELD_LABELS: Record<string, string> = {
+  title: "Track title",
+  description: "Track description",
+  status: "Workflow status",
+  specStatus: "Spec approval",
+  planStatus: "Plan approval",
+  priority: "Priority",
+  githubIssue: "GitHub issue link",
+  githubPullRequest: "GitHub pull request link",
+  spec: "Spec artifact",
+  plan: "Plan artifact",
+  tasks: "Tasks artifact",
+};
+
 function cloneResolution(resolution?: OpenSpecImportResolution): OpenSpecImportResolution {
   return {
     ...(resolution?.track ? { track: { ...resolution.track } } : {}),
@@ -158,6 +194,109 @@ function buildOpenSpecResolutionGuide(
     policies: OPENSPEC_SOURCE_OF_TRUTH_POLICIES.map((policy) => ({ ...policy })),
     presets: OPENSPEC_RESOLUTION_PRESETS.map((candidate) => ({ ...candidate, resolution: cloneResolution(candidate.resolution) })),
   };
+}
+
+function getEffectiveResolutionChoice(
+  guide: OpenSpecImportResolutionGuide,
+  policy: OpenSpecSourceOfTruthPolicy,
+): OpenSpecImportResolutionChoice {
+  const groupResolution = guide.effectiveResolution[policy.group];
+  const choice = groupResolution?.[policy.field as keyof typeof groupResolution];
+  return choice ?? policy.defaultChoice;
+}
+
+function buildOperatorChoiceSummaries(guide: OpenSpecImportResolutionGuide): OpenSpecImportOperatorChoiceSummary[] {
+  return guide.policies.map((policy) => ({
+    group: policy.group,
+    field: policy.field,
+    label: OPENSPEC_FIELD_LABELS[policy.field] ?? policy.field,
+    choice: getEffectiveResolutionChoice(guide, policy),
+    sourceOfTruth: policy.sourceOfTruth,
+    rationale: policy.rationale,
+  }));
+}
+
+function summarizePreset(preset: OpenSpecImportResolutionPreset, guide: OpenSpecImportResolutionGuide): OpenSpecImportPresetSummary {
+  const presetGuide = buildOpenSpecResolutionGuide(preset.name);
+  const choices = buildOperatorChoiceSummaries(presetGuide);
+  return {
+    name: preset.name,
+    label: preset.label,
+    description: preset.description,
+    highlights: [
+      `${preset.label} keeps ${choices.filter((choice) => choice.choice === "existing").length} fields/artifacts from SpecRail.`,
+      `${preset.label} takes ${choices.filter((choice) => choice.choice === "incoming").length} fields/artifacts from the imported bundle.`,
+      guide.presetApplied === preset.name ? "Currently selected for this import request." : "Available as an import preset.",
+    ],
+    choices,
+  };
+}
+
+function buildOpenSpecOperatorExamples(): OpenSpecImportOperatorExample[] {
+  return [
+    {
+      id: "reject-preview",
+      label: "Preview before applying",
+      description: "Inspect the bundle and conflict details without writing track state or artifacts.",
+      request: { dryRun: true, conflictPolicy: "reject" },
+      explanation: [
+        "Use this first when operators need to see what will change.",
+        "If conflicts appear, keep the same path and retry with overwrite or resolve.",
+      ],
+    },
+    {
+      id: "overwrite-apply",
+      label: "Apply the bundle as-is",
+      description: "Replace the current track/artifacts with the imported bundle when the incoming package should win.",
+      request: { conflictPolicy: "overwrite", resolutionPreset: "preferIncomingAll" },
+      explanation: [
+        "This is the fastest apply flow once preview looks correct.",
+        "Useful for restoring or syncing a track from a trusted OpenSpec export.",
+      ],
+    },
+    {
+      id: "policy-defaults-resolve",
+      label: "Use policy defaults",
+      description: "Keep SpecRail workflow metadata while taking imported descriptive fields and artifacts.",
+      request: { conflictPolicy: "resolve", resolutionPreset: "policyDefaults" },
+      explanation: [
+        "Good operator default when importing work into an active SpecRail track.",
+        "Statuses, priority, and GitHub links stay local unless you explicitly override them.",
+      ],
+    },
+    {
+      id: "preset-with-override",
+      label: "Start from a preset, then override one field",
+      description: "Combine a named preset with explicit exceptions for the fields that should stay local.",
+      request: { conflictPolicy: "resolve", resolutionPreset: "policyDefaults", resolution: { artifacts: { plan: "existing" } } },
+      explanation: [
+        "Operators can reuse a preset instead of building a full resolution map every time.",
+        "Explicit resolution entries override the preset only where needed.",
+      ],
+    },
+  ];
+}
+
+function buildOpenSpecImportOperatorGuide(guide: OpenSpecImportResolutionGuide): OpenSpecImportOperatorGuide {
+  return {
+    recommendedFlow: [
+      "Preview with dryRun=true first.",
+      "Pick a named preset that matches the workflow you want.",
+      "Add explicit resolution overrides only for the fields that should behave differently.",
+      "Retry with conflictPolicy=resolve or overwrite once the preview looks right.",
+    ],
+    conflictPolicies: OPENSPEC_CONFLICT_POLICY_GUIDANCE.map((policy) => ({ ...policy })),
+    selectedPreset: guide.presetApplied ? summarizePreset(getResolutionPreset(guide.presetApplied) ?? OPENSPEC_RESOLUTION_PRESETS[0], guide) : null,
+    effectiveChoices: buildOperatorChoiceSummaries(guide),
+    examples: buildOpenSpecOperatorExamples(),
+  };
+}
+
+export function getOpenSpecImportOperatorGuide(input?: {
+  resolutionPreset?: OpenSpecImportResolutionPresetName;
+  resolution?: OpenSpecImportResolution;
+}): OpenSpecImportOperatorGuide {
+  return buildOpenSpecImportOperatorGuide(buildOpenSpecResolutionGuide(input?.resolutionPreset, input?.resolution));
 }
 
 export interface TrackArtifactWriterInput {
@@ -324,6 +463,7 @@ export interface ImportTrackFromOpenSpecResult {
   importHistory: OpenSpecImportRecord[];
   resolvedArtifacts: OpenSpecTrackArtifacts;
   resolutionGuide: OpenSpecImportResolutionGuide;
+  operatorGuide: OpenSpecImportOperatorGuide;
   conflict: {
     hasConflict: boolean;
     reason: "track_id_exists" | null;
@@ -761,6 +901,13 @@ export class SpecRailService {
     };
   }
 
+  getOpenSpecImportHelp(input?: {
+    resolutionPreset?: OpenSpecImportResolutionPresetName;
+    resolution?: OpenSpecImportResolution;
+  }): OpenSpecImportOperatorGuide {
+    return getOpenSpecImportOperatorGuide(input);
+  }
+
   async listOpenSpecImportHistory(input: OpenSpecImportHistoryListInput = {}): Promise<OpenSpecImportHistoryEntry[]> {
     const tracks = input.trackId
       ? [await this.dependencies.trackRepository.getById(input.trackId)].filter((track): track is Track => track !== null)
@@ -882,6 +1029,7 @@ export class SpecRailService {
     const conflictPolicy = input.conflictPolicy ?? "reject";
     const action = existingTrack ? "updated" : "created";
     const resolutionGuide = buildOpenSpecResolutionGuide(input.resolutionPreset, input.resolution);
+    const operatorGuide = buildOpenSpecImportOperatorGuide(resolutionGuide);
     const provenance: OpenSpecImportRecord = {
       id: `openspec-import-${this.idGenerator()}`,
       source: input.source,
@@ -911,6 +1059,7 @@ export class SpecRailService {
           importHistory: track.openSpecImportHistory ?? [],
           resolvedArtifacts,
           resolutionGuide,
+          operatorGuide,
           conflict,
         };
       }
@@ -931,6 +1080,7 @@ export class SpecRailService {
         importHistory: track.openSpecImportHistory ?? [],
         resolvedArtifacts,
         resolutionGuide,
+        operatorGuide,
         conflict,
       };
     }
@@ -958,6 +1108,7 @@ export class SpecRailService {
       importHistory: track.openSpecImportHistory ?? [],
       resolvedArtifacts,
       resolutionGuide,
+      operatorGuide,
       conflict,
     };
   }

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -22,7 +22,14 @@ import type {
   TrackStatus,
 } from "../domain/types.js";
 import { NotFoundError } from "../errors.js";
-import type { EventStore, ExecutionRepository, ProjectRepository, TrackRepository } from "./ports.js";
+import type {
+  EventStore,
+  ExecutionRepository,
+  GitHubRunCommentPublishResult,
+  GitHubRunCommentPublisher,
+  ProjectRepository,
+  TrackRepository,
+} from "./ports.js";
 
 export interface TrackArtifactWriterInput {
   track: Track;
@@ -80,6 +87,7 @@ export interface SpecRailServiceDependencies {
     defaultWorkflowPolicy?: string;
   };
   workspaceRoot: string;
+  githubRunCommentPublisher?: GitHubRunCommentPublisher;
   now?: () => string;
   idGenerator?: () => string;
 }
@@ -416,7 +424,8 @@ export class SpecRailService {
       await this.dependencies.eventStore.listByExecution(executionId),
     );
     await this.dependencies.executionRepository.update(execution);
-    await this.reconcileTrackStatusFromRun(track.id, execution);
+    const nextTrack = await this.reconcileTrackStatusFromRun(track.id, execution);
+    await this.publishRunSummaryForExecution(nextTrack ?? track, execution);
 
     return execution;
   }
@@ -455,7 +464,8 @@ export class SpecRailService {
       await this.dependencies.eventStore.listByExecution(execution.id),
     );
     await this.dependencies.executionRepository.update(reconciledExecution);
-    await this.reconcileTrackStatusFromRun(reconciledExecution.trackId, reconciledExecution);
+    const track = await this.reconcileTrackStatusFromRun(reconciledExecution.trackId, reconciledExecution);
+    await this.publishRunSummaryForExecution(track, reconciledExecution);
 
     return reconciledExecution;
   }
@@ -481,7 +491,8 @@ export class SpecRailService {
       await this.dependencies.eventStore.listByExecution(execution.id),
     );
     await this.dependencies.executionRepository.update(cancelledExecution);
-    await this.reconcileTrackStatusFromRun(cancelledExecution.trackId, cancelledExecution);
+    const track = await this.reconcileTrackStatusFromRun(cancelledExecution.trackId, cancelledExecution);
+    await this.publishRunSummaryForExecution(track, cancelledExecution);
 
     return cancelledExecution;
   }
@@ -543,24 +554,55 @@ export class SpecRailService {
       await this.dependencies.eventStore.listByExecution(event.executionId),
     );
     await this.dependencies.executionRepository.update(reconciledExecution);
-    await this.reconcileTrackStatusFromRun(reconciledExecution.trackId, reconciledExecution);
+    const track = await this.reconcileTrackStatusFromRun(reconciledExecution.trackId, reconciledExecution);
+    await this.publishRunSummaryForExecution(track, reconciledExecution);
   }
 
-  private async reconcileTrackStatusFromRun(trackId: string, execution: Execution): Promise<void> {
-    const nextStatus = mapTrackStatusFromExecution(execution.status);
-    if (!nextStatus) {
-      return;
+  async publishRunSummary(runId: string): Promise<GitHubRunCommentPublishResult[]> {
+    const execution = await this.requireRun(runId);
+    const track = await this.dependencies.trackRepository.getById(execution.trackId);
+
+    if (!track) {
+      throw new NotFoundError(`Track not found: ${execution.trackId}`);
     }
 
+    return this.publishRunSummaryForExecution(track, execution);
+  }
+
+  private async reconcileTrackStatusFromRun(trackId: string, execution: Execution): Promise<Track | undefined> {
     const track = await this.dependencies.trackRepository.getById(trackId);
-    if (!track || track.status === nextStatus) {
-      return;
+    if (!track) {
+      return undefined;
     }
 
-    await this.dependencies.trackRepository.update({
+    const nextStatus = mapTrackStatusFromExecution(execution.status);
+    if (!nextStatus || track.status === nextStatus) {
+      return track;
+    }
+
+    const updatedTrack = {
       ...track,
       status: nextStatus,
       updatedAt: execution.finishedAt ?? this.now(),
+    };
+
+    await this.dependencies.trackRepository.update(updatedTrack);
+    return updatedTrack;
+  }
+
+  private async publishRunSummaryForExecution(track: Track | undefined, execution: Execution): Promise<GitHubRunCommentPublishResult[]> {
+    if (!track || !this.dependencies.githubRunCommentPublisher) {
+      return [];
+    }
+
+    if (!track.githubIssue && !track.githubPullRequest) {
+      return [];
+    }
+
+    return this.dependencies.githubRunCommentPublisher.publishRunSummary({
+      track,
+      run: execution,
+      events: await this.dependencies.eventStore.listByExecution(execution.id),
     });
   }
 

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -25,7 +25,7 @@ import type {
   TrackIntegrationsInspection,
   TrackStatus,
 } from "../domain/types.js";
-import { NotFoundError } from "../errors.js";
+import { ConflictError, NotFoundError } from "../errors.js";
 import type {
   EventStore,
   ExecutionRepository,
@@ -660,6 +660,37 @@ export class SpecRailService {
     }
 
     return this.publishRunSummaryForExecution(track, execution);
+  }
+
+  async retryGitHubRunCommentSync(trackId: string): Promise<{ runId: string; results: GitHubRunCommentPublishResult[] }> {
+    const track = await this.dependencies.trackRepository.getById(trackId);
+
+    if (!track) {
+      throw new NotFoundError(`Track not found: ${trackId}`);
+    }
+
+    const syncState = await this.dependencies.githubRunCommentSyncStore?.getByTrackId(track.id);
+    const failedComments = syncState?.comments.filter((comment) => comment.lastSyncStatus === "failed") ?? [];
+
+    if (failedComments.length === 0) {
+      throw new ConflictError(`Track does not have any failed GitHub run comment syncs: ${track.id}`);
+    }
+
+    const retryCandidate = failedComments
+      .slice()
+      .sort((left, right) => {
+        const published = right.lastPublishedAt.localeCompare(left.lastPublishedAt);
+        return published || right.lastRunId.localeCompare(left.lastRunId);
+      })[0];
+
+    if (!retryCandidate) {
+      throw new ConflictError(`Track does not have any retryable GitHub run comment syncs: ${track.id}`);
+    }
+
+    return {
+      runId: retryCandidate.lastRunId,
+      results: await this.publishRunSummary(retryCandidate.lastRunId),
+    };
   }
 
   private async reconcileTrackStatusFromRun(trackId: string, execution: Execution): Promise<Track | undefined> {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -15,6 +15,8 @@ import type {
   Execution,
   ExecutionEvent,
   ExecutionStatus,
+  GitHubIssueReference,
+  GitHubPullRequestReference,
   Project,
   Track,
   TrackStatus,
@@ -86,6 +88,8 @@ export interface CreateTrackInput {
   title: string;
   description: string;
   priority?: Track["priority"];
+  githubIssue?: GitHubIssueReference;
+  githubPullRequest?: GitHubPullRequestReference;
 }
 
 export interface StartRunInput {
@@ -99,6 +103,8 @@ export interface UpdateTrackInput {
   status?: TrackStatus;
   specStatus?: ApprovalStatus;
   planStatus?: ApprovalStatus;
+  githubIssue?: GitHubIssueReference;
+  githubPullRequest?: GitHubPullRequestReference;
 }
 
 export interface ResumeRunInput {
@@ -249,6 +255,17 @@ function normalizeProfile(value: string | undefined): string {
   return trimmed ? trimmed : "default";
 }
 
+function normalizeGitHubReference<T extends GitHubIssueReference | GitHubPullRequestReference>(value: T | undefined): T | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return {
+    ...value,
+    url: value.url.trim(),
+  };
+}
+
 export class SpecRailService {
   private readonly now: () => string;
   private readonly idGenerator: () => string;
@@ -266,6 +283,8 @@ export class SpecRailService {
       projectId: project.id,
       title: normalizeRequiredString(input.title),
       description: normalizeRequiredString(input.description),
+      githubIssue: normalizeGitHubReference(input.githubIssue),
+      githubPullRequest: normalizeGitHubReference(input.githubPullRequest),
       status: "new",
       specStatus: "draft",
       planStatus: "draft",
@@ -340,6 +359,9 @@ export class SpecRailService {
       status: input.status ?? track.status,
       specStatus: input.specStatus ?? track.specStatus,
       planStatus: input.planStatus ?? track.planStatus,
+      githubIssue: input.githubIssue === undefined ? track.githubIssue : normalizeGitHubReference(input.githubIssue),
+      githubPullRequest:
+        input.githubPullRequest === undefined ? track.githubPullRequest : normalizeGitHubReference(input.githubPullRequest),
       updatedAt: this.now(),
     };
 

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -22,6 +22,7 @@ import type {
   RunInspection,
   Track,
   TrackInspection,
+  TrackIntegrationsInspection,
   TrackStatus,
 } from "../domain/types.js";
 import { NotFoundError } from "../errors.js";
@@ -295,6 +296,31 @@ function listGitHubRunCommentTargets(track: Pick<Track, "githubIssue" | "githubP
   );
 }
 
+function summarizeGitHubIntegration(
+  track: Pick<Track, "githubIssue" | "githubPullRequest">,
+  syncState: GitHubRunCommentSyncState | null,
+): TrackIntegrationsInspection["github"]["summary"] {
+  const linkedTargetCount = listGitHubRunCommentTargets(track).length;
+  const syncedTargetCount = syncState?.comments.length ?? 0;
+
+  if (!syncState || syncState.comments.length === 0) {
+    return { linkedTargetCount, syncedTargetCount };
+  }
+
+  const sortedComments = [...syncState.comments].sort((left, right) => right.lastPublishedAt.localeCompare(left.lastPublishedAt));
+  const lastComment = sortedComments[0];
+  const statuses = new Set(syncState.comments.map((comment) => comment.lastSyncStatus));
+  const lastErrorComment = sortedComments.find((comment) => comment.lastSyncError);
+
+  return {
+    linkedTargetCount,
+    syncedTargetCount,
+    lastPublishedAt: lastComment?.lastPublishedAt,
+    lastSyncStatus: statuses.size > 1 ? "mixed" : lastComment?.lastSyncStatus,
+    ...(lastErrorComment?.lastSyncError ? { lastSyncError: lastErrorComment.lastSyncError } : {}),
+  };
+}
+
 export class SpecRailService {
   private readonly now: () => string;
   private readonly idGenerator: () => string;
@@ -347,6 +373,25 @@ export class SpecRailService {
     return {
       track,
       githubRunCommentSync: (await this.dependencies.githubRunCommentSyncStore?.getByTrackId(track.id)) ?? null,
+    };
+  }
+
+  async getTrackIntegrationsInspection(trackId: string): Promise<TrackIntegrationsInspection | null> {
+    const track = await this.dependencies.trackRepository.getById(trackId);
+    if (!track) {
+      return null;
+    }
+
+    const githubRunCommentSync = (await this.dependencies.githubRunCommentSyncStore?.getByTrackId(track.id)) ?? null;
+
+    return {
+      trackId: track.id,
+      github: {
+        issue: track.githubIssue,
+        pullRequest: track.githubPullRequest,
+        runCommentSync: githubRunCommentSync,
+        summary: summarizeGitHubIntegration(track, githubRunCommentSync),
+      },
     };
   }
 


### PR DESCRIPTION
Bring forward the pending GitHub run summary sync and OpenSpec admin/history work from the legacy branch.\n\nNote: this branch predates recent main work and may require significant conflict resolution before merge.