### PR TITLE
ci: force test runner exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:terminal": "pnpm --filter @specrail/terminal dev",
     "dev:telegram": "pnpm --filter @specrail/telegram dev",
     "lint": "pnpm -r lint",
-    "test": "tsx --tsconfig tsconfig.base.json --test packages/core/src/domain/__tests__/*.test.ts packages/core/src/services/__tests__/*.test.ts packages/config/src/__tests__/*.test.ts packages/adapters/src/__tests__/*.test.ts apps/api/src/__tests__/*.test.ts apps/acp-server/src/__tests__/*.test.ts apps/telegram/src/__tests__/*.test.ts apps/terminal/src/__tests__/*.test.ts",
+    "test": "tsx --tsconfig tsconfig.base.json --test --test-force-exit packages/core/src/domain/__tests__/*.test.ts packages/core/src/services/__tests__/*.test.ts packages/config/src/__tests__/*.test.ts packages/adapters/src/__tests__/*.test.ts apps/api/src/__tests__/*.test.ts apps/acp-server/src/__tests__/*.test.ts apps/telegram/src/__tests__/*.test.ts apps/terminal/src/__tests__/*.test.ts",
     "test:claude-smoke": "tsx --tsconfig tsconfig.base.json --test packages/adapters/src/__tests__/claude-code.smoke.test.ts",
     "check:links": "node scripts/check-markdown-links.mjs"
   },


### PR DESCRIPTION
## Summary
- add Node test runner `--test-force-exit` to the baseline `pnpm test` command
- preserve the existing explicit test file globs
- prevent lingering handles from holding CI until the workflow timeout after tests finish

## Validation
- pnpm check
- pnpm test

Closes #133