### PR TITLE
ci: run markdown link check

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Typecheck packages
         run: pnpm check
 
+      - name: Check Markdown links
+        run: pnpm check:links
+
       - name: Run tests
         run: pnpm test
 


### PR DESCRIPTION
## Summary
- add `pnpm check:links` to the baseline validation workflow
- run the docs link check after typecheck and before tests/build

## Validation
- pnpm check
- pnpm check:links

Closes #129