### PR TITLE
feat: add runtime approval resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Current endpoints in `apps/api/src/index.ts`:
   - `backend` is optional and must match the run's persisted backend when provided
 - `POST /runs/:runId/cancel`
   - cancel a running run
+- `POST /runs/:runId/approval-requests/:requestId/approve`
+  - resolve a pending runtime approval request as approved
+  - body: `{ decidedBy, comment? }`
+- `POST /runs/:runId/approval-requests/:requestId/reject`
+  - resolve a pending runtime approval request as rejected
+  - body: `{ decidedBy, comment? }`
 - `GET /runs/:runId/events`
   - return persisted normalized events as JSON
 - `GET /runs/:runId/events/stream`

--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -158,7 +158,48 @@ function createFakeService() {
         });
       }
     },
-  } satisfies Pick<SpecRailService, "getTrack" | "startRun" | "resumeRun" | "cancelRun" | "getRun" | "listRunEvents" | "recordExecutionEvent">;
+    async resolveRuntimeApprovalRequest(input: {
+      runId: string;
+      requestId: string;
+      outcome: "approved" | "rejected";
+      decidedBy: "user" | "agent" | "system";
+      comment?: string;
+    }) {
+      const runEvents = events.get(input.runId) ?? [];
+      const requestedEvent = runEvents.find((event) => event.type === "approval_requested" && event.id === input.requestId);
+      if (!requestedEvent) {
+        throw new Error(`missing approval request ${input.requestId}`);
+      }
+
+      const event: ExecutionEvent = {
+        id: `${input.runId}-approval-resolved`,
+        executionId: input.runId,
+        type: "approval_resolved",
+        timestamp: "2026-04-13T00:00:01.500Z",
+        source: "specrail",
+        summary: `Approved runtime approval request ${input.requestId}`,
+        payload: {
+          status: input.outcome === "approved" ? "running" : "cancelled",
+          requestId: input.requestId,
+          outcome: input.outcome,
+          decidedBy: input.decidedBy,
+          comment: input.comment,
+        },
+      };
+      await service.recordExecutionEvent(event);
+      return event;
+    },
+  } satisfies Pick<
+    SpecRailService,
+    | "getTrack"
+    | "startRun"
+    | "resumeRun"
+    | "cancelRun"
+    | "getRun"
+    | "listRunEvents"
+    | "recordExecutionEvent"
+    | "resolveRuntimeApprovalRequest"
+  >;
 
   return service;
 }

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -601,25 +601,18 @@ export class SpecRailAcpServer {
       throw new ValidationError("_meta.specrail.permissionResolution.outcome must be approved or rejected");
     }
 
-    const event: ExecutionEvent = {
-      id: `${execution.id}:approval_resolved:${this.now()}`,
-      executionId: execution.id,
-      type: "approval_resolved",
-      timestamp: this.now(),
-      source: "acp_server",
-      summary: `${outcome === "approved" ? "Approved" : "Rejected"} runtime permission request ${requestId}`,
-      payload: {
-        status: outcome === "approved" ? "running" : "cancelled",
-        requestId,
-        outcome,
-        decidedBy: this.optionalString(resolution?.decidedBy),
-        comment: this.optionalString(resolution?.comment),
-        toolName: pending.toolName,
-        toolUseId: pending.toolUseId,
-      },
-    };
+    const decidedBy = this.optionalString(resolution?.decidedBy) ?? "user";
+    if (decidedBy !== "user" && decidedBy !== "agent" && decidedBy !== "system") {
+      throw new ValidationError("_meta.specrail.permissionResolution.decidedBy must be user, agent, or system");
+    }
 
-    await this.options.service.recordExecutionEvent?.(event);
+    const event = await this.options.service.resolveRuntimeApprovalRequest({
+      runId: execution.id,
+      requestId,
+      outcome,
+      decidedBy,
+      comment: this.optionalString(resolution?.comment),
+    });
 
     const updatedSession: AcpSessionRecord = {
       ...session,

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -467,6 +467,74 @@ test("API supports resuming and cancelling a run", async () => {
   });
 });
 
+test("API resolves runtime approval requests", async () => {
+  await withServer(async (baseUrl, { dataDir }) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Runtime approval",
+        description: "Exercise runtime approval resolution route.",
+      }),
+    });
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const createRunResponse = await fetch(`${baseUrl}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        prompt: "Start gated work",
+      }),
+    });
+    const runPayload = (await createRunResponse.json()) as { run: { id: string } };
+    const requestId = `${runPayload.run.id}:approval-requested`;
+
+    await writeFile(
+      path.join(dataDir, "state", "events", `${runPayload.run.id}.jsonl`),
+      `${JSON.stringify({
+        id: requestId,
+        executionId: runPayload.run.id,
+        type: "approval_requested",
+        timestamp: "2026-04-09T07:00:00.000Z",
+        source: "codex",
+        summary: "Approve Bash",
+        payload: { toolName: "Bash", toolUseId: "toolu-runtime" },
+      })}\n`,
+      { encoding: "utf8", flag: "a" },
+    );
+
+    const approveResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/approval-requests/${requestId}/approve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decidedBy: "user", comment: "approved" }),
+    });
+    assert.equal(approveResponse.status, 200);
+    const approvePayload = (await approveResponse.json()) as {
+      event: { type: string; payload: { requestId: string; outcome: string; status: string; toolName: string } };
+    };
+    assert.equal(approvePayload.event.type, "approval_resolved");
+    assert.equal(approvePayload.event.payload.requestId, requestId);
+    assert.equal(approvePayload.event.payload.outcome, "approved");
+    assert.equal(approvePayload.event.payload.status, "running");
+    assert.equal(approvePayload.event.payload.toolName, "Bash");
+
+    const duplicateResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/approval-requests/${requestId}/reject`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decidedBy: "user" }),
+    });
+    assert.equal(duplicateResponse.status, 422);
+
+    const unknownResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/approval-requests/missing-request/approve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ decidedBy: "user" }),
+    });
+    assert.equal(unknownResponse.status, 404);
+  });
+});
+
 test("API blocks run start when planning revisions are still pending approval", async () => {
   await withServer(async (baseUrl) => {
     const trackResponse = await fetch(`${baseUrl}/tracks`, {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -99,6 +99,11 @@ interface DecideApprovalRequestBody {
   comment?: string;
 }
 
+interface ResolveRuntimeApprovalRequestBody {
+  decidedBy: "user" | "agent" | "system";
+  comment?: string;
+}
+
 interface BindChannelRequestBody {
   projectId: string;
   channelType: "telegram";
@@ -580,6 +585,22 @@ function assertValidProposeArtifactRevisionBody(body: ProposeArtifactRevisionReq
 }
 
 function assertValidDecideApprovalRequestBody(body: DecideApprovalRequestBody): void {
+  const details = getDecisionBodyValidationDetails(body);
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
+  }
+}
+
+function assertValidResolveRuntimeApprovalRequestBody(body: ResolveRuntimeApprovalRequestBody): void {
+  const details = getDecisionBodyValidationDetails(body);
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
+  }
+}
+
+function getDecisionBodyValidationDetails(body: DecideApprovalRequestBody | ResolveRuntimeApprovalRequestBody): ApiErrorDetail[] {
   const details: ApiErrorDetail[] = [];
 
   if (body.decidedBy !== "user" && body.decidedBy !== "agent" && body.decidedBy !== "system") {
@@ -593,9 +614,7 @@ function assertValidDecideApprovalRequestBody(body: DecideApprovalRequestBody): 
     }
   }
 
-  if (details.length > 0) {
-    throw new RequestValidationError("request validation failed", details);
-  }
+  return details;
 }
 
 function assertValidBindChannelBody(body: BindChannelRequestBody): void {
@@ -1041,6 +1060,26 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           comment: body.comment,
         });
         sendJson(response, 200, { approvalRequest });
+        return;
+      }
+
+      if (
+        method === "POST" &&
+        segments.length === 5 &&
+        segments[0] === "runs" &&
+        segments[2] === "approval-requests" &&
+        (segments[4] === "approve" || segments[4] === "reject")
+      ) {
+        const body = await readJson<ResolveRuntimeApprovalRequestBody>(request);
+        assertValidResolveRuntimeApprovalRequestBody(body);
+        const event = await deps.service.resolveRuntimeApprovalRequest({
+          runId: segments[1] ?? "",
+          requestId: segments[3] ?? "",
+          outcome: segments[4] === "approve" ? "approved" : "rejected",
+          decidedBy: body.decidedBy,
+          comment: body.comment,
+        });
+        sendJson(response, 200, { event });
         return;
       }
 

--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -174,6 +174,8 @@ Implemented routes:
 - `GET /runs/:runId`
 - `POST /runs/:runId/resume`
 - `POST /runs/:runId/cancel`
+- `POST /runs/:runId/approval-requests/:requestId/approve`
+- `POST /runs/:runId/approval-requests/:requestId/reject`
 - `GET /runs/:runId/events`
 - `GET /runs/:runId/events/stream`
 
@@ -186,7 +188,6 @@ Implemented routes:
 Not implemented yet:
 - project CRUD endpoints beyond default project bootstrap
 - direct artifact edit/update endpoints outside the proposal/approval flow
-- backend-native approval action callbacks for executor-level permission brokers
 - webhook callback endpoints for GitHub or other hosted integrations
 
 ## Data model snapshot

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -30,7 +30,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
   - some provider-specific fields remain in `payload` / `_meta`
 - approval workflow depth
   - artifact revision approval is implemented
-  - runtime permission approval is still adapter-mediated rather than a backend-native broker callback
+  - runtime permission request resolution is available through core service and HTTP APIs
+  - active executor callback wiring is still adapter-specific
 - artifact contract convergence
   - generated track artifacts exist in the repo-visible layout
   - authoritative run events still live under `state/events/<runId>.jsonl`
@@ -56,9 +57,9 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - connect completed run summaries back into track artifacts if desired
 
 ### Milestone B — Runtime approval broker
-- model backend-native permission requests independent of adapter-specific payloads
-- persist approval requested/resolved events with a consistent domain contract
-- route approval decisions back to active executors without relying on edge-adapter synthesis
+- route core/API approval decisions back to active executors when a backend supports continuation callbacks
+- keep approval requested/resolved events provider-neutral while preserving provider metadata
+- document fallback behavior for rejected approvals and interrupted sessions
 
 ### Milestone C — Worktree and branch orchestration
 - create isolated workspaces per execution when requested
@@ -79,8 +80,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 1. **Define artifact/state event-history ownership**
    - settle what belongs in repo-visible artifacts versus internal state.
-2. **Add backend-native runtime approval broker callbacks**
-   - make approval requests/resolutions first-class outside ACP/adapter synthesis.
+2. **Wire runtime approval decisions into active executors**
+   - continue from the new core/API resolution path into backend-specific callbacks.
 3. **Add execution worktree orchestration**
    - isolate agent runs and track branch/worktree lifecycle.
 4. **Add project management APIs**

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -915,8 +915,15 @@ test("SpecRailService derives waiting approval and resumed running state from ap
     },
     workspaceRoot: path.join(rootDir, "workspaces"),
     now: (() => {
-      const values = ["2026-04-09T06:00:00.000Z", "2026-04-09T06:00:01.000Z", "2026-04-09T06:00:02.000Z"];
-      return () => values.shift() ?? "2026-04-09T06:00:02.000Z";
+      const values = [
+        "2026-04-09T06:00:00.000Z",
+        "2026-04-09T06:00:01.000Z",
+        "2026-04-09T06:00:02.000Z",
+        "2026-04-09T06:00:03.000Z",
+        "2026-04-09T06:00:04.000Z",
+        "2026-04-09T06:00:05.000Z",
+      ];
+      return () => values.shift() ?? "2026-04-09T06:00:05.000Z";
     })(),
     idGenerator: (() => {
       const values = ["track-approval", "run-approval"];
@@ -956,18 +963,27 @@ test("SpecRailService derives waiting approval and resumed running state from ap
     lastEventAt: "2026-04-09T06:00:01.000Z",
   });
 
-  await service.recordExecutionEvent({
-    id: `${run.id}:approval-resolved`,
-    executionId: run.id,
-    type: "approval_resolved",
-    timestamp: "2026-04-09T06:00:02.000Z",
-    source: "codex",
-    summary: "Approval resolved",
-    payload: {
-      gate: "plan",
-      resolution: "approved",
-    },
+  const resolutionEvent = await service.resolveRuntimeApprovalRequest({
+    runId: run.id,
+    requestId: `${run.id}:approval-requested`,
+    outcome: "approved",
+    decidedBy: "user",
+    comment: "approved for test",
   });
+  assert.equal(resolutionEvent.type, "approval_resolved");
+  assert.equal(resolutionEvent.payload?.requestId, `${run.id}:approval-requested`);
+  assert.equal(resolutionEvent.payload?.outcome, "approved");
+  assert.equal(resolutionEvent.payload?.status, "running");
+
+  await assert.rejects(
+    service.resolveRuntimeApprovalRequest({
+      runId: run.id,
+      requestId: `${run.id}:approval-requested`,
+      outcome: "approved",
+      decidedBy: "user",
+    }),
+    /already resolved/,
+  );
 
   const resumedRun = await service.getRun(run.id);
   assert.equal(resumedRun?.status, "running");
@@ -975,9 +991,49 @@ test("SpecRailService derives waiting approval and resumed running state from ap
   assert.equal(resumedRun?.finishedAt, undefined);
   assert.deepEqual(resumedRun?.summary, {
     eventCount: 3,
-    lastEventSummary: "Approval resolved",
-    lastEventAt: "2026-04-09T06:00:02.000Z",
+    lastEventSummary: `Approved runtime approval request ${run.id}:approval-requested`,
+    lastEventAt: "2026-04-09T06:00:03.000Z",
   });
+
+  const rejectedTrack = await service.createTrack({
+    title: "Rejected approval run",
+    description: "Reconcile rejected runtime approval from normalized events.",
+  });
+  const rejectedRun = await service.startRun({
+    trackId: rejectedTrack.id,
+    prompt: "Start the rejected gated work",
+  });
+
+  await service.recordExecutionEvent({
+    id: `${rejectedRun.id}:approval-requested`,
+    executionId: rejectedRun.id,
+    type: "approval_requested",
+    timestamp: "2026-04-09T06:00:04.000Z",
+    source: "codex",
+    summary: "Approval requested for risky command",
+    payload: {
+      toolName: "Bash",
+      toolUseId: "toolu-rejected",
+    },
+  });
+
+  const rejectedResolution = await service.resolveRuntimeApprovalRequest({
+    runId: rejectedRun.id,
+    requestId: `${rejectedRun.id}:approval-requested`,
+    outcome: "rejected",
+    decidedBy: "agent",
+    comment: "too risky",
+  });
+  assert.equal(rejectedResolution.payload?.status, "cancelled");
+  assert.equal(rejectedResolution.payload?.outcome, "rejected");
+  assert.equal(rejectedResolution.payload?.toolName, "Bash");
+
+  const cancelledRun = await service.getRun(rejectedRun.id);
+  assert.equal(cancelledRun?.status, "cancelled");
+  assert.equal(cancelledRun?.finishedAt, "2026-04-09T06:00:05.000Z");
+
+  const blockedTrack = await service.getTrack(rejectedTrack.id);
+  assert.equal(blockedTrack?.status, "blocked");
 });
 
 test("SpecRailService lists tracks and runs with basic filters", async () => {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -177,6 +177,14 @@ export interface DecideApprovalRequestInput {
   comment?: string;
 }
 
+export interface ResolveRuntimeApprovalRequestInput {
+  runId: string;
+  requestId: string;
+  outcome: "approved" | "rejected";
+  decidedBy: ApprovalRequest["requestedBy"];
+  comment?: string;
+}
+
 export interface BindChannelInput {
   projectId: string;
   channelType: ChannelBinding["channelType"];
@@ -254,6 +262,11 @@ function readExecutionStatus(event: ExecutionEvent): ExecutionStatus | null {
   }
 
   if (event.type === "approval_resolved") {
+    const status = event.payload?.status;
+    if (status === "running" || status === "cancelled") {
+      return status;
+    }
+
     return "running";
   }
 
@@ -911,15 +924,66 @@ export class SpecRailService {
 
   async recordExecutionEvent(event: ExecutionEvent): Promise<void> {
     await this.dependencies.eventStore.append(event);
+    await this.reconcileExecutionFromEvents(event.executionId);
+  }
 
-    const execution = await this.dependencies.executionRepository.getById(event.executionId);
+  async resolveRuntimeApprovalRequest(input: ResolveRuntimeApprovalRequestInput): Promise<ExecutionEvent> {
+    const execution = await this.requireRun(input.runId);
+    const events = await this.dependencies.eventStore.listByExecution(execution.id);
+    const requestedEvent = events.find(
+      (event) =>
+        event.type === "approval_requested" &&
+        (event.id === input.requestId || event.payload?.requestId === input.requestId),
+    );
+
+    if (!requestedEvent) {
+      throw new NotFoundError(`Runtime approval request not found: ${input.requestId}`);
+    }
+
+    const alreadyResolved = events.some(
+      (event) =>
+        event.type === "approval_resolved" &&
+        (event.payload?.requestId === input.requestId || event.payload?.requestEventId === requestedEvent.id),
+    );
+
+    if (alreadyResolved) {
+      throw new ValidationError(`Runtime approval request is already resolved: ${input.requestId}`);
+    }
+
+    const event: ExecutionEvent = {
+      id: `${execution.id}:approval-resolved:${this.dependencies.idGenerator?.() ?? randomUUID()}`,
+      executionId: execution.id,
+      type: "approval_resolved",
+      timestamp: this.now(),
+      source: "specrail",
+      summary: `${input.outcome === "approved" ? "Approved" : "Rejected"} runtime approval request ${input.requestId}`,
+      payload: {
+        status: input.outcome === "approved" ? "running" : "cancelled",
+        requestId: input.requestId,
+        requestEventId: requestedEvent.id,
+        outcome: input.outcome,
+        decidedBy: input.decidedBy,
+        comment: input.comment,
+        toolName: requestedEvent.payload?.toolName,
+        toolUseId: requestedEvent.payload?.toolUseId,
+      },
+    };
+
+    await this.dependencies.eventStore.append(event);
+    await this.reconcileExecutionFromEvents(execution.id);
+
+    return event;
+  }
+
+  private async reconcileExecutionFromEvents(executionId: string): Promise<void> {
+    const execution = await this.dependencies.executionRepository.getById(executionId);
     if (!execution) {
       return;
     }
 
     const reconciledExecution = buildExecutionSnapshot(
       execution,
-      await this.dependencies.eventStore.listByExecution(event.executionId),
+      await this.dependencies.eventStore.listByExecution(executionId),
     );
     await this.dependencies.executionRepository.update(await this.hydrateExecutionPlanningContext(reconciledExecution));
     await this.reconcileTrackStatusFromRun(reconciledExecution.trackId, reconciledExecution);


### PR DESCRIPTION
## Summary
- add core service support for resolving runtime approval requests as approved or rejected
- expose HTTP approve/reject endpoints under runs
- route ACP permission resolution through the core service instead of synthesizing events at the edge
- update docs and tests for runtime approval state transitions

Closes #142

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build