### PR TITLE
docs: add documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ curl -X POST http://127.0.0.1:3000/tracks \
   -d '{"title":"Executor MVP","description":"Persist command metadata and launch runs.","priority":"high"}'
 ```
 
+## Documentation
+
+See [docs/README.md](./docs/README.md) for a categorized documentation index.
+
 ## Verification source of truth
 
 The docs above are aligned to the current MVP implementation and tests in:

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Use this index to find the right reference before changing SpecRail's core servi
 ## Client surfaces
 
 - [Terminal client](./terminal-client.md) — terminal UI behavior, run following, planning workspace, and controls.
-- [Client surfaces and structure](./architecture/client-surfaces-and-structure.md) — client-surface organization and ownership.
+- [Telegram bot interface strategy](./architecture/telegram-bot-interface-strategy.md) — Telegram-facing product and integration strategy.
 
 ## Research
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# SpecRail Documentation
+
+Use this index to find the right reference before changing SpecRail's core service, adapters, APIs, clients, or operator workflows.
+
+## Start here
+
+- [MVP architecture](./architecture/mvp-architecture.md) — current system slices, API coverage, data model, persistence layout, and request/event flows.
+- [Domain entities](./domain-entities.md) — domain object overview for projects, tracks, planning, approvals, executions, events, and integrations.
+- [Interfaces and adapters](./interfaces-and-adapters.md) — adapter boundaries and how external surfaces connect to the core service.
+
+## Architecture and roadmap
+
+- [Repository structure](./architecture/repository-structure.md) — package and app ownership.
+- [MVP roadmap](./architecture/mvp-roadmap.md) — historical MVP milestones and validation focus.
+- [Next steps from 2026-04-09](./architecture/next-steps-2026-04-09.md) — earlier planning notes for follow-up work.
+- [Interactive planning layer](./architecture/interactive-planning-layer.md) — planning workflow direction.
+- [Telegram bot interface strategy](./architecture/telegram-bot-interface-strategy.md) — Telegram-facing product and integration strategy.
+- [GitHub Speckit/OpenSpec integration plan](./architecture/github-speckit-openspec-integration-plan.md) — integration strategy for GitHub, Speckit, and OpenSpec.
+
+## Execution and adapters
+
+- [ACP server edge adapter](./acp-server-edge-adapter.md) — ACP boundary, session mapping, event projections, permission round-trip, and limitations.
+- [Claude Code operations](./claude-code-operations.md) — Claude Code setup, runtime behavior, smoke tests, and operational recovery.
+- [Agent invocation analysis](./agent-invocation-analysis.md) — agent invocation behavior and design observations.
+- [Agent invocation design notes](./agent-invocation-design-notes.md) — design notes for invocation and execution flows.
+
+## Client surfaces
+
+- [Terminal client](./terminal-client.md) — terminal UI behavior, run following, planning workspace, and controls.
+- [Client surfaces and structure](./architecture/client-surfaces-and-structure.md) — client-surface organization and ownership.
+
+## Research
+
+- [ACP fit for SpecRail](./research/acp-fit-for-specrail.md) — research notes on where ACP fits in SpecRail's architecture.
+
+## How to keep docs current
+
+When a PR changes API routes, event payloads, persistence layout, adapter behavior, or operator workflow, update the relevant docs in the same PR. If a change spans multiple surfaces, update this index when it creates a new durable reference.


### PR DESCRIPTION
## Summary
- add `docs/README.md` as a categorized documentation index
- group architecture, adapter, operations, client-surface, and research docs
- link the docs index from the root README

## Validation
- pnpm check
- local markdown link check

Closes #107