### PR TITLE
feat: expose workspace mode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ That workflow is intentionally gated behind repository variable `SPECRAIL_ENABLE
 For the Telegram frontend, set `SPECRAIL_API_BASE_URL`, `TELEGRAM_BOT_TOKEN`, and optionally `TELEGRAM_APP_PORT` / `TELEGRAM_WEBHOOK_PATH` before `pnpm dev:telegram`.
 
 For the API server, you can set `SPECRAIL_EXECUTION_BACKEND` and `SPECRAIL_EXECUTION_PROFILE` to choose the default executor/backend and profile used when callers omit them.
+Set `SPECRAIL_EXECUTION_WORKSPACE_MODE=directory` for the default plain workspace directory behavior, or `SPECRAIL_EXECUTION_WORKSPACE_MODE=git_worktree` to allocate execution workspaces with `git worktree add -b specrail/<runId> workspaces/<runId>` from the configured local repo path.
 
 Then call the API locally, for example:
 

--- a/apps/acp-server/src/index.ts
+++ b/apps/acp-server/src/index.ts
@@ -20,12 +20,14 @@ import {
   JsonlEventStore,
   JsonlPlanningMessageStore,
   SpecRailService,
+  createExecutionWorkspaceManager,
   type SpecRailServiceDependencies,
 } from "@specrail/core";
 
 import { SpecRailAcpServer, type JsonRpcRequest } from "./server.js";
 
 function createService(dataDir: string, repoArtifactRoot: string): SpecRailService {
+  const config = loadConfig();
   const stateDir = path.join(dataDir, "state");
   const artifactRoot = path.join(dataDir, "artifacts");
   const workspaceRoot = path.join(dataDir, "workspaces");
@@ -109,8 +111,8 @@ function createService(dataDir: string, repoArtifactRoot: string): SpecRailServi
       codex: codexExecutor,
       claude_code: claudeCodeExecutor,
     },
-    defaultExecutionBackend: loadConfig().executionBackend,
-    defaultExecutionProfile: loadConfig().executionProfile,
+    defaultExecutionBackend: config.executionBackend,
+    defaultExecutionProfile: config.executionProfile,
     defaultProject: {
       id: "project-default",
       name: "SpecRail",
@@ -119,6 +121,7 @@ function createService(dataDir: string, repoArtifactRoot: string): SpecRailServi
       defaultWorkflowPolicy: "artifact-first-mvp",
     },
     workspaceRoot,
+    workspaceManager: createExecutionWorkspaceManager(config.executionWorkspaceMode),
   };
 
   service = new SpecRailService(dependencies);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import {
   getStatePaths,
   SpecRailService,
   TRACK_STATUSES,
+  createExecutionWorkspaceManager,
   type ExecutionEvent,
   type ApprovalStatus,
   type ArtifactKind,
@@ -183,6 +184,7 @@ class RequestValidationError extends Error {
 }
 
 function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultDependencies {
+  const config = loadConfig();
   const stateDir = path.join(dataDir, "state");
   const artifactRoot = path.join(dataDir, "artifacts");
   const workspaceRoot = path.join(dataDir, "workspaces");
@@ -266,8 +268,8 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
       codex: codexExecutor,
       claude_code: claudeCodeExecutor,
     },
-    defaultExecutionBackend: loadConfig().executionBackend,
-    defaultExecutionProfile: loadConfig().executionProfile,
+    defaultExecutionBackend: config.executionBackend,
+    defaultExecutionProfile: config.executionProfile,
     defaultProject: {
       id: "project-default",
       name: "SpecRail",
@@ -276,6 +278,7 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
       defaultWorkflowPolicy: "artifact-first-mvp",
     },
     workspaceRoot,
+    workspaceManager: createExecutionWorkspaceManager(config.executionWorkspaceMode),
   };
 
   service = new SpecRailService(serviceDependencies);

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -65,6 +65,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 ### Milestone C — Worktree and branch orchestration
 - current contract defines `directory` and `git_worktree` workspace modes
 - workspace manager abstraction supports default directory allocation and explicit git worktree command planning/execution
+- config/env wiring exposes workspace mode selection to API and ACP server entrypoints
 - record branch/worktree metadata consistently
 - define explicit cleanup and recovery behavior for interrupted runs
 
@@ -80,9 +81,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add execution workspace mode selection**
-   - expose directory vs git worktree mode through config/API without changing execution records.
-2. **Add execution workspace cleanup operations**
+1. **Add execution workspace cleanup operations**
    - explicitly clean up owned `specrail/<runId>` worktrees/branches after review.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,7 @@ Then confirm the runtime configuration you expect:
 - `SPECRAIL_REPO_ARTIFACT_DIR`
 - `SPECRAIL_EXECUTION_BACKEND`
 - `SPECRAIL_EXECUTION_PROFILE`
+- `SPECRAIL_EXECUTION_WORKSPACE_MODE` (`directory` or `git_worktree`)
 - `SPECRAIL_API_BASE_URL`
 
 ## API server does not start

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadConfig } from "../index.js";
+
+test("loadConfig returns execution defaults", () => {
+  assert.deepEqual(loadConfig({}), {
+    port: 4000,
+    dataDir: ".specrail-data",
+    repoArtifactDir: ".specrail",
+    executionBackend: "codex",
+    executionProfile: "default",
+    executionWorkspaceMode: "directory",
+  });
+});
+
+test("loadConfig reads execution workspace mode", () => {
+  assert.equal(loadConfig({ SPECRAIL_EXECUTION_WORKSPACE_MODE: "git_worktree" }).executionWorkspaceMode, "git_worktree");
+  assert.equal(loadConfig({ SPECRAIL_EXECUTION_WORKSPACE_MODE: "directory" }).executionWorkspaceMode, "directory");
+});
+
+test("loadConfig rejects unsupported execution workspace modes", () => {
+  assert.throws(
+    () => loadConfig({ SPECRAIL_EXECUTION_WORKSPACE_MODE: "worktree" }),
+    /Unsupported SPECRAIL_EXECUTION_WORKSPACE_MODE: worktree/,
+  );
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,7 +6,10 @@ export interface SpecRailConfig {
   repoArtifactDir: string;
   executionBackend: string;
   executionProfile: string;
+  executionWorkspaceMode: SpecRailExecutionWorkspaceMode;
 }
+
+export type SpecRailExecutionWorkspaceMode = "directory" | "git_worktree";
 
 export interface SpecRailTerminalClientConfig {
   apiBaseUrl: string;
@@ -15,13 +18,28 @@ export interface SpecRailTerminalClientConfig {
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): SpecRailConfig {
+  const executionWorkspaceMode = parseExecutionWorkspaceMode(env.SPECRAIL_EXECUTION_WORKSPACE_MODE);
+
   return {
     port: Number(env.SPECRAIL_PORT ?? 4000),
     dataDir: env.SPECRAIL_DATA_DIR ?? ".specrail-data",
     repoArtifactDir: env.SPECRAIL_REPO_ARTIFACT_DIR ?? ".specrail",
     executionBackend: env.SPECRAIL_EXECUTION_BACKEND ?? "codex",
     executionProfile: env.SPECRAIL_EXECUTION_PROFILE ?? "default",
+    executionWorkspaceMode,
   };
+}
+
+function parseExecutionWorkspaceMode(value: string | undefined): SpecRailExecutionWorkspaceMode {
+  if (!value || value === "directory") {
+    return "directory";
+  }
+
+  if (value === "git_worktree") {
+    return "git_worktree";
+  }
+
+  throw new Error(`Unsupported SPECRAIL_EXECUTION_WORKSPACE_MODE: ${value}`);
 }
 
 export function loadTerminalClientConfig(env: NodeJS.ProcessEnv = process.env): SpecRailTerminalClientConfig {

--- a/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
+++ b/packages/core/src/services/__tests__/execution-workspace-manager.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   DirectoryExecutionWorkspaceManager,
   GitWorktreeExecutionWorkspaceManager,
+  createExecutionWorkspaceManager,
   type GitCommandRunner,
 } from "../execution-workspace-manager.js";
 
@@ -21,6 +22,11 @@ test("DirectoryExecutionWorkspaceManager allocates stable workspace and branch m
   assert.equal(workspace.branchName, "specrail/run-workspace-a");
   assert.equal(workspace.mode, "directory");
   assert.equal((await stat(workspace.workspacePath)).isDirectory(), true);
+});
+
+test("createExecutionWorkspaceManager selects directory and git worktree managers", () => {
+  assert.ok(createExecutionWorkspaceManager("directory") instanceof DirectoryExecutionWorkspaceManager);
+  assert.ok(createExecutionWorkspaceManager("git_worktree") instanceof GitWorktreeExecutionWorkspaceManager);
 });
 
 test("GitWorktreeExecutionWorkspaceManager plans git worktree allocation commands", async () => {

--- a/packages/core/src/services/execution-workspace-manager.ts
+++ b/packages/core/src/services/execution-workspace-manager.ts
@@ -87,6 +87,15 @@ export class GitWorktreeExecutionWorkspaceManager implements ExecutionWorkspaceM
   }
 }
 
+export function createExecutionWorkspaceManager(mode: ExecutionWorkspaceMode): ExecutionWorkspaceManager {
+  switch (mode) {
+    case "directory":
+      return new DirectoryExecutionWorkspaceManager();
+    case "git_worktree":
+      return new GitWorktreeExecutionWorkspaceManager();
+  }
+}
+
 async function pathExists(filePath: string): Promise<boolean> {
   try {
     await access(filePath);


### PR DESCRIPTION
## Summary
- add `SPECRAIL_EXECUTION_WORKSPACE_MODE` with `directory` default and `git_worktree` opt-in
- wire API and ACP server entrypoints to select the workspace manager from config
- add config parsing and workspace-manager factory tests
- document the new operator-facing env var in README/troubleshooting and update the roadmap

Closes #158

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build