### PR TITLE
docs: define runtime approval callback contract

### DIFF
--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -51,12 +51,13 @@ The adapter now keeps the raw SpecRail event payload in `_meta.specrail.executio
 
 ### Permission round-trip
 
-Runtime approval is still adapter-mediated, but the ACP edge now supports a basic round-trip shape:
+Runtime approval decisions now use the same domain service/API path as non-ACP clients:
 
 1. SpecRail emits `approval_requested`.
 2. The ACP adapter publishes `session/request_permission` with the original event attached in `_meta.specrail.executionEvent`.
 3. The client answers on the next `session/prompt` with `_meta.specrail.permissionResolution`.
-4. The adapter records a synthetic `approval_resolved` execution event and resumes the linked SpecRail run.
+4. The adapter calls `SpecRailService.resolveRuntimeApprovalRequest(...)` to record the canonical `approval_resolved` event.
+5. The adapter resumes the linked SpecRail run after an approved decision; rejected decisions keep the run cancelled.
 
 Example client payload:
 
@@ -83,11 +84,11 @@ This is intentionally an initial bridge, not a full ACP implementation.
 
 1. `session/new` currently requires SpecRail-specific metadata, especially `_meta.specrail.trackId`.
 2. Planning artifacts, approvals, channel bindings, and attachment flows stay in the existing REST API.
-3. Runtime permission requests are translated into ACP-friendly updates, but they are still mediated by the adapter rather than a backend-native approval broker.
+3. Runtime permission requests are translated into ACP-friendly updates; decisions are persisted through the core approval path, but active executor callback delivery is not implemented yet.
 4. Event updates are richer than the initial bridge, but the mapping still collapses many provider-specific details into `session/update` plus `_meta` rather than a full ACP-native event taxonomy.
 5. The adapter stores ACP session records locally, but run state still lives in the normal SpecRail repositories.
 6. Terminal and filesystem ACP capabilities are not exposed yet, because SpecRail-managed workspaces need a clearer ownership model first.
-7. `approval_resolved` is currently synthesized by the ACP adapter when the client sends `permissionResolution`, so the persisted event expresses the ACP decision clearly but does not yet prove that the underlying executor consumed a real broker callback.
+7. `approval_resolved` is persisted by the core service when the client sends `permissionResolution`, but the event does not yet prove that the underlying executor consumed a real callback.
 
 ## Why this shape
 
@@ -99,7 +100,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 ## Near-term follow-up
 
 Good next steps from the current bridge:
-- move runtime permission handling behind a backend-native approval broker so ACP decisions are not only adapter-synthesized events
+- deliver persisted runtime approval decisions into active executor callbacks where providers support continuation
 - expand the ACP-facing event taxonomy beyond readable `agent_message_chunk` fallbacks for provider-specific details that clients need to render natively
 - define workspace ownership rules before exposing filesystem or terminal ACP capabilities for SpecRail-managed workspaces
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client

--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -63,7 +63,7 @@ Currently implemented:
 
 Currently not implemented:
 - worktree/git orchestration beyond metadata/workspace path allocation
-- backend-native approval broker callbacks independent of adapters
+- executor callback delivery for already-recorded runtime approval decisions
 - scheduler/queue management
 
 ### 3. Interface plane
@@ -451,16 +451,49 @@ Current Claude Code coverage:
 Current ACP edge coverage:
 - `task_status_changed` updates ACP session status metadata
 - `approval_requested` can be projected as ACP `session/request_permission`
-- client `_meta.specrail.permissionResolution` can synthesize an `approval_resolved` event and resume the run
+- client `_meta.specrail.permissionResolution` is resolved through `SpecRailService.resolveRuntimeApprovalRequest(...)` and then resumes the run
 
-Some provider-specific details are still carried in event `payload` / `_meta` rather than promoted into a larger native taxonomy. That keeps the core event contract stable while adapter fidelity improves incrementally.
+### Runtime approval callback contract
+
+Runtime approval resolution has two separate responsibilities:
+
+1. persist the domain decision in SpecRail
+2. deliver that decision to the active executor when the backend supports continuation callbacks
+
+The implemented domain decision path is canonical:
+
+```text
+POST /runs/:runId/approval-requests/:requestId/approve|reject
+  -> SpecRailService.resolveRuntimeApprovalRequest(...)
+  -> append approval_resolved to state/events/<runId>.jsonl
+  -> reconcile the run snapshot from persisted execution events
+```
+
+Executors should treat the persisted `approval_resolved` event as the durable source of truth. A future executor callback receives the resolved event plus the current execution snapshot, not a provider-specific API shape. The stable fields are:
+
+- `executionId`
+- `payload.requestId`
+- `payload.requestEventId`
+- `payload.outcome` (`approved` or `rejected`)
+- `payload.decidedBy` (`user`, `agent`, or `system`)
+- `payload.comment`
+- `payload.toolName`
+- `payload.toolUseId`
+
+Expected callback behavior:
+
+- `approved`: continue the blocked operation when the provider exposes a permission-continuation primitive; otherwise resume the run with a clear event explaining the fallback path.
+- `rejected`: do not retry the blocked operation; mark or keep the run cancelled unless a backend can represent a narrower blocked-step state.
+- callback failure after the domain event is recorded must append an additional `task_status_changed` or `summary` event rather than mutating the approval decision.
+
+Provider-specific metadata can remain under event `payload` / `_meta`, but the callback boundary should not require callers to know Codex, Claude Code, or ACP transport details. That keeps the core event contract stable while adapter fidelity improves incrementally.
 
 ## Out of scope for the current MVP
 
 - database layer
 - production auth system
 - production deployment manifests
-- backend-native approval broker callbacks
+- executor callback delivery for runtime approval decisions
 - rich artifact editing/versioning API outside the current proposal/approval flow
 - multi-project tenant management beyond default project bootstrap
 - hosted GitHub app/webhook automation

--- a/docs/claude-code-operations.md
+++ b/docs/claude-code-operations.md
@@ -136,8 +136,9 @@ These are current, expected limitations of the MVP:
    - `*.claude-stream.jsonl` captures Claude stdout stream-json output.
    - stderr is normalized into SpecRail events, but not mirrored into that raw stdout transcript file.
 
-6. no approval broker exists yet.
-   - SpecRail advertises the capability shape, but there is not yet a separate approval workflow layered on top of Claude Code.
+6. approval decisions are persisted, but not delivered back into Claude Code yet.
+   - `approval_requested` events can be resolved through the core service/API.
+   - a future executor callback still needs to bridge approved/rejected decisions into Claude Code continuation behavior when the CLI exposes a usable primitive.
 
 ## Recovery guide
 


### PR DESCRIPTION
## Summary
- document the split between persisted runtime approval decisions and executor callback delivery
- define the provider-neutral fields and approved/rejected callback expectations
- update ACP and Claude Code docs to reflect the #142 core approval path

Closes #144

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build