### PR TITLE
chore: add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# SpecRail API server
+SPECRAIL_PORT=4000
+SPECRAIL_DATA_DIR=.specrail-data
+SPECRAIL_REPO_ARTIFACT_DIR=.specrail
+
+# Default execution backend used when API callers omit backend/profile.
+# Supported backend values currently include: codex, claude_code
+SPECRAIL_EXECUTION_BACKEND=codex
+SPECRAIL_EXECUTION_PROFILE=default
+
+# Terminal and Telegram clients
+SPECRAIL_API_BASE_URL=http://127.0.0.1:4000
+SPECRAIL_TERMINAL_REFRESH_MS=5000
+SPECRAIL_TERMINAL_INITIAL_SCREEN=home
+
+# Telegram adapter
+# Do not commit real bot tokens. Copy this file to .env locally and fill the token there.
+TELEGRAM_BOT_TOKEN=replace-with-telegram-bot-token
+TELEGRAM_APP_PORT=4100
+TELEGRAM_WEBHOOK_PATH=/telegram/webhook
+
+# Optional Claude Code smoke test controls
+SPECRAIL_RUN_CLAUDE_SMOKE=0
+SPECRAIL_CLAUDE_SMOKE_STRICT=0
+CLAUDE_SMOKE_PROMPT=Reply with exactly the single word ok.
+CLAUDE_SMOKE_MODEL=default

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 .env
 .env.*
+!.env.example
 dist
 coverage
 .tmp


### PR DESCRIPTION
## Summary
- add `.env.example` with SpecRail API, execution, terminal, Telegram, and Claude smoke-test variables
- allow `.env.example` while keeping secret-bearing `.env` files ignored

## Validation
- pnpm check
- env example uniqueness check

Closes #121