### PR TITLE
feat: add git worktree workspace mode

### DIFF
--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -397,7 +397,13 @@ Cleanup expectations:
 - `cancelled`: keep the workspace for inspection unless explicit cleanup is requested.
 - interrupted process: recover from persisted execution metadata and event history; do not assume the worktree can be deleted automatically.
 
-First implementation slice should add a workspace manager abstraction and tests for `directory` mode plus git command planning. Actual branch deletion/cleanup should be a separate explicit operation.
+The first implementation slice provides a workspace manager abstraction with:
+
+- `DirectoryExecutionWorkspaceManager` for the default plain directory behavior.
+- `GitWorktreeExecutionWorkspaceManager` for explicit `git worktree add -b specrail/<runId> workspaces/<runId>` allocation when a local repository path is provided.
+- `GitCommandRunner` injection so tests and future operators can validate command planning without invoking git directly.
+
+Actual branch deletion/cleanup remains a separate explicit operation.
 
 ## Request flow
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -63,8 +63,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - future provider-native permission continuation can replace the resume fallback when available
 
 ### Milestone C — Worktree and branch orchestration
-- current contract defines `directory` and future `git_worktree` workspace modes
-- create isolated git worktrees per execution when requested
+- current contract defines `directory` and `git_worktree` workspace modes
+- workspace manager abstraction supports default directory allocation and explicit git worktree command planning/execution
 - record branch/worktree metadata consistently
 - define explicit cleanup and recovery behavior for interrupted runs
 
@@ -80,10 +80,10 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add execution workspace manager abstraction**
-   - implement the documented `directory` fallback and prepare `git_worktree` command planning.
-2. **Add execution git worktree orchestration**
-   - isolate agent runs and track branch/worktree lifecycle.
+1. **Add execution workspace mode selection**
+   - expose directory vs git worktree mode through config/API without changing execution records.
+2. **Add execution workspace cleanup operations**
+   - explicitly clean up owned `specrail/<runId>` worktrees/branches after review.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**

--- a/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
+++ b/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { DirectoryExecutionWorkspaceManager } from "../execution-workspace-manager.js";
+import {
+  DirectoryExecutionWorkspaceManager,
+  GitWorktreeExecutionWorkspaceManager,
+  type GitCommandRunner,
+} from "../execution-workspace-manager.js";
 
 test("DirectoryExecutionWorkspaceManager allocates stable workspace and branch metadata", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-workspace-manager-"));
@@ -18,3 +22,79 @@ test("DirectoryExecutionWorkspaceManager allocates stable workspace and branch m
   assert.equal(workspace.mode, "directory");
   assert.equal((await stat(workspace.workspacePath)).isDirectory(), true);
 });
+
+test("GitWorktreeExecutionWorkspaceManager plans git worktree allocation commands", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-worktree-manager-"));
+  const workspaceRoot = path.join(rootDir, "workspaces");
+  const localRepoPath = path.join(rootDir, "repo");
+  const commands: Array<{ cwd: string; command: string; args: string[] }> = [];
+  const gitRunner: GitCommandRunner = {
+    async run(input) {
+      commands.push(input);
+    },
+  };
+  const manager = new GitWorktreeExecutionWorkspaceManager({ gitRunner });
+
+  const workspace = await manager.allocate({ executionId: "run-worktree-a", workspaceRoot, localRepoPath });
+
+  assert.deepEqual(workspace, {
+    workspacePath: path.join(workspaceRoot, "run-worktree-a"),
+    branchName: "specrail/run-worktree-a",
+    mode: "git_worktree",
+  });
+  assert.deepEqual(commands, [
+    {
+      cwd: localRepoPath,
+      command: "git",
+      args: ["worktree", "add", "-b", "specrail/run-worktree-a", path.join(workspaceRoot, "run-worktree-a")],
+    },
+  ]);
+});
+
+test("GitWorktreeExecutionWorkspaceManager rejects missing repo paths and existing workspaces", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-worktree-manager-"));
+  const workspaceRoot = path.join(rootDir, "workspaces");
+  const manager = new GitWorktreeExecutionWorkspaceManager({
+    gitRunner: {
+      async run() {
+        throw new Error("git should not be called");
+      },
+    },
+  });
+
+  await assert.rejects(
+    () => manager.allocate({ executionId: "run-missing-repo", workspaceRoot }),
+    /requires localRepoPath/,
+  );
+
+  await mkdir(path.join(workspaceRoot, "run-collision"), { recursive: true });
+  await assert.rejects(
+    () => manager.allocate({ executionId: "run-collision", workspaceRoot, localRepoPath: rootDir }),
+    new RegExp(`Execution workspace already exists: ${escapeRegExp(path.join(workspaceRoot, "run-collision"))}`),
+  );
+});
+
+test("GitWorktreeExecutionWorkspaceManager maps git runner failures", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-worktree-manager-"));
+  const manager = new GitWorktreeExecutionWorkspaceManager({
+    gitRunner: {
+      async run() {
+        throw new Error("fatal: a branch named 'specrail/run-fail' already exists");
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      manager.allocate({
+        executionId: "run-fail",
+        workspaceRoot: path.join(rootDir, "workspaces"),
+        localRepoPath: path.join(rootDir, "repo"),
+      }),
+    /Failed to allocate git worktree for execution run-fail: fatal: a branch named 'specrail\/run-fail' already exists/,
+  );
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -23,7 +23,7 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "specrail-service-"));
   const artifactRoot = path.join(rootDir, ".specrail");
   const workspaceRoot = path.join(rootDir, "workspaces");
-  const workspaceAllocations: Array<{ executionId: string; workspaceRoot: string }> = [];
+  const workspaceAllocations: Array<{ executionId: string; workspaceRoot: string; localRepoPath?: string }> = [];
 
   const service = new SpecRailService({
     projectRepository: new FileProjectRepository(path.join(rootDir, "state")),
@@ -192,7 +192,7 @@ test("SpecRailService creates tracks, artifacts, runs, and execution events", as
   assert.equal(run.sessionRef, "session:run-run-a");
   assert.equal(run.workspacePath, path.join(workspaceRoot, "run-run-a"));
   assert.equal(run.branchName, "specrail/run-run-a");
-  assert.deepEqual(workspaceAllocations, [{ executionId: "run-run-a", workspaceRoot }]);
+  assert.deepEqual(workspaceAllocations, [{ executionId: "run-run-a", workspaceRoot, localRepoPath: undefined }]);
   assert.equal(run.command?.command, "codex");
   assert.equal(run.status, "running");
   assert.deepEqual(run.summary, {

--- a/packages/core/src/services/execution-workspace-manager.ts
+++ b/packages/core/src/services/execution-workspace-manager.ts
@@ -1,11 +1,16 @@
-import { mkdir } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { access, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 export type ExecutionWorkspaceMode = "directory" | "git_worktree";
 
 export interface AllocateExecutionWorkspaceInput {
   executionId: string;
   workspaceRoot: string;
+  localRepoPath?: string;
 }
 
 export interface AllocatedExecutionWorkspace {
@@ -16,6 +21,16 @@ export interface AllocatedExecutionWorkspace {
 
 export interface ExecutionWorkspaceManager {
   allocate(input: AllocateExecutionWorkspaceInput): Promise<AllocatedExecutionWorkspace>;
+}
+
+export interface GitCommandRunner {
+  run(input: { cwd: string; command: string; args: string[] }): Promise<void>;
+}
+
+export class NodeGitCommandRunner implements GitCommandRunner {
+  async run(input: { cwd: string; command: string; args: string[] }): Promise<void> {
+    await execFileAsync(input.command, input.args, { cwd: input.cwd });
+  }
 }
 
 export class DirectoryExecutionWorkspaceManager implements ExecutionWorkspaceManager {
@@ -31,4 +46,56 @@ export class DirectoryExecutionWorkspaceManager implements ExecutionWorkspaceMan
       mode: "directory",
     };
   }
+}
+
+export class GitWorktreeExecutionWorkspaceManager implements ExecutionWorkspaceManager {
+  private readonly gitRunner: GitCommandRunner;
+
+  constructor(input: { gitRunner?: GitCommandRunner } = {}) {
+    this.gitRunner = input.gitRunner ?? new NodeGitCommandRunner();
+  }
+
+  async allocate(input: AllocateExecutionWorkspaceInput): Promise<AllocatedExecutionWorkspace> {
+    if (!input.localRepoPath) {
+      throw new Error("Git worktree workspace allocation requires localRepoPath");
+    }
+
+    const workspacePath = path.join(input.workspaceRoot, input.executionId);
+    const branchName = `specrail/${input.executionId}`;
+
+    if (await pathExists(workspacePath)) {
+      throw new Error(`Execution workspace already exists: ${workspacePath}`);
+    }
+
+    await mkdir(input.workspaceRoot, { recursive: true });
+
+    try {
+      await this.gitRunner.run({
+        cwd: input.localRepoPath,
+        command: "git",
+        args: ["worktree", "add", "-b", branchName, workspacePath],
+      });
+    } catch (error) {
+      throw new Error(`Failed to allocate git worktree for execution ${input.executionId}: ${formatErrorMessage(error)}`);
+    }
+
+    return {
+      workspacePath,
+      branchName,
+      mode: "git_worktree",
+    };
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -774,6 +774,7 @@ export class SpecRailService {
     const workspace = await this.workspaceManager.allocate({
       executionId,
       workspaceRoot: this.dependencies.workspaceRoot,
+      localRepoPath: this.dependencies.defaultProject.localRepoPath,
     });
     const prompt = normalizeRequiredString(input.prompt);
     const profile = normalizeProfile(this.resolveExecutionProfile(input.profile));


### PR DESCRIPTION
## Summary
- add `GitWorktreeExecutionWorkspaceManager` for explicit git worktree allocation
- add injectable `GitCommandRunner` and default Node runner for `git worktree add -b specrail/<runId> workspaces/<runId>`
- pass project `localRepoPath` through start-run workspace allocation
- fail clearly for missing repo paths, existing workspace paths, and git runner errors
- update architecture and roadmap docs for the implemented git worktree slice

Closes #156

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build