### PR TITLE
docs: define worktree orchestration contract

### DIFF
--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -366,6 +366,39 @@ workspaces/
   <runId>/
 ```
 
+### Execution workspace and branch contract
+
+The current MVP always allocates a per-run workspace path before starting an executor:
+
+```text
+workspacePath = workspaces/<runId>/
+branchName = specrail/<runId>
+```
+
+The workspace path is persisted on the execution record and passed to the selected executor as its working directory. The branch name is currently metadata only; future git orchestration should make it real without changing the execution record shape.
+
+Workspace modes:
+
+- `directory`: create `workspaces/<runId>/` as an empty/plain directory. This is the current behavior and remains the safe fallback.
+- `git_worktree`: create a git worktree rooted at `workspaces/<runId>/` with branch `specrail/<runId>` when the project has a local git repository and worktree creation is enabled.
+
+Branch and worktree ownership rules:
+
+- SpecRail owns branches matching `specrail/<runId>` that it creates.
+- SpecRail must not delete or mutate unrelated branches/worktrees.
+- If `specrail/<runId>` already exists, startup should fail with a validation error rather than silently reusing it.
+- If worktree creation fails, the run should not start unless the caller/config explicitly allows falling back to `directory` mode.
+- `workspacePath`, `branchName`, backend, profile, and session refs are the durable recovery handles.
+
+Cleanup expectations:
+
+- `completed`: keep the workspace by default until review/merge tooling decides what to do.
+- `failed`: keep the workspace for debugging.
+- `cancelled`: keep the workspace for inspection unless explicit cleanup is requested.
+- interrupted process: recover from persisted execution metadata and event history; do not assume the worktree can be deleted automatically.
+
+First implementation slice should add a workspace manager abstraction and tests for `directory` mode plus git command planning. Actual branch deletion/cleanup should be a separate explicit operation.
+
 ## Request flow
 
 ### Create track

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -31,7 +31,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - approval workflow depth
   - artifact revision approval is implemented
   - runtime permission request resolution is available through core service and HTTP APIs
-  - active executor callback wiring is still adapter-specific
+  - Codex and Claude Code runtime approval callbacks use provider-specific resume/no-retry fallbacks
 - artifact contract convergence
   - generated track artifacts exist in the repo-visible layout
   - authoritative run events still live under `state/events/<runId>.jsonl`
@@ -57,14 +57,16 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - connect completed run summaries back into track artifacts if desired
 
 ### Milestone B — Runtime approval broker
-- route core/API approval decisions back to active executors when a backend supports continuation callbacks
-- keep approval requested/resolved events provider-neutral while preserving provider metadata
-- document fallback behavior for rejected approvals and interrupted sessions
+- core/API approval decisions route back to active executors through callback hooks
+- approval requested/resolved events stay provider-neutral while preserving provider metadata
+- Codex and Claude Code currently use normal resume fallbacks for approved decisions and no-retry cancellation for rejected decisions
+- future provider-native permission continuation can replace the resume fallback when available
 
 ### Milestone C — Worktree and branch orchestration
-- create isolated workspaces per execution when requested
+- current contract defines `directory` and future `git_worktree` workspace modes
+- create isolated git worktrees per execution when requested
 - record branch/worktree metadata consistently
-- define cleanup and recovery behavior for interrupted runs
+- define explicit cleanup and recovery behavior for interrupted runs
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -78,13 +80,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Define artifact/state event-history ownership**
-   - settle what belongs in repo-visible artifacts versus internal state.
-2. **Wire runtime approval decisions into active executors**
-   - continue from the new core/API resolution path into backend-specific callbacks.
-3. **Add execution worktree orchestration**
+1. **Add execution workspace manager abstraction**
+   - implement the documented `directory` fallback and prepare `git_worktree` command planning.
+2. **Add execution git worktree orchestration**
    - isolate agent runs and track branch/worktree lifecycle.
-4. **Add project management APIs**
+3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**
    - build on the stabilized HTTP/SSE API rather than adding new core behavior.


### PR DESCRIPTION
## Summary
- define the execution workspace/branch contract for directory and future git worktree modes
- document branch ownership, fallback, cleanup, and recovery expectations
- update the roadmap now that runtime approval callbacks are wired through provider fallbacks

Closes #152

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build