### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: pnpm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    groups:
+      typescript-tooling:
+        patterns:
+          - typescript
+          - tsx
+          - "@types/node"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- add Dependabot configuration for the pnpm workspace
- add Dependabot coverage for GitHub Actions workflows
- keep update volume modest with weekly schedules and PR limits

## Validation
- pnpm check
- Dependabot YAML parse check

Closes #111