### PR TITLE
feat: deliver runtime approval callbacks

### DIFF
--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -63,7 +63,7 @@ Currently implemented:
 
 Currently not implemented:
 - worktree/git orchestration beyond metadata/workspace path allocation
-- executor callback delivery for already-recorded runtime approval decisions
+- executor callback delivery for already-recorded runtime approval decisions when a backend implements `resolveRuntimeApproval(...)`
 - scheduler/queue management
 
 ### 3. Interface plane
@@ -458,7 +458,7 @@ Current ACP edge coverage:
 Runtime approval resolution has two separate responsibilities:
 
 1. persist the domain decision in SpecRail
-2. deliver that decision to the active executor when the backend supports continuation callbacks
+2. deliver that decision to the active executor when the backend implements `resolveRuntimeApproval(...)`
 
 The implemented domain decision path is canonical:
 
@@ -469,7 +469,7 @@ POST /runs/:runId/approval-requests/:requestId/approve|reject
   -> reconcile the run snapshot from persisted execution events
 ```
 
-Executors should treat the persisted `approval_resolved` event as the durable source of truth. A future executor callback receives the resolved event plus the current execution snapshot, not a provider-specific API shape. The stable fields are:
+Executors treat the persisted `approval_resolved` event as the durable source of truth. The optional executor callback receives the resolved event plus the current execution snapshot, not a provider-specific API shape. The stable fields are:
 
 - `executionId`
 - `payload.requestId`
@@ -484,7 +484,8 @@ Expected callback behavior:
 
 - `approved`: continue the blocked operation when the provider exposes a permission-continuation primitive; otherwise resume the run with a clear event explaining the fallback path.
 - `rejected`: do not retry the blocked operation; mark or keep the run cancelled unless a backend can represent a narrower blocked-step state.
-- callback failure after the domain event is recorded must append an additional `task_status_changed` or `summary` event rather than mutating the approval decision.
+- unsupported callbacks append a `summary` event so the gap is visible in run history.
+- callback failure after the domain event is recorded appends an additional `summary` event rather than mutating the approval decision.
 
 Provider-specific metadata can remain under event `payload` / `_meta`, but the callback boundary should not require callers to know Codex, Claude Code, or ACP transport details. That keeps the core event contract stable while adapter fidelity improves incrementally.
 
@@ -493,7 +494,7 @@ Provider-specific metadata can remain under event `payload` / `_meta`, but the c
 - database layer
 - production auth system
 - production deployment manifests
-- executor callback delivery for runtime approval decisions
+- provider-specific executor continuation implementations for runtime approval decisions
 - rich artifact editing/versioning API outside the current proposal/approval flow
 - multi-project tenant management beyond default project bootstrap
 - hosted GitHub app/webhook automation

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -990,9 +990,9 @@ test("SpecRailService derives waiting approval and resumed running state from ap
   assert.equal(resumedRun?.startedAt, run.startedAt);
   assert.equal(resumedRun?.finishedAt, undefined);
   assert.deepEqual(resumedRun?.summary, {
-    eventCount: 3,
-    lastEventSummary: `Approved runtime approval request ${run.id}:approval-requested`,
-    lastEventAt: "2026-04-09T06:00:03.000Z",
+    eventCount: 4,
+    lastEventSummary: "Runtime approval callback is not supported by executor codex",
+    lastEventAt: "2026-04-09T06:00:04.000Z",
   });
 
   const rejectedTrack = await service.createTrack({
@@ -1034,6 +1034,165 @@ test("SpecRailService derives waiting approval and resumed running state from ap
 
   const blockedTrack = await service.getTrack(rejectedTrack.id);
   assert.equal(blockedTrack?.status, "blocked");
+});
+
+test("SpecRailService delivers runtime approval decisions to executor callbacks", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-approval-callback-"));
+  const callbackCalls: Array<{ outcome: unknown; requestId: unknown; status: string }> = [];
+
+  const makeExecutor = (name: string, fail = false) => ({
+    name,
+    async spawn(input: { executionId: string; prompt: string; workspacePath: string }) {
+      return {
+        sessionRef: `session:${input.executionId}`,
+        command: {
+          command: name,
+          args: ["exec", input.prompt],
+          cwd: input.workspacePath,
+          prompt: input.prompt,
+        },
+        events: [
+          {
+            id: `${input.executionId}:started`,
+            executionId: input.executionId,
+            type: "task_status_changed" as const,
+            timestamp: "2026-04-09T07:00:00.000Z",
+            source: name,
+            summary: "Run started",
+            payload: { status: "running" },
+          },
+        ],
+      };
+    },
+    async resume() {
+      throw new Error("should not be called");
+    },
+    async cancel() {
+      throw new Error("should not be called");
+    },
+    async resolveRuntimeApproval(input: {
+      execution: { id: string; status: string };
+      approvalResolvedEvent: ExecutionEvent;
+    }) {
+      callbackCalls.push({
+        outcome: input.approvalResolvedEvent.payload?.outcome,
+        requestId: input.approvalResolvedEvent.payload?.requestId,
+        status: input.execution.status,
+      });
+
+      if (fail) {
+        throw new Error("callback transport unavailable");
+      }
+
+      return [
+        {
+          id: `${input.execution.id}:approval-callback-delivered`,
+          executionId: input.execution.id,
+          type: "summary" as const,
+          timestamp: "2026-04-09T07:00:05.000Z",
+          source: "specrail",
+          summary: "Runtime approval callback delivered to executor",
+          payload: { outcome: input.approvalResolvedEvent.payload?.outcome },
+        },
+      ];
+    },
+  });
+
+  const service = new SpecRailService({
+    projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
+    trackRepository: new FileTrackRepository(path.join(rootDir, "state")),
+    planningSessionRepository: new FilePlanningSessionRepository(path.join(rootDir, "state")),
+    planningMessageStore: new JsonlPlanningMessageStore(path.join(rootDir, "state")),
+    artifactRevisionRepository: new FileArtifactRevisionRepository(path.join(rootDir, "state")),
+    approvalRequestRepository: new FileApprovalRequestRepository(path.join(rootDir, "state")),
+    channelBindingRepository: new FileChannelBindingRepository(path.join(rootDir, "state")),
+    attachmentReferenceRepository: new FileAttachmentReferenceRepository(path.join(rootDir, "state")),
+    executionRepository: new FileExecutionRepository(path.join(rootDir, "state")),
+    eventStore: new JsonlEventStore(path.join(rootDir, "state")),
+    artifactWriter: { async write() {}, async writeApprovedArtifact() {} },
+    executor: makeExecutor("callback_executor"),
+    executors: {
+      callback_executor: makeExecutor("callback_executor"),
+      failing_executor: makeExecutor("failing_executor", true),
+    },
+    defaultExecutionBackend: "callback_executor",
+    defaultProject: {
+      id: "project-default",
+      name: "SpecRail",
+    },
+    workspaceRoot: path.join(rootDir, "workspaces"),
+    now: (() => {
+      const values = [
+        "2026-04-09T07:00:00.000Z",
+        "2026-04-09T07:00:01.000Z",
+        "2026-04-09T07:00:02.000Z",
+        "2026-04-09T07:00:03.000Z",
+        "2026-04-09T07:00:04.000Z",
+        "2026-04-09T07:00:05.000Z",
+        "2026-04-09T07:00:06.000Z",
+        "2026-04-09T07:00:07.000Z",
+      ];
+      return () => values.shift() ?? "2026-04-09T07:00:08.000Z";
+    })(),
+    idGenerator: (() => {
+      const values = ["track-callback", "run-callback", "approval-callback", "track-failing", "run-failing", "approval-failing"];
+      return () => values.shift() ?? "extra";
+    })(),
+  });
+
+  const track = await service.createTrack({ title: "Callback run", description: "approval callback" });
+  const run = await service.startRun({ trackId: track.id, prompt: "Start callback run", backend: "callback_executor" });
+  await service.recordExecutionEvent({
+    id: `${run.id}:approval-requested`,
+    executionId: run.id,
+    type: "approval_requested",
+    timestamp: "2026-04-09T07:00:02.000Z",
+    source: "callback_executor",
+    summary: "Approval requested",
+    payload: { toolName: "Bash", toolUseId: "toolu-callback" },
+  });
+
+  await service.resolveRuntimeApprovalRequest({
+    runId: run.id,
+    requestId: `${run.id}:approval-requested`,
+    outcome: "approved",
+    decidedBy: "user",
+  });
+
+  const callbackEvents = await service.listRunEvents(run.id);
+  assert.ok(callbackEvents.some((event) => event.summary === "Runtime approval callback delivered to executor"));
+  assert.deepEqual(callbackCalls[0], {
+    outcome: "approved",
+    requestId: `${run.id}:approval-requested`,
+    status: "running",
+  });
+
+  const failingTrack = await service.createTrack({ title: "Failing callback run", description: "approval callback failure" });
+  const failingRun = await service.startRun({
+    trackId: failingTrack.id,
+    prompt: "Start failing callback run",
+    backend: "failing_executor",
+  });
+  await service.recordExecutionEvent({
+    id: `${failingRun.id}:approval-requested`,
+    executionId: failingRun.id,
+    type: "approval_requested",
+    timestamp: "2026-04-09T07:00:06.000Z",
+    source: "failing_executor",
+    summary: "Approval requested",
+    payload: { toolName: "Bash", toolUseId: "toolu-failing" },
+  });
+
+  await service.resolveRuntimeApprovalRequest({
+    runId: failingRun.id,
+    requestId: `${failingRun.id}:approval-requested`,
+    outcome: "approved",
+    decidedBy: "system",
+  });
+
+  const failingEvents = await service.listRunEvents(failingRun.id);
+  assert.ok(failingEvents.some((event) => event.summary === "Runtime approval callback delivery failed"));
+  assert.equal((await service.getRun(failingRun.id))?.status, "running");
 });
 
 test("SpecRailService lists tracks and runs with basic filters", async () => {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -67,6 +67,12 @@ export interface ExecutorLaunchResult {
   events: ExecutionEvent[];
 }
 
+export interface RuntimeApprovalDecisionInput {
+  execution: Execution;
+  approvalRequestedEvent: ExecutionEvent;
+  approvalResolvedEvent: ExecutionEvent;
+}
+
 export interface ExecutionBackend {
   readonly name: string;
   spawn(input: {
@@ -88,6 +94,7 @@ export interface ExecutionBackend {
     workspacePath: string;
     profile: string;
   }): Promise<ExecutionEvent>;
+  resolveRuntimeApproval?(input: RuntimeApprovalDecisionInput): Promise<ExecutionEvent[]>;
 }
 
 export interface SpecRailServiceDependencies {
@@ -971,8 +978,70 @@ export class SpecRailService {
 
     await this.dependencies.eventStore.append(event);
     await this.reconcileExecutionFromEvents(execution.id);
+    await this.deliverRuntimeApprovalDecision(execution.id, requestedEvent, event);
 
     return event;
+  }
+
+  private async deliverRuntimeApprovalDecision(
+    executionId: string,
+    approvalRequestedEvent: ExecutionEvent,
+    approvalResolvedEvent: ExecutionEvent,
+  ): Promise<void> {
+    const execution = await this.dependencies.executionRepository.getById(executionId);
+    if (!execution) {
+      return;
+    }
+
+    const executor = this.resolveExecutor(execution.backend);
+    if (!executor.resolveRuntimeApproval) {
+      await this.dependencies.eventStore.append({
+        id: `${execution.id}:approval-callback-unsupported:${this.idGenerator()}`,
+        executionId: execution.id,
+        type: "summary",
+        timestamp: this.now(),
+        source: "specrail",
+        summary: `Runtime approval callback is not supported by executor ${executor.name}`,
+        payload: {
+          requestId: approvalResolvedEvent.payload?.requestId,
+          outcome: approvalResolvedEvent.payload?.outcome,
+          executor: executor.name,
+        },
+      });
+      await this.reconcileExecutionFromEvents(execution.id);
+      return;
+    }
+
+    try {
+      const callbackEvents = await executor.resolveRuntimeApproval({
+        execution,
+        approvalRequestedEvent,
+        approvalResolvedEvent,
+      });
+
+      for (const callbackEvent of callbackEvents) {
+        await this.dependencies.eventStore.append(callbackEvent);
+      }
+      if (callbackEvents.length > 0) {
+        await this.reconcileExecutionFromEvents(execution.id);
+      }
+    } catch (error) {
+      await this.dependencies.eventStore.append({
+        id: `${execution.id}:approval-callback-failed:${this.idGenerator()}`,
+        executionId: execution.id,
+        type: "summary",
+        timestamp: this.now(),
+        source: "specrail",
+        summary: "Runtime approval callback delivery failed",
+        payload: {
+          requestId: approvalResolvedEvent.payload?.requestId,
+          outcome: approvalResolvedEvent.payload?.outcome,
+          executor: executor.name,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      await this.reconcileExecutionFromEvents(execution.id);
+    }
   }
 
   private async reconcileExecutionFromEvents(executionId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add an optional `ExecutionBackend.resolveRuntimeApproval(...)` hook for provider-neutral approval decision delivery
- call the hook after canonical `approval_resolved` events are persisted and execution state is reconciled
- append observable summary events for unsupported or failing callback delivery without mutating approval decisions
- cover supported, unsupported, and failing callback paths in service tests
- update architecture docs to describe the implemented hook behavior

Closes #146

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build