### PR TITLE
chore: add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+* text=auto eol=lf
+
+# Source and project metadata
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.toml text eol=lf
+
+# Images and icons
+*.ico binary
+*.icns binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.svg text eol=lf
+
+# Archives and packaged artifacts
+*.zip binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.gz binary
+*.dmg binary
+
+# Fonts and media
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp3 binary
+*.mp4 binary
+*.mov binary
+
+# Local databases, caches, and logs
+*.sqlite binary
+*.sqlite3 binary
+*.db binary
+*.log text eol=lf


### PR DESCRIPTION
## Summary
- add root `.gitattributes` for line ending normalization
- keep source/docs/config/scripts normalized to LF
- mark common binary assets, archives, media, and local database files as binary

## Validation
- pnpm check
- gitattributes baseline script

Closes #99