### PR TITLE
fix: normalize execution profile once during run start

### DIFF
--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -732,13 +732,12 @@ export class SpecRailService {
     }
 
     const executor = this.resolveExecutor(input.backend);
-    const profile = this.resolveExecutionProfile(input.profile);
     const planningContext = await this.resolvePlanningContextForStart(track, input.planningSessionId);
     const executionId = `run-${this.idGenerator()}`;
     const createdAt = this.now();
     const workspacePath = path.join(this.dependencies.workspaceRoot, executionId);
     const prompt = normalizeRequiredString(input.prompt);
-    const profile = normalizeProfile(input.profile);
+    const profile = normalizeProfile(this.resolveExecutionProfile(input.profile));
     await mkdir(workspacePath, { recursive: true });
 
     const launch = await executor.spawn({


### PR DESCRIPTION
## Summary\n- remove duplicate profile declarations during run start\n- keep prompt/profile normalization in a single path\n\n## Testing\n- pnpm test\n\nThis unblocks current main and follow-up integration work.