### PR TITLE
feat: expose cleanup preview API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Current endpoints in `apps/api/src/index.ts`:
   - `backend` is optional and must match the run's persisted backend when provided
 - `POST /runs/:runId/cancel`
   - cancel a running run
+- `GET /runs/:runId/workspace-cleanup/preview`
+  - return a non-destructive cleanup plan for the run workspace
+  - response includes `cleanupPlan: { dryRun: true, eligible, operations, refusalReasons }`
 - `POST /runs/:runId/approval-requests/:requestId/approve`
   - resolve a pending runtime approval request as approved
   - body: `{ decidedBy, comment? }`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -464,6 +464,60 @@ test("API supports resuming and cancelling a run", async () => {
     assert.match(eventsPayload.events[1]?.summary ?? "", /Spawned Codex session/);
     assert.ok(eventsPayload.events.some((event) => /Resumed Codex session/.test(event.summary)));
     assert.ok(eventsPayload.events.some((event) => /Cancelled Codex session/.test(event.summary)));
+
+    const cleanupPreviewResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/workspace-cleanup/preview`);
+    assert.equal(cleanupPreviewResponse.status, 200);
+    const cleanupPreviewPayload = (await cleanupPreviewResponse.json()) as {
+      cleanupPlan: {
+        executionId: string;
+        eligible: boolean;
+        dryRun: boolean;
+        mode: string;
+        operations: Array<{ kind: string; path?: string }>;
+        refusalReasons: string[];
+      };
+    };
+    assert.equal(cleanupPreviewPayload.cleanupPlan.executionId, runPayload.run.id);
+    assert.equal(cleanupPreviewPayload.cleanupPlan.eligible, true);
+    assert.equal(cleanupPreviewPayload.cleanupPlan.dryRun, true);
+    assert.equal(cleanupPreviewPayload.cleanupPlan.mode, "directory");
+    assert.equal(cleanupPreviewPayload.cleanupPlan.operations[0]?.kind, "remove_directory");
+    assert.deepEqual(cleanupPreviewPayload.cleanupPlan.refusalReasons, []);
+  });
+});
+
+test("API refuses workspace cleanup preview for active runs", async () => {
+  await withServer(async (baseUrl) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Cleanup active run",
+        description: "Preview cleanup guardrails.",
+      }),
+    });
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const createRunResponse = await fetch(`${baseUrl}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        prompt: "Start the work",
+      }),
+    });
+    const runPayload = (await createRunResponse.json()) as { run: { id: string } };
+
+    const cleanupPreviewResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/workspace-cleanup/preview`);
+    assert.equal(cleanupPreviewResponse.status, 200);
+    const cleanupPreviewPayload = (await cleanupPreviewResponse.json()) as {
+      cleanupPlan: { eligible: boolean; operations: unknown[]; refusalReasons: string[] };
+    };
+    assert.equal(cleanupPreviewPayload.cleanupPlan.eligible, false);
+    assert.deepEqual(cleanupPreviewPayload.cleanupPlan.operations, []);
+    assert.deepEqual(cleanupPreviewPayload.cleanupPlan.refusalReasons, [
+      "Execution status running is not eligible for workspace cleanup",
+    ]);
   });
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -34,6 +34,8 @@ import {
   SpecRailService,
   TRACK_STATUSES,
   createExecutionWorkspaceManager,
+  planExecutionWorkspaceCleanup,
+  type ExecutionWorkspaceMode,
   type ExecutionEvent,
   type ApprovalStatus,
   type ArtifactKind,
@@ -48,6 +50,9 @@ interface ApiDeps {
   artifactRoot: string;
   eventLogDir: string;
   service: SpecRailService;
+  workspaceRoot: string;
+  executionWorkspaceMode: ExecutionWorkspaceMode;
+  localRepoPath?: string;
 }
 
 interface TrackRequestBody {
@@ -157,6 +162,9 @@ interface ListMeta {
 interface DefaultDependencies {
   artifactRoot: string;
   eventLogDir: string;
+  workspaceRoot: string;
+  executionWorkspaceMode: ExecutionWorkspaceMode;
+  localRepoPath?: string;
   serviceDependencies: SpecRailServiceDependencies;
 }
 
@@ -286,6 +294,9 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
   return {
     artifactRoot,
     eventLogDir: getStatePaths(stateDir).eventsDir,
+    workspaceRoot,
+    executionWorkspaceMode: config.executionWorkspaceMode,
+    localRepoPath: serviceDependencies.defaultProject.localRepoPath,
     serviceDependencies,
   };
 }
@@ -1195,6 +1206,24 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (method === "GET" && segments.length === 4 && segments[0] === "runs" && segments[2] === "workspace-cleanup" && segments[3] === "preview") {
+        const run = await deps.service.getRun(segments[1] ?? "");
+
+        if (!run) {
+          sendError(response, 404, "not_found", "run not found");
+          return;
+        }
+
+        const cleanupPlan = planExecutionWorkspaceCleanup({
+          execution: run,
+          workspaceRoot: deps.workspaceRoot,
+          mode: deps.executionWorkspaceMode,
+          localRepoPath: deps.localRepoPath,
+        });
+        sendJson(response, 200, { cleanupPlan });
+        return;
+      }
+
       if (method === "GET" && segments.length === 2 && segments[0] === "runs") {
         const run = await deps.service.getRun(segments[1] ?? "");
 
@@ -1268,6 +1297,9 @@ export function createDefaultServer(): http.Server {
     artifactRoot: dependencies.artifactRoot,
     eventLogDir: dependencies.eventLogDir,
     service: new SpecRailService(dependencies.serviceDependencies),
+    workspaceRoot: dependencies.workspaceRoot,
+    executionWorkspaceMode: dependencies.executionWorkspaceMode,
+    localRepoPath: dependencies.localRepoPath,
   });
 }
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -69,6 +69,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - record branch/worktree metadata consistently
 - cleanup safety contract defines dry-run, ownership checks, event recording, and partial-failure behavior
 - non-destructive cleanup planner previews directory and git worktree operations with guardrail refusal reasons
+- API cleanup preview endpoint exposes dry-run plans without filesystem or git side effects
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -82,9 +83,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add execution workspace cleanup API preview endpoint**
-   - expose the non-destructive cleanup planner through API/operator surfaces.
-2. **Add execution workspace cleanup apply path**
+1. **Add execution workspace cleanup apply path**
    - explicitly clean up owned workspaces/branches after review using the previewed operations.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.


### PR DESCRIPTION
## Summary
- add `GET /runs/:runId/workspace-cleanup/preview`
- return non-destructive cleanup plans with `dryRun`, `eligible`, operations, and refusal reasons
- wire the endpoint to the configured workspace root/mode/repo path
- add API tests for eligible cancelled-run previews and active-run refusal
- document the endpoint and update the roadmap

Closes #164

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build