### PR TITLE
fix: make sse event streaming deterministic

### DIFF
--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -89,6 +89,9 @@ async function openSseStream(url: string): Promise<{
       (response) => {
         response.setEncoding("utf8");
         let buffer = "";
+        response.on("data", (chunk: string) => {
+          buffer += chunk;
+        });
 
         resolve({
           statusCode: response.statusCode ?? 0,
@@ -104,8 +107,7 @@ async function openSseStream(url: string): Promise<{
                 innerReject(new Error(`timed out waiting for ${expectedCount} SSE events`));
               }, 5000);
 
-              const onData = (chunk: string): void => {
-                buffer += chunk;
+              const onData = (): void => {
                 const events = parseSseEvents(buffer);
 
                 if (events.length >= expectedCount) {
@@ -140,8 +142,7 @@ async function openSseStream(url: string): Promise<{
                 innerReject(new Error("timed out waiting for matching SSE event"));
               }, 10000);
 
-              const onData = (chunk: string): void => {
-                buffer += chunk;
+              const onData = (): void => {
                 const events = parseSseEvents(buffer);
 
                 if (events.some(matches)) {

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -374,6 +374,23 @@ test("API supports streaming run events over SSE", async () => {
     assert.equal(initialEvents[0]?.summary, "Run started");
     assert.match(initialEvents[1]?.summary ?? "", /Spawned Codex session/);
 
+    const resumeResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/resume`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "Continue with verification" }),
+    });
+    assert.equal(resumeResponse.status, 200);
+
+    const resumedEvents = await stream.waitForEvent((event) => /Resumed Codex session/.test(event.summary));
+    assert.ok(resumedEvents.some((event) => /Resumed Codex session/.test(event.summary)));
+
+    const cancelResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/cancel`, {
+      method: "POST",
+    });
+    assert.equal(cancelResponse.status, 200);
+
+    const cancelledEvents = await stream.waitForEvent((event) => /Cancelled Codex session/.test(event.summary));
+    assert.ok(cancelledEvents.some((event) => /Cancelled Codex session/.test(event.summary)));
     stream.close();
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -742,6 +742,8 @@ async function streamRunEvents(
   let closed = false;
   let offset = 0;
   let pendingLine = "";
+  let flushInFlight: Promise<void> | null = null;
+  const sentEventIds = new Set<string>();
   const eventLogPath = path.join(eventLogDir, `${runId}.jsonl`);
 
   const flushAppendedEvents = async (): Promise<void> => {
@@ -774,30 +776,51 @@ async function streamRunEvents(
           continue;
         }
 
-        writeSseEvent(response, JSON.parse(line) as ExecutionEvent);
+        const event = JSON.parse(line) as ExecutionEvent;
+        if (sentEventIds.has(event.id)) {
+          continue;
+        }
+
+        sentEventIds.add(event.id);
+        writeSseEvent(response, event);
       }
     } finally {
       await handle.close();
     }
   };
 
+  const scheduleFlush = (): void => {
+    if (closed || flushInFlight) {
+      return;
+    }
+
+    flushInFlight = flushAppendedEvents()
+      .catch(() => {
+        close();
+      })
+      .finally(() => {
+        flushInFlight = null;
+      });
+  };
+
   const initialEvents = await service.listRunEvents(runId);
   for (const event of initialEvents) {
+    sentEventIds.add(event.id);
     writeSseEvent(response, event);
   }
 
-  offset = (await stat(eventLogPath).catch(() => null))?.size ?? 0;
   response.write(`: connected\n\n`);
+  scheduleFlush();
 
   const watcher = watch(eventLogDir, (_eventType, filename) => {
     if (closed || filename !== `${runId}.jsonl`) {
       return;
     }
 
-    void flushAppendedEvents().catch(() => {
-      close();
-    });
+    scheduleFlush();
   });
+
+  const poller = setInterval(scheduleFlush, 250);
 
   const heartbeat = setInterval(() => {
     response.write(`: keep-alive\n\n`);
@@ -810,6 +833,7 @@ async function streamRunEvents(
 
     closed = true;
     clearInterval(heartbeat);
+    clearInterval(poller);
     watcher.close();
     response.end();
   };


### PR DESCRIPTION
## Summary
- add a lightweight polling fallback around the API SSE event-log watcher
- dedupe emitted SSE events by id so initial snapshot and appended reads cannot double-send
- restore integration coverage for live resume/cancel events over SSE

Closes #136

## Validation
- pnpm check
- pnpm test
- pnpm build