### PR TITLE
chore: ignore temporary issue drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 coverage
 .tmp
 .specrail-data
+
+# Local issue draft scratch files
+.tmp-issue-*.md


### PR DESCRIPTION
## Summary
- ignore local `.tmp-issue-*.md` planning draft files
- keep generated issue-body scratch files out of `git status`

## Validation
- pnpm check
- git status --short

Closes #89