### PR TITLE
feat: add workspace cleanup planner

### DIFF
--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -68,6 +68,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - config/env wiring exposes workspace mode selection to API and ACP server entrypoints
 - record branch/worktree metadata consistently
 - cleanup safety contract defines dry-run, ownership checks, event recording, and partial-failure behavior
+- non-destructive cleanup planner previews directory and git worktree operations with guardrail refusal reasons
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -81,8 +82,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add execution workspace cleanup planner**
-   - implement non-destructive cleanup previews for owned `specrail/<runId>` worktrees/branches.
+1. **Add execution workspace cleanup API preview endpoint**
+   - expose the non-destructive cleanup planner through API/operator surfaces.
 2. **Add execution workspace cleanup apply path**
    - explicitly clean up owned workspaces/branches after review using the previewed operations.
 3. **Add project management APIs**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./domain/artifacts.js";
 export * from "./domain/types.js";
 export * from "./errors.js";
+export * from "./services/execution-workspace-cleanup-planner.js";
 export * from "./services/execution-workspace-manager.js";
 export * from "./services/file-repositories.js";
 export * from "./services/ports.js";

--- a/packages/core/src/services/__tests__/execution-workspace-cleanup-planner.test.ts
+++ b/packages/core/src/services/__tests__/execution-workspace-cleanup-planner.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import type { Execution } from "../../domain/types.js";
+import { planExecutionWorkspaceCleanup } from "../execution-workspace-cleanup-planner.js";
+
+const baseExecution: Execution = {
+  id: "run-cleanup-a",
+  trackId: "track-cleanup",
+  backend: "codex",
+  profile: "default",
+  workspacePath: path.join("/tmp/specrail-workspaces", "run-cleanup-a"),
+  branchName: "specrail/run-cleanup-a",
+  status: "completed",
+  createdAt: "2026-05-02T13:00:00.000Z",
+  startedAt: "2026-05-02T13:00:00.000Z",
+  finishedAt: "2026-05-02T13:05:00.000Z",
+};
+
+test("planExecutionWorkspaceCleanup previews directory cleanup", () => {
+  const plan = planExecutionWorkspaceCleanup({
+    execution: baseExecution,
+    workspaceRoot: "/tmp/specrail-workspaces",
+    mode: "directory",
+  });
+
+  assert.equal(plan.eligible, true);
+  assert.equal(plan.dryRun, true);
+  assert.deepEqual(plan.refusalReasons, []);
+  assert.deepEqual(plan.operations, [
+    {
+      kind: "remove_directory",
+      path: path.resolve("/tmp/specrail-workspaces/run-cleanup-a"),
+    },
+  ]);
+});
+
+test("planExecutionWorkspaceCleanup previews git worktree cleanup", () => {
+  const plan = planExecutionWorkspaceCleanup({
+    execution: baseExecution,
+    workspaceRoot: "/tmp/specrail-workspaces",
+    mode: "git_worktree",
+    localRepoPath: "/tmp/specrail-repo",
+  });
+
+  assert.equal(plan.eligible, true);
+  assert.deepEqual(plan.operations, [
+    {
+      kind: "git_worktree_remove",
+      cwd: "/tmp/specrail-repo",
+      command: "git",
+      args: ["worktree", "remove", path.resolve("/tmp/specrail-workspaces/run-cleanup-a")],
+    },
+    {
+      kind: "git_branch_delete",
+      cwd: "/tmp/specrail-repo",
+      command: "git",
+      args: ["branch", "-D", "specrail/run-cleanup-a"],
+    },
+  ]);
+});
+
+test("planExecutionWorkspaceCleanup refuses active executions", () => {
+  const plan = planExecutionWorkspaceCleanup({
+    execution: { ...baseExecution, status: "running" },
+    workspaceRoot: "/tmp/specrail-workspaces",
+    mode: "directory",
+  });
+
+  assert.equal(plan.eligible, false);
+  assert.deepEqual(plan.operations, []);
+  assert.deepEqual(plan.refusalReasons, ["Execution status running is not eligible for workspace cleanup"]);
+});
+
+test("planExecutionWorkspaceCleanup refuses non-owned paths and branches", () => {
+  const plan = planExecutionWorkspaceCleanup({
+    execution: {
+      ...baseExecution,
+      workspacePath: "/tmp/other/run-cleanup-a",
+      branchName: "feature/not-owned",
+    },
+    workspaceRoot: "/tmp/specrail-workspaces",
+    mode: "git_worktree",
+  });
+
+  assert.equal(plan.eligible, false);
+  assert.deepEqual(plan.operations, []);
+  assert.deepEqual(plan.refusalReasons, [
+    "Execution workspace path is outside workspace root: /tmp/other/run-cleanup-a",
+    "Execution branch is not owned by SpecRail for this run: feature/not-owned",
+    "Git worktree cleanup planning requires localRepoPath",
+  ]);
+});

--- a/packages/core/src/services/execution-workspace-cleanup-planner.ts
+++ b/packages/core/src/services/execution-workspace-cleanup-planner.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+
+import type { Execution } from "../domain/types.js";
+import type { ExecutionWorkspaceMode } from "./execution-workspace-manager.js";
+
+export type ExecutionWorkspaceCleanupOperation =
+  | {
+      kind: "remove_directory";
+      path: string;
+    }
+  | {
+      kind: "git_worktree_remove";
+      cwd: string;
+      command: "git";
+      args: ["worktree", "remove", string];
+    }
+  | {
+      kind: "git_branch_delete";
+      cwd: string;
+      command: "git";
+      args: ["branch", "-D", string];
+    };
+
+export interface PlanExecutionWorkspaceCleanupInput {
+  execution: Execution;
+  workspaceRoot: string;
+  mode: ExecutionWorkspaceMode;
+  localRepoPath?: string;
+}
+
+export interface ExecutionWorkspaceCleanupPlan {
+  executionId: string;
+  eligible: boolean;
+  dryRun: true;
+  workspacePath: string;
+  branchName: string;
+  mode: ExecutionWorkspaceMode;
+  operations: ExecutionWorkspaceCleanupOperation[];
+  refusalReasons: string[];
+}
+
+const CLEANUP_ELIGIBLE_STATUSES = new Set<Execution["status"]>(["completed", "failed", "cancelled"]);
+
+export function planExecutionWorkspaceCleanup(input: PlanExecutionWorkspaceCleanupInput): ExecutionWorkspaceCleanupPlan {
+  const refusalReasons: string[] = [];
+  const workspacePath = path.resolve(input.execution.workspacePath);
+  const workspaceRoot = path.resolve(input.workspaceRoot);
+  const expectedBranchName = `specrail/${input.execution.id}`;
+
+  if (!CLEANUP_ELIGIBLE_STATUSES.has(input.execution.status)) {
+    refusalReasons.push(`Execution status ${input.execution.status} is not eligible for workspace cleanup`);
+  }
+
+  if (!isPathWithinRoot(workspacePath, workspaceRoot)) {
+    refusalReasons.push(`Execution workspace path is outside workspace root: ${input.execution.workspacePath}`);
+  }
+
+  if (input.execution.branchName !== expectedBranchName) {
+    refusalReasons.push(`Execution branch is not owned by SpecRail for this run: ${input.execution.branchName}`);
+  }
+
+  if (input.mode === "git_worktree" && !input.localRepoPath) {
+    refusalReasons.push("Git worktree cleanup planning requires localRepoPath");
+  }
+
+  const eligible = refusalReasons.length === 0;
+  const operations = eligible ? buildCleanupOperations(input, workspacePath) : [];
+
+  return {
+    executionId: input.execution.id,
+    eligible,
+    dryRun: true,
+    workspacePath,
+    branchName: input.execution.branchName,
+    mode: input.mode,
+    operations,
+    refusalReasons,
+  };
+}
+
+function buildCleanupOperations(
+  input: PlanExecutionWorkspaceCleanupInput,
+  workspacePath: string,
+): ExecutionWorkspaceCleanupOperation[] {
+  if (input.mode === "directory") {
+    return [{ kind: "remove_directory", path: workspacePath }];
+  }
+
+  const cwd = input.localRepoPath ?? "";
+
+  return [
+    {
+      kind: "git_worktree_remove",
+      cwd,
+      command: "git",
+      args: ["worktree", "remove", workspacePath],
+    },
+    {
+      kind: "git_branch_delete",
+      cwd,
+      command: "git",
+      args: ["branch", "-D", input.execution.branchName],
+    },
+  ];
+}
+
+function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}


### PR DESCRIPTION
## Summary
- add a non-destructive execution workspace cleanup planner
- preview directory removal and git worktree/branch cleanup operations without executing them
- refuse active runs, workspaces outside the configured root, non-owned branches, and missing git repo paths
- export the planner and add guardrail tests
- update the roadmap with the next API preview slice

Closes #162

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build