### PR TITLE
feat: add execution workspace manager

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./domain/artifacts.js";
 export * from "./domain/types.js";
 export * from "./errors.js";
+export * from "./services/execution-workspace-manager.js";
 export * from "./services/file-repositories.js";
 export * from "./services/ports.js";
 export * from "./services/specrail-service.js";

--- a/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
+++ b/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { mkdtemp, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { DirectoryExecutionWorkspaceManager } from "../execution-workspace-manager.js";
+
+test("DirectoryExecutionWorkspaceManager allocates stable workspace and branch metadata", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-workspace-manager-"));
+  const workspaceRoot = path.join(rootDir, "workspaces");
+  const manager = new DirectoryExecutionWorkspaceManager();
+
+  const workspace = await manager.allocate({ executionId: "run-workspace-a", workspaceRoot });
+
+  assert.equal(workspace.workspacePath, path.join(workspaceRoot, "run-workspace-a"));
+  assert.equal(workspace.branchName, "specrail/run-workspace-a");
+  assert.equal(workspace.mode, "directory");
+  assert.equal((await stat(workspace.workspacePath)).isDirectory(), true);
+});

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -23,6 +23,7 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-"));
   const artifactRoot = path.join(rootDir, ".specrail");
   const workspaceRoot = path.join(rootDir, "workspaces");
+  const workspaceAllocations: Array<{ executionId: string; workspaceRoot: string }> = [];
 
   const service = new SpecRailService({
     projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
@@ -125,6 +126,16 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
       repoUrl: "https://github.com/yoophi-a/specrail",
     },
     workspaceRoot,
+    workspaceManager: {
+      async allocate(input) {
+        workspaceAllocations.push(input);
+        return {
+          workspacePath: path.join(input.workspaceRoot, input.executionId),
+          branchName: `specrail/${input.executionId}`,
+          mode: "directory",
+        };
+      },
+    },
     now: (() => {
       const values = [
         "2026-04-09T03:00:00.000Z",
@@ -179,6 +190,9 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
 
   assert.equal(run.id, "run-run-a");
   assert.equal(run.sessionRef, "session:run-run-a");
+  assert.equal(run.workspacePath, path.join(workspaceRoot, "run-run-a"));
+  assert.equal(run.branchName, "specrail/run-run-a");
+  assert.deepEqual(workspaceAllocations, [{ executionId: "run-run-a", workspaceRoot }]);
   assert.equal(run.command?.command, "codex");
   assert.equal(run.status, "running");
   assert.deepEqual(run.summary, {

--- a/packages/core/src/services/execution-workspace-manager.ts
+++ b/packages/core/src/services/execution-workspace-manager.ts
@@ -1,0 +1,34 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+export type ExecutionWorkspaceMode = "directory" | "git_worktree";
+
+export interface AllocateExecutionWorkspaceInput {
+  executionId: string;
+  workspaceRoot: string;
+}
+
+export interface AllocatedExecutionWorkspace {
+  workspacePath: string;
+  branchName: string;
+  mode: ExecutionWorkspaceMode;
+}
+
+export interface ExecutionWorkspaceManager {
+  allocate(input: AllocateExecutionWorkspaceInput): Promise<AllocatedExecutionWorkspace>;
+}
+
+export class DirectoryExecutionWorkspaceManager implements ExecutionWorkspaceManager {
+  async allocate(input: AllocateExecutionWorkspaceInput): Promise<AllocatedExecutionWorkspace> {
+    const workspacePath = path.join(input.workspaceRoot, input.executionId);
+    const branchName = `specrail/${input.executionId}`;
+
+    await mkdir(workspacePath, { recursive: true });
+
+    return {
+      workspacePath,
+      branchName,
+      mode: "directory",
+    };
+  }
+}

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -1,5 +1,3 @@
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import {
@@ -42,6 +40,10 @@ import type {
   ProjectRepository,
   TrackRepository,
 } from "./ports.js";
+import {
+  DirectoryExecutionWorkspaceManager,
+  type ExecutionWorkspaceManager,
+} from "./execution-workspace-manager.js";
 
 export interface TrackArtifactWriterInput {
   track: Track;
@@ -121,6 +123,7 @@ export interface SpecRailServiceDependencies {
     defaultWorkflowPolicy?: string;
   };
   workspaceRoot: string;
+  workspaceManager?: ExecutionWorkspaceManager;
   now?: () => string;
   idGenerator?: () => string;
 }
@@ -379,6 +382,7 @@ function normalizeProfile(value: string | undefined): string {
 export class SpecRailService {
   private readonly now: () => string;
   private readonly idGenerator: () => string;
+  private readonly workspaceManager: ExecutionWorkspaceManager;
 
   private listExecutors(): Record<string, ExecutionBackend> {
     if (this.dependencies.executors && Object.keys(this.dependencies.executors).length > 0) {
@@ -415,6 +419,7 @@ export class SpecRailService {
   constructor(private readonly dependencies: SpecRailServiceDependencies) {
     this.now = dependencies.now ?? (() => new Date().toISOString());
     this.idGenerator = dependencies.idGenerator ?? randomUUID;
+    this.workspaceManager = dependencies.workspaceManager ?? new DirectoryExecutionWorkspaceManager();
   }
 
   async createTrack(input: CreateTrackInput): Promise<Track> {
@@ -766,15 +771,17 @@ export class SpecRailService {
     const planningContext = await this.resolvePlanningContextForStart(track, input.planningSessionId);
     const executionId = `run-${this.idGenerator()}`;
     const createdAt = this.now();
-    const workspacePath = path.join(this.dependencies.workspaceRoot, executionId);
+    const workspace = await this.workspaceManager.allocate({
+      executionId,
+      workspaceRoot: this.dependencies.workspaceRoot,
+    });
     const prompt = normalizeRequiredString(input.prompt);
     const profile = normalizeProfile(this.resolveExecutionProfile(input.profile));
-    await mkdir(workspacePath, { recursive: true });
 
     const launch = await executor.spawn({
       executionId,
       prompt,
-      workspacePath,
+      workspacePath: workspace.workspacePath,
       profile,
     });
 
@@ -783,8 +790,8 @@ export class SpecRailService {
       trackId: track.id,
       backend: executor.name,
       profile,
-      workspacePath,
-      branchName: `specrail/${executionId}`,
+      workspacePath: workspace.workspacePath,
+      branchName: workspace.branchName,
       sessionRef: launch.sessionRef,
       command: launch.command,
       planningSessionId: planningContext.planningSessionId,


### PR DESCRIPTION
## Summary
- add a core execution workspace manager abstraction
- move start-run workspace allocation behind the manager while preserving `workspaces/<runId>` and `specrail/<runId>` behavior
- export the directory workspace manager for future git worktree orchestration
- add tests for directory allocation and service integration

Closes #154

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build