### PR TITLE
feat: add provider approval callbacks

### DIFF
--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -100,7 +100,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 ## Near-term follow-up
 
 Good next steps from the current bridge:
-- deliver persisted runtime approval decisions into active executor callbacks where providers support continuation
+- replace provider resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
 - expand the ACP-facing event taxonomy beyond readable `agent_message_chunk` fallbacks for provider-specific details that clients need to render natively
 - define workspace ownership rules before exposing filesystem or terminal ACP capabilities for SpecRail-managed workspaces
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client

--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -60,10 +60,11 @@ Currently implemented:
 - run summary derivation from persisted events
 - terminal-state reconciliation back into track status (`completed -> review`, `failed -> failed`, `cancelled -> blocked`)
 - planning-context capture for runs, including stale-context rejection when newer planning revisions are pending approval
+- executor callback delivery for runtime approval decisions through Codex and Claude Code resume/no-retry fallbacks
 
 Currently not implemented:
 - worktree/git orchestration beyond metadata/workspace path allocation
-- executor callback delivery for already-recorded runtime approval decisions when a backend implements `resolveRuntimeApproval(...)`
+- provider-native permission continuation beyond normal resume fallback behavior
 - scheduler/queue management
 
 ### 3. Interface plane
@@ -495,7 +496,7 @@ Provider-specific metadata can remain under event `payload` / `_meta`, but the c
 - database layer
 - production auth system
 - production deployment manifests
-- provider-specific executor continuation implementations for runtime approval decisions
+- provider-native permission continuation primitives beyond current resume fallback behavior
 - rich artifact editing/versioning API outside the current proposal/approval flow
 - multi-project tenant management beyond default project bootstrap
 - hosted GitHub app/webhook automation

--- a/docs/claude-code-operations.md
+++ b/docs/claude-code-operations.md
@@ -136,9 +136,10 @@ These are current, expected limitations of the MVP:
    - `*.claude-stream.jsonl` captures Claude stdout stream-json output.
    - stderr is normalized into SpecRail events, but not mirrored into that raw stdout transcript file.
 
-6. approval decisions are persisted, but not delivered back into Claude Code yet.
+6. approval decisions are persisted and delivered through the Claude Code executor callback hook.
    - `approval_requested` events can be resolved through the core service/API.
-   - a future executor callback still needs to bridge approved/rejected decisions into Claude Code continuation behavior when the CLI exposes a usable primitive.
+   - approved decisions currently spawn the normal Claude Code resume fallback because the CLI does not expose a narrower permission-continuation primitive.
+   - rejected decisions are recorded as no-retry outcomes and mark the adapter session cancelled.
 
 ## Recovery guide
 

--- a/packages/adapters/src/__tests__/claude-code-adapter.test.ts
+++ b/packages/adapters/src/__tests__/claude-code-adapter.test.ts
@@ -307,6 +307,129 @@ test("ClaudeCodeAdapter records an explicit failure message when Claude exits no
   assert.equal(runtimeEvents.at(-1)?.subtype, "claude_failed");
 });
 
+
+test("ClaudeCodeAdapter records runtime approval callback outcomes", async () => {
+  const sessionsDir = await mkdtemp(path.join(os.tmpdir(), "specrail-claude-sessions-"));
+  const child = new FakeChildProcess(6262);
+  const adapter = new ClaudeCodeAdapter({
+    sessionsDir,
+    now: (() => {
+      const timestamps = ["2026-04-10T13:00:00.000Z", "2026-04-10T13:00:01.000Z", "2026-04-10T13:00:02.000Z"];
+      return () => timestamps.shift() ?? "2026-04-10T13:00:03.000Z";
+    })(),
+    spawnProcess: () => child,
+  });
+
+  const spawnResult = await adapter.spawn({
+    executionId: "run-claude-approval",
+    prompt: "Initial prompt",
+    workspacePath: "/tmp/specrail/run-claude-approval",
+    profile: "default",
+  });
+
+  child.stdout.emitData('{"type":"system","subtype":"init","session_id":"claude-approval-session","uuid":"init-approval"}\n');
+  await flush();
+
+  const approvedEvents = await adapter.resolveRuntimeApproval({
+    execution: {
+      id: "run-claude-approval",
+      trackId: "track-approval",
+      backend: "claude_code",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-claude-approval",
+      branchName: "specrail/run-claude-approval",
+      sessionRef: spawnResult.sessionRef,
+      status: "running",
+      createdAt: "2026-04-10T13:00:00.000Z",
+    },
+    approvalRequestedEvent: {
+      id: "run-claude-approval:approval-requested",
+      executionId: "run-claude-approval",
+      type: "approval_requested",
+      timestamp: "2026-04-10T13:00:00.500Z",
+      source: "claude_code",
+      summary: "Approval requested",
+      payload: { toolName: "Bash", toolUseId: "toolu-claude" },
+    },
+    approvalResolvedEvent: {
+      id: "run-claude-approval:approval-resolved",
+      executionId: "run-claude-approval",
+      type: "approval_resolved",
+      timestamp: "2026-04-10T13:00:01.500Z",
+      source: "specrail",
+      summary: "Approved runtime approval request",
+      payload: {
+        requestId: "run-claude-approval:approval-requested",
+        requestEventId: "run-claude-approval:approval-requested",
+        outcome: "approved",
+        decidedBy: "user",
+        toolName: "Bash",
+        toolUseId: "toolu-claude",
+      },
+    },
+  });
+
+  assert.equal(approvedEvents[0]?.summary, "Resumed Claude Code session run-claude-approval-claude");
+  assert.equal(approvedEvents[1]?.summary, "Claude Code runtime approval run-claude-approval:approval-requested accepted; spawned normal resume fallback");
+  assert.equal(approvedEvents[1]?.payload?.strategy, "resume_fallback");
+  let metadata = await readClaudeCodeSessionMetadata(sessionsDir, spawnResult.sessionRef);
+  assert.equal(metadata.status, "running");
+  assert.deepEqual(metadata.providerMetadata?.runtimeApproval, {
+    requestId: "run-claude-approval:approval-requested",
+    requestEventId: "run-claude-approval:approval-requested",
+    outcome: "approved",
+    decidedBy: "user",
+    resolvedAt: "2026-04-10T13:00:01.500Z",
+    handledAt: "2026-04-10T13:00:03.000Z",
+    strategy: "claude-code-resume-fallback",
+  });
+
+  const rejectedEvents = await adapter.resolveRuntimeApproval({
+    execution: {
+      id: "run-claude-approval",
+      trackId: "track-approval",
+      backend: "claude_code",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-claude-approval",
+      branchName: "specrail/run-claude-approval",
+      sessionRef: spawnResult.sessionRef,
+      status: "cancelled",
+      createdAt: "2026-04-10T13:00:00.000Z",
+    },
+    approvalRequestedEvent: {
+      id: "run-claude-approval:approval-requested-2",
+      executionId: "run-claude-approval",
+      type: "approval_requested",
+      timestamp: "2026-04-10T13:00:02.250Z",
+      source: "claude_code",
+      summary: "Approval requested",
+    },
+    approvalResolvedEvent: {
+      id: "run-claude-approval:approval-rejected",
+      executionId: "run-claude-approval",
+      type: "approval_resolved",
+      timestamp: "2026-04-10T13:00:02.500Z",
+      source: "specrail",
+      summary: "Rejected runtime approval request",
+      payload: {
+        requestId: "run-claude-approval:approval-requested-2",
+        requestEventId: "run-claude-approval:approval-requested-2",
+        outcome: "rejected",
+        decidedBy: "agent",
+      },
+    },
+  });
+
+  assert.equal(rejectedEvents[0]?.payload?.strategy, "no_retry");
+  metadata = await readClaudeCodeSessionMetadata(sessionsDir, spawnResult.sessionRef);
+  assert.equal(metadata.status, "cancelled");
+  assert.equal(metadata.finishedAt, "2026-04-10T13:00:03.000Z");
+
+  const runtimeEvents = await readClaudeCodeSessionEvents(sessionsDir, spawnResult.sessionRef);
+  assert.ok(runtimeEvents.some((event) => event.summary === approvedEvents[0]?.summary));
+  assert.ok(runtimeEvents.some((event) => event.summary === rejectedEvents[0]?.summary));
+});
+
 test("ClaudeCodeAdapter normalizes lifecycle and fallback stream events into shared execution events", () => {
   const adapter = new ClaudeCodeAdapter({ sessionsDir: "/tmp/specrail-claude" });
 

--- a/packages/adapters/src/__tests__/codex-adapter.test.ts
+++ b/packages/adapters/src/__tests__/codex-adapter.test.ts
@@ -227,6 +227,129 @@ test("CodexAdapter resume prefers discovered Codex session id and cancel marks t
   assert.equal((await readCodexSessionMetadata(sessionsDir, spawnResult.sessionRef)).status, "cancelled");
 });
 
+
+test("CodexAdapter records runtime approval callback outcomes", async () => {
+  const sessionsDir = await mkdtemp(path.join(os.tmpdir(), "specrail-codex-sessions-"));
+  const child = new FakeChildProcess(5252);
+  const adapter = new CodexAdapter({
+    sessionsDir,
+    now: (() => {
+      const timestamps = ["2026-04-09T01:00:00.000Z", "2026-04-09T01:00:01.000Z", "2026-04-09T01:00:02.000Z"];
+      return () => timestamps.shift() ?? "2026-04-09T01:00:03.000Z";
+    })(),
+    spawnProcess: () => child,
+  });
+
+  const spawnResult = await adapter.spawn({
+    executionId: "run-codex-approval",
+    prompt: "Initial prompt",
+    workspacePath: "/tmp/specrail/run-codex-approval",
+    profile: "default",
+  });
+
+  const approvedEvents = await adapter.resolveRuntimeApproval({
+    execution: {
+      id: "run-codex-approval",
+      trackId: "track-approval",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-codex-approval",
+      branchName: "specrail/run-codex-approval",
+      sessionRef: spawnResult.sessionRef,
+      status: "running",
+      createdAt: "2026-04-09T01:00:00.000Z",
+    },
+    approvalRequestedEvent: {
+      id: "run-codex-approval:approval-requested",
+      executionId: "run-codex-approval",
+      type: "approval_requested",
+      timestamp: "2026-04-09T01:00:00.500Z",
+      source: "codex",
+      summary: "Approval requested",
+      payload: { toolName: "Bash", toolUseId: "toolu-codex" },
+    },
+    approvalResolvedEvent: {
+      id: "run-codex-approval:approval-resolved",
+      executionId: "run-codex-approval",
+      type: "approval_resolved",
+      timestamp: "2026-04-09T01:00:01.500Z",
+      source: "specrail",
+      summary: "Approved runtime approval request",
+      payload: {
+        requestId: "run-codex-approval:approval-requested",
+        requestEventId: "run-codex-approval:approval-requested",
+        outcome: "approved",
+        decidedBy: "user",
+        toolName: "Bash",
+        toolUseId: "toolu-codex",
+      },
+    },
+  });
+
+  assert.equal(approvedEvents[0]?.summary, "Resumed Codex session run-codex-approval-codex");
+  assert.equal(approvedEvents[1]?.summary, "Codex runtime approval run-codex-approval:approval-requested accepted; spawned normal resume fallback");
+  assert.equal(approvedEvents[1]?.payload?.strategy, "resume_fallback");
+  let metadata = await readCodexSessionMetadata(sessionsDir, spawnResult.sessionRef);
+  assert.equal(metadata.status, "running");
+  assert.deepEqual(metadata.providerMetadata?.runtimeApproval, {
+    requestId: "run-codex-approval:approval-requested",
+    requestEventId: "run-codex-approval:approval-requested",
+    outcome: "approved",
+    decidedBy: "user",
+    resolvedAt: "2026-04-09T01:00:01.500Z",
+    handledAt: "2026-04-09T01:00:02.000Z",
+    strategy: "codex-resume-fallback",
+  });
+
+  const rejectedEvents = await adapter.resolveRuntimeApproval({
+    execution: {
+      id: "run-codex-approval",
+      trackId: "track-approval",
+      backend: "codex",
+      profile: "default",
+      workspacePath: "/tmp/specrail/run-codex-approval",
+      branchName: "specrail/run-codex-approval",
+      sessionRef: spawnResult.sessionRef,
+      status: "cancelled",
+      createdAt: "2026-04-09T01:00:00.000Z",
+    },
+    approvalRequestedEvent: {
+      id: "run-codex-approval:approval-requested-2",
+      executionId: "run-codex-approval",
+      type: "approval_requested",
+      timestamp: "2026-04-09T01:00:01.750Z",
+      source: "codex",
+      summary: "Approval requested",
+    },
+    approvalResolvedEvent: {
+      id: "run-codex-approval:approval-rejected",
+      executionId: "run-codex-approval",
+      type: "approval_resolved",
+      timestamp: "2026-04-09T01:00:02.500Z",
+      source: "specrail",
+      summary: "Rejected runtime approval request",
+      payload: {
+        requestId: "run-codex-approval:approval-requested-2",
+        requestEventId: "run-codex-approval:approval-requested-2",
+        outcome: "rejected",
+        decidedBy: "agent",
+      },
+    },
+  });
+
+  assert.equal(rejectedEvents[0]?.payload?.strategy, "no_retry");
+  metadata = await readCodexSessionMetadata(sessionsDir, spawnResult.sessionRef);
+  assert.equal(metadata.status, "cancelled");
+  assert.equal(metadata.finishedAt, "2026-04-09T01:00:03.000Z");
+
+  const runtimeEvents = await readCodexSessionEvents(sessionsDir, spawnResult.sessionRef);
+  assert.deepEqual(runtimeEvents.map((event) => event.summary), [
+    approvedEvents[0]?.summary,
+    approvedEvents[1]?.summary,
+    rejectedEvents[0]?.summary,
+  ]);
+});
+
 test("CodexAdapter normalizes lifecycle and stream events into shared execution events", () => {
   const adapter = new CodexAdapter({ sessionsDir: "/tmp/specrail-codex" });
 

--- a/packages/adapters/src/interfaces/executor-adapter.ts
+++ b/packages/adapters/src/interfaces/executor-adapter.ts
@@ -1,4 +1,4 @@
-import type { CommandExecutionMetadata, ExecutionEvent } from "@specrail/core";
+import type { CommandExecutionMetadata, ExecutionEvent, RuntimeApprovalDecisionInput } from "@specrail/core";
 
 export type ExecutionBackend = "codex" | "claude_code" | (string & {});
 
@@ -80,5 +80,6 @@ export interface ExecutorAdapter {
   spawn(input: SpawnExecutionInput): Promise<SpawnExecutionResult>;
   resume(input: ResumeExecutionInput): Promise<ResumeExecutionResult>;
   cancel(input: CancelExecutionInput): Promise<ExecutionEvent>;
+  resolveRuntimeApproval?(input: RuntimeApprovalDecisionInput): Promise<ExecutionEvent[]>;
   normalize(rawEvent: unknown): ExecutionEvent | null;
 }

--- a/packages/adapters/src/providers/claude-code-adapter.ts
+++ b/packages/adapters/src/providers/claude-code-adapter.ts
@@ -9,7 +9,7 @@ import {
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
-import type { CommandExecutionMetadata, ExecutionEvent } from "@specrail/core";
+import type { CommandExecutionMetadata, ExecutionEvent, RuntimeApprovalDecisionInput } from "@specrail/core";
 import type {
   CancelExecutionInput,
   ExecutorAdapter,
@@ -376,6 +376,72 @@ export class ClaudeCodeAdapter implements ExecutorAdapter {
       command: toCommandMetadata(command, input.prompt, resumeSessionRef),
       events: event ? [event] : [],
     };
+  }
+
+  async resolveRuntimeApproval(input: RuntimeApprovalDecisionInput): Promise<ExecutionEvent[]> {
+    if (!input.execution.sessionRef) {
+      throw new Error(`Claude Code runtime approval callback requires a sessionRef for execution ${input.execution.id}`);
+    }
+
+    const metadata = await readSessionMetadata(this.sessionsDir, input.execution.sessionRef);
+    const outcome = input.approvalResolvedEvent.payload?.outcome;
+    const requestId = input.approvalResolvedEvent.payload?.requestId;
+    const approved = outcome === "approved";
+    const resumeEvents = approved
+      ? (await this.resume({
+          sessionRef: metadata.sessionRef,
+          prompt: "Permission approved. Continue the blocked operation.",
+          workspacePath: metadata.workspacePath,
+          profile: metadata.profile,
+        })).events
+      : [];
+    const latestMetadata = approved ? await readSessionMetadata(this.sessionsDir, metadata.sessionRef) : metadata;
+    const timestamp = this.now();
+    const updatedMetadata: ExecutorSessionMetadata = {
+      ...latestMetadata,
+      status: approved ? "running" : "cancelled",
+      updatedAt: timestamp,
+      finishedAt: approved ? latestMetadata.finishedAt : (latestMetadata.finishedAt ?? timestamp),
+      providerMetadata: mergeProviderMetadata(latestMetadata, {
+        runtimeApproval: {
+          requestId,
+          requestEventId: input.approvalResolvedEvent.payload?.requestEventId,
+          outcome,
+          decidedBy: input.approvalResolvedEvent.payload?.decidedBy,
+          resolvedAt: input.approvalResolvedEvent.timestamp,
+          handledAt: timestamp,
+          strategy: approved ? "claude-code-resume-fallback" : "claude-code-reject-no-retry",
+        },
+      }),
+    };
+    await writeSessionMetadata(this.sessionsDir, updatedMetadata);
+
+    const event: ExecutionEvent = {
+      id: `${input.execution.id}:claude-code-approval-callback:${timestamp}`,
+      executionId: input.execution.id,
+      type: "summary",
+      timestamp,
+      source: this.name,
+      summary: approved
+        ? `Claude Code runtime approval ${String(requestId)} accepted; spawned normal resume fallback`
+        : `Claude Code runtime approval ${String(requestId)} rejected; blocked operation will not be retried`,
+      payload: {
+        sessionRef: metadata.sessionRef,
+        providerSessionId: metadata.providerSessionId,
+        providerInvocationId: metadata.providerInvocationId,
+        requestId,
+        requestEventId: input.approvalResolvedEvent.payload?.requestEventId,
+        outcome,
+        strategy: approved ? "resume_fallback" : "no_retry",
+        toolName: input.approvalResolvedEvent.payload?.toolName,
+        toolUseId: input.approvalResolvedEvent.payload?.toolUseId,
+      },
+    };
+    for (const resumeEvent of resumeEvents) {
+      appendSessionEventSync(this.sessionsDir, metadata.sessionRef, resumeEvent);
+    }
+    appendSessionEventSync(this.sessionsDir, metadata.sessionRef, event);
+    return [...resumeEvents, event];
   }
 
   async cancel(input: CancelExecutionInput | string): Promise<ExecutionEvent> {

--- a/packages/adapters/src/providers/codex-adapter.stub.ts
+++ b/packages/adapters/src/providers/codex-adapter.stub.ts
@@ -9,7 +9,7 @@ import {
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
-import type { CommandExecutionMetadata, ExecutionEvent } from "@specrail/core";
+import type { CommandExecutionMetadata, ExecutionEvent, RuntimeApprovalDecisionInput } from "@specrail/core";
 import type {
   CancelExecutionInput,
   ExecutorAdapter,
@@ -298,6 +298,71 @@ export class CodexAdapter implements ExecutorAdapter {
       command: toCommandMetadata(command, input.prompt, resumeSessionRef),
       events: event ? [event] : [],
     };
+  }
+
+  async resolveRuntimeApproval(input: RuntimeApprovalDecisionInput): Promise<ExecutionEvent[]> {
+    if (!input.execution.sessionRef) {
+      throw new Error(`Codex runtime approval callback requires a sessionRef for execution ${input.execution.id}`);
+    }
+
+    const metadata = await readSessionMetadata(this.sessionsDir, input.execution.sessionRef);
+    const outcome = input.approvalResolvedEvent.payload?.outcome;
+    const requestId = input.approvalResolvedEvent.payload?.requestId;
+    const approved = outcome === "approved";
+    const resumeEvents = approved
+      ? (await this.resume({
+          sessionRef: metadata.sessionRef,
+          prompt: "Permission approved. Continue the blocked operation.",
+          workspacePath: metadata.workspacePath,
+          profile: metadata.profile,
+        })).events
+      : [];
+    const latestMetadata = approved ? await readSessionMetadata(this.sessionsDir, metadata.sessionRef) : metadata;
+    const timestamp = this.now();
+    const updatedMetadata: ExecutorSessionMetadata = {
+      ...latestMetadata,
+      status: approved ? "running" : "cancelled",
+      updatedAt: timestamp,
+      finishedAt: approved ? latestMetadata.finishedAt : (latestMetadata.finishedAt ?? timestamp),
+      providerMetadata: {
+        ...(latestMetadata.providerMetadata ?? {}),
+        runtimeApproval: {
+          requestId,
+          requestEventId: input.approvalResolvedEvent.payload?.requestEventId,
+          outcome,
+          decidedBy: input.approvalResolvedEvent.payload?.decidedBy,
+          resolvedAt: input.approvalResolvedEvent.timestamp,
+          handledAt: timestamp,
+          strategy: approved ? "codex-resume-fallback" : "codex-reject-no-retry",
+        },
+      },
+    };
+    await writeSessionMetadata(this.sessionsDir, updatedMetadata);
+
+    const event: ExecutionEvent = {
+      id: `${input.execution.id}:codex-approval-callback:${timestamp}`,
+      executionId: input.execution.id,
+      type: "summary",
+      timestamp,
+      source: this.name,
+      summary: approved
+        ? `Codex runtime approval ${String(requestId)} accepted; spawned normal resume fallback`
+        : `Codex runtime approval ${String(requestId)} rejected; blocked operation will not be retried`,
+      payload: {
+        sessionRef: metadata.sessionRef,
+        requestId,
+        requestEventId: input.approvalResolvedEvent.payload?.requestEventId,
+        outcome,
+        strategy: approved ? "resume_fallback" : "no_retry",
+        toolName: input.approvalResolvedEvent.payload?.toolName,
+        toolUseId: input.approvalResolvedEvent.payload?.toolUseId,
+      },
+    };
+    for (const resumeEvent of resumeEvents) {
+      appendSessionEventSync(this.sessionsDir, metadata.sessionRef, resumeEvent);
+    }
+    appendSessionEventSync(this.sessionsDir, metadata.sessionRef, event);
+    return [...resumeEvents, event];
   }
 
   async cancel(input: CancelExecutionInput | string): Promise<ExecutionEvent> {


### PR DESCRIPTION
## Summary
- implement runtime approval callback hooks for Codex and Claude Code adapters
- approved decisions spawn provider-specific normal resume fallbacks and record callback summary events
- rejected decisions update adapter session metadata as no-retry/cancelled without retrying the blocked operation
- persist provider runtime approval metadata and session events for auditability
- update architecture, ACP edge, and Claude Code operations docs

Closes #150

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build