### PR TITLE
feat: expose approval callback outcome

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -187,7 +187,7 @@ function createFakeService() {
         },
       };
       await service.recordExecutionEvent(event);
-      return event;
+      return { event, callback: { status: "unsupported" as const, events: [] } };
     },
   } satisfies Pick<
     SpecRailService,
@@ -207,7 +207,7 @@ function createFakeService() {
 test("ACP server initializes and maps session/new + prompt to SpecRail run lifecycle", async () => {
   const stateDir = await mkdtemp(path.join(os.tmpdir(), "specrail-acp-state-"));
   const server = new SpecRailAcpServer({
-    service: createFakeService() as SpecRailService,
+    service: createFakeService() as unknown as SpecRailService,
     stateDir,
     now: () => "2026-04-13T12:00:00.000Z",
     pollIntervalMs: 1,
@@ -290,7 +290,7 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
 test("ACP server emits richer permission request and resolution updates", async () => {
   const stateDir = await mkdtemp(path.join(os.tmpdir(), "specrail-acp-state-"));
   const server = new SpecRailAcpServer({
-    service: createFakeService() as SpecRailService,
+    service: createFakeService() as unknown as SpecRailService,
     stateDir,
     now: () => "2026-04-13T12:00:00.000Z",
     pollIntervalMs: 1,

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   type Execution,
   type ExecutionEvent,
+  type RuntimeApprovalResolutionResult,
   type SpecRailService,
   NotFoundError,
   ValidationError,
@@ -271,7 +272,12 @@ export class SpecRailAcpServer {
       let execution: Execution;
       let startingEventCount = 0;
 
-      if (session.runId) {
+      const permissionResolution = body._meta?.specrail?.permissionResolution;
+
+      if (session.runId && permissionResolution) {
+        execution = await this.requireRun(session.runId);
+        startingEventCount = (await this.options.service.listRunEvents(execution.id)).length;
+      } else if (session.runId) {
         execution = await this.options.service.resumeRun({ runId: session.runId, prompt, profile: session.profile, backend: session.backend });
         startingEventCount = (await this.options.service.listRunEvents(execution.id)).length;
       } else {
@@ -296,11 +302,18 @@ export class SpecRailAcpServer {
       await this.writeSession(updatedSession);
       notify(this.toSessionInfoUpdate(updatedSession, execution));
 
-      const permissionResolution = body._meta?.specrail?.permissionResolution;
       if (permissionResolution) {
-        const resolutionEvent = await this.resolvePendingPermission(updatedSession, execution, permissionResolution);
-        if (resolutionEvent) {
-          notify(this.toSessionUpdate(updatedSession.sessionId, resolutionEvent));
+        const resolution = await this.resolvePendingPermission(updatedSession, execution, permissionResolution);
+        if (resolution) {
+          notify(this.toSessionUpdate(updatedSession.sessionId, resolution.event));
+          if (permissionResolution.outcome === "approved" && resolution.callback.status !== "handled") {
+            execution = await this.options.service.resumeRun({
+              runId: execution.id,
+              prompt,
+              profile: session.profile,
+              backend: session.backend,
+            });
+          }
         }
       }
 
@@ -585,7 +598,7 @@ export class SpecRailAcpServer {
         ? R
         : never
       : never,
-  ): Promise<ExecutionEvent | null> {
+  ): Promise<RuntimeApprovalResolutionResult | null> {
     const pending = session.pendingPermissionRequest;
     if (!pending) {
       throw new ValidationError("permissionResolution provided but there is no pending runtime permission request");
@@ -606,7 +619,7 @@ export class SpecRailAcpServer {
       throw new ValidationError("_meta.specrail.permissionResolution.decidedBy must be user, agent, or system");
     }
 
-    const event = await this.options.service.resolveRuntimeApprovalRequest({
+    const result = await this.options.service.resolveRuntimeApprovalRequest({
       runId: execution.id,
       requestId,
       outcome,
@@ -623,7 +636,7 @@ export class SpecRailAcpServer {
     await this.writeSession(updatedSession);
     Object.assign(session, updatedSession);
 
-    return event;
+    return result;
   }
 
   private async requireRun(runId: string): Promise<Execution> {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1072,14 +1072,14 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
       ) {
         const body = await readJson<ResolveRuntimeApprovalRequestBody>(request);
         assertValidResolveRuntimeApprovalRequestBody(body);
-        const event = await deps.service.resolveRuntimeApprovalRequest({
+        const result = await deps.service.resolveRuntimeApprovalRequest({
           runId: segments[1] ?? "",
           requestId: segments[3] ?? "",
           outcome: segments[4] === "approve" ? "approved" : "rejected",
           decidedBy: body.decidedBy,
           comment: body.comment,
         });
-        sendJson(response, 200, { event });
+        sendJson(response, 200, { event: result.event });
         return;
       }
 

--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -484,7 +484,8 @@ Expected callback behavior:
 
 - `approved`: continue the blocked operation when the provider exposes a permission-continuation primitive; otherwise resume the run with a clear event explaining the fallback path.
 - `rejected`: do not retry the blocked operation; mark or keep the run cancelled unless a backend can represent a narrower blocked-step state.
-- unsupported callbacks append a `summary` event so the gap is visible in run history.
+- unsupported callbacks append a `summary` event so the gap is visible in run history and edge adapters can use their fallback resume path.
+- handled callbacks let edge adapters skip duplicate resume/continuation behavior.
 - callback failure after the domain event is recorded appends an additional `summary` event rather than mutating the approval decision.
 
 Provider-specific metadata can remain under event `payload` / `_meta`, but the callback boundary should not require callers to know Codex, Claude Code, or ACP transport details. That keeps the core event contract stable while adapter fidelity improves incrementally.

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -963,17 +963,18 @@ test("SpecRailService derives waiting approval and resumed running state from ap
     lastEventAt: "2026-04-09T06:00:01.000Z",
   });
 
-  const resolutionEvent = await service.resolveRuntimeApprovalRequest({
+  const resolution = await service.resolveRuntimeApprovalRequest({
     runId: run.id,
     requestId: `${run.id}:approval-requested`,
     outcome: "approved",
     decidedBy: "user",
     comment: "approved for test",
   });
-  assert.equal(resolutionEvent.type, "approval_resolved");
-  assert.equal(resolutionEvent.payload?.requestId, `${run.id}:approval-requested`);
-  assert.equal(resolutionEvent.payload?.outcome, "approved");
-  assert.equal(resolutionEvent.payload?.status, "running");
+  assert.equal(resolution.event.type, "approval_resolved");
+  assert.equal(resolution.event.payload?.requestId, `${run.id}:approval-requested`);
+  assert.equal(resolution.event.payload?.outcome, "approved");
+  assert.equal(resolution.event.payload?.status, "running");
+  assert.equal(resolution.callback.status, "unsupported");
 
   await assert.rejects(
     service.resolveRuntimeApprovalRequest({
@@ -1024,9 +1025,9 @@ test("SpecRailService derives waiting approval and resumed running state from ap
     decidedBy: "agent",
     comment: "too risky",
   });
-  assert.equal(rejectedResolution.payload?.status, "cancelled");
-  assert.equal(rejectedResolution.payload?.outcome, "rejected");
-  assert.equal(rejectedResolution.payload?.toolName, "Bash");
+  assert.equal(rejectedResolution.event.payload?.status, "cancelled");
+  assert.equal(rejectedResolution.event.payload?.outcome, "rejected");
+  assert.equal(rejectedResolution.event.payload?.toolName, "Bash");
 
   const cancelledRun = await service.getRun(rejectedRun.id);
   assert.equal(cancelledRun?.status, "cancelled");
@@ -1152,12 +1153,13 @@ test("SpecRailService delivers runtime approval decisions to executor callbacks"
     payload: { toolName: "Bash", toolUseId: "toolu-callback" },
   });
 
-  await service.resolveRuntimeApprovalRequest({
+  const callbackResolution = await service.resolveRuntimeApprovalRequest({
     runId: run.id,
     requestId: `${run.id}:approval-requested`,
     outcome: "approved",
     decidedBy: "user",
   });
+  assert.equal(callbackResolution.callback.status, "handled");
 
   const callbackEvents = await service.listRunEvents(run.id);
   assert.ok(callbackEvents.some((event) => event.summary === "Runtime approval callback delivered to executor"));
@@ -1183,12 +1185,14 @@ test("SpecRailService delivers runtime approval decisions to executor callbacks"
     payload: { toolName: "Bash", toolUseId: "toolu-failing" },
   });
 
-  await service.resolveRuntimeApprovalRequest({
+  const failingResolution = await service.resolveRuntimeApprovalRequest({
     runId: failingRun.id,
     requestId: `${failingRun.id}:approval-requested`,
     outcome: "approved",
     decidedBy: "system",
   });
+  assert.equal(failingResolution.callback.status, "failed");
+  assert.equal(failingResolution.callback.error, "callback transport unavailable");
 
   const failingEvents = await service.listRunEvents(failingRun.id);
   assert.ok(failingEvents.some((event) => event.summary === "Runtime approval callback delivery failed"));

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -192,6 +192,17 @@ export interface ResolveRuntimeApprovalRequestInput {
   comment?: string;
 }
 
+export interface RuntimeApprovalCallbackDelivery {
+  status: "handled" | "unsupported" | "failed";
+  events: ExecutionEvent[];
+  error?: string;
+}
+
+export interface RuntimeApprovalResolutionResult {
+  event: ExecutionEvent;
+  callback: RuntimeApprovalCallbackDelivery;
+}
+
 export interface BindChannelInput {
   projectId: string;
   channelType: ChannelBinding["channelType"];
@@ -934,7 +945,7 @@ export class SpecRailService {
     await this.reconcileExecutionFromEvents(event.executionId);
   }
 
-  async resolveRuntimeApprovalRequest(input: ResolveRuntimeApprovalRequestInput): Promise<ExecutionEvent> {
+  async resolveRuntimeApprovalRequest(input: ResolveRuntimeApprovalRequestInput): Promise<RuntimeApprovalResolutionResult> {
     const execution = await this.requireRun(input.runId);
     const events = await this.dependencies.eventStore.listByExecution(execution.id);
     const requestedEvent = events.find(
@@ -978,24 +989,24 @@ export class SpecRailService {
 
     await this.dependencies.eventStore.append(event);
     await this.reconcileExecutionFromEvents(execution.id);
-    await this.deliverRuntimeApprovalDecision(execution.id, requestedEvent, event);
+    const callback = await this.deliverRuntimeApprovalDecision(execution.id, requestedEvent, event);
 
-    return event;
+    return { event, callback };
   }
 
   private async deliverRuntimeApprovalDecision(
     executionId: string,
     approvalRequestedEvent: ExecutionEvent,
     approvalResolvedEvent: ExecutionEvent,
-  ): Promise<void> {
+  ): Promise<RuntimeApprovalCallbackDelivery> {
     const execution = await this.dependencies.executionRepository.getById(executionId);
     if (!execution) {
-      return;
+      return { status: "failed", events: [], error: `Execution not found: ${executionId}` };
     }
 
     const executor = this.resolveExecutor(execution.backend);
     if (!executor.resolveRuntimeApproval) {
-      await this.dependencies.eventStore.append({
+      const event: ExecutionEvent = {
         id: `${execution.id}:approval-callback-unsupported:${this.idGenerator()}`,
         executionId: execution.id,
         type: "summary",
@@ -1007,9 +1018,10 @@ export class SpecRailService {
           outcome: approvalResolvedEvent.payload?.outcome,
           executor: executor.name,
         },
-      });
+      };
+      await this.dependencies.eventStore.append(event);
       await this.reconcileExecutionFromEvents(execution.id);
-      return;
+      return { status: "unsupported", events: [event] };
     }
 
     try {
@@ -1025,8 +1037,9 @@ export class SpecRailService {
       if (callbackEvents.length > 0) {
         await this.reconcileExecutionFromEvents(execution.id);
       }
+      return { status: "handled", events: callbackEvents };
     } catch (error) {
-      await this.dependencies.eventStore.append({
+      const event: ExecutionEvent = {
         id: `${execution.id}:approval-callback-failed:${this.idGenerator()}`,
         executionId: execution.id,
         type: "summary",
@@ -1039,8 +1052,14 @@ export class SpecRailService {
           executor: executor.name,
           error: error instanceof Error ? error.message : String(error),
         },
-      });
+      };
+      await this.dependencies.eventStore.append(event);
       await this.reconcileExecutionFromEvents(execution.id);
+      return {
+        status: "failed",
+        events: [event],
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- return runtime approval callback delivery status from the core resolution path
- keep HTTP response compatibility by continuing to expose `{ event }`
- update ACP permission resolution to avoid pre-resume and skip fallback resume when the executor callback handled continuation
- keep unsupported and failed callbacks on the safe fallback resume path
- update tests and architecture notes for callback outcomes

Closes #148

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build