### PR TITLE
chore: add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a reproducible SpecRail problem
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please include enough context for someone to reproduce it locally.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Which SpecRail area is affected?
+      options:
+        - Core domain/service
+        - File-backed persistence
+        - HTTP API or SSE
+        - Executor adapter - Codex
+        - Executor adapter - Claude Code
+        - ACP server
+        - Terminal client
+        - Telegram adapter
+        - OpenSpec/GitHub integration
+        - CI/process/docs
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Briefly describe the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest reliable reproduction steps.
+      placeholder: |
+        1. Run ...
+        2. Call ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: Contract impact
+      description: Does this affect API responses, execution events, persistence layout, or external adapter behavior?
+      placeholder: Describe known contract impact, or write "none/unsure".
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation context
+      description: Commands, logs, environment, or versions that help diagnose the issue.
+      placeholder: |
+        - Command:
+        - Relevant output:
+        - Node/pnpm version:
+        - Provider/backend profile:
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Reporter checks
+      options:
+        - label: I searched existing issues/PRs for duplicates.
+          required: false
+        - label: I included relevant logs or command output when available.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,87 @@
+name: Feature or follow-up request
+description: Propose a SpecRail improvement or implementation follow-up
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for API, core, adapter, ACP, terminal, Telegram, CI, docs, or process follow-ups.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Target surface
+      description: Which SpecRail area should this change target?
+      options:
+        - Core domain/service
+        - File-backed persistence
+        - HTTP API or SSE
+        - Executor adapter - Codex
+        - Executor adapter - Claude Code
+        - ACP server
+        - Terminal client
+        - Telegram adapter
+        - OpenSpec/GitHub integration
+        - CI/process/docs
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What user, operator, or maintenance problem should this solve?
+      placeholder: Describe the friction, missing capability, or follow-up need.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should change?
+      placeholder: Describe the intended behavior or implementation direction.
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: Contract impact
+      description: Will this affect API responses, execution events, persistence layout, or external adapter behavior?
+      placeholder: Describe expected contract changes, or write "none/unsure".
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this issue is complete?
+      placeholder: |
+        - ...
+        - ...
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Suggested validation
+      description: Which checks or manual verification should cover this work?
+      placeholder: |
+        - pnpm check
+        - pnpm test
+        - pnpm build
+        - pnpm test:claude-smoke (if provider credentials are available)
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Requester checks
+      options:
+        - label: I searched existing issues/PRs for duplicates.
+          required: false
+        - label: I noted any API/event/persistence contract impact above.
+          required: false


### PR DESCRIPTION
## Summary
- add GitHub issue forms for bug reports and feature/follow-up requests
- capture affected SpecRail surface, contract impact, reproduction/proposal details, and validation context
- prompt reporters/requesters to check for duplicates

## Validation
- pnpm check
- issue form YAML parse check

Closes #103