### PR TITLE
feat: add workspace cleanup applier

### DIFF
--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -70,6 +70,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - cleanup safety contract defines dry-run, ownership checks, event recording, and partial-failure behavior
 - non-destructive cleanup planner previews directory and git worktree operations with guardrail refusal reasons
 - API cleanup preview endpoint exposes dry-run plans without filesystem or git side effects
+- core cleanup applier requires explicit confirmation and injectable filesystem/git runners before applying previewed operations
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -83,8 +84,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add execution workspace cleanup apply path**
-   - explicitly clean up owned workspaces/branches after review using the previewed operations.
+1. **Expose execution workspace cleanup apply API**
+   - require a fresh preview/confirmation token before applying owned workspace/branch cleanup through HTTP.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./domain/artifacts.js";
 export * from "./domain/types.js";
 export * from "./errors.js";
+export * from "./services/execution-workspace-cleanup-applier.js";
 export * from "./services/execution-workspace-cleanup-planner.js";
 export * from "./services/execution-workspace-manager.js";
 export * from "./services/file-repositories.js";

--- a/packages/core/src/services/__tests__/execution-workspace-cleanup-applier.test.ts
+++ b/packages/core/src/services/__tests__/execution-workspace-cleanup-applier.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ExecutionWorkspaceCleanupApplier } from "../execution-workspace-cleanup-applier.js";
+import type { ExecutionWorkspaceCleanupPlan } from "../execution-workspace-cleanup-planner.js";
+
+const directoryPlan: ExecutionWorkspaceCleanupPlan = {
+  executionId: "run-cleanup-a",
+  eligible: true,
+  dryRun: true,
+  workspacePath: "/tmp/specrail-workspaces/run-cleanup-a",
+  branchName: "specrail/run-cleanup-a",
+  mode: "directory",
+  operations: [{ kind: "remove_directory", path: "/tmp/specrail-workspaces/run-cleanup-a" }],
+  refusalReasons: [],
+};
+
+const gitWorktreePlan: ExecutionWorkspaceCleanupPlan = {
+  executionId: "run-cleanup-b",
+  eligible: true,
+  dryRun: true,
+  workspacePath: "/tmp/specrail-workspaces/run-cleanup-b",
+  branchName: "specrail/run-cleanup-b",
+  mode: "git_worktree",
+  operations: [
+    {
+      kind: "git_worktree_remove",
+      cwd: "/tmp/specrail-repo",
+      command: "git",
+      args: ["worktree", "remove", "/tmp/specrail-workspaces/run-cleanup-b"],
+    },
+    {
+      kind: "git_branch_delete",
+      cwd: "/tmp/specrail-repo",
+      command: "git",
+      args: ["branch", "-D", "specrail/run-cleanup-b"],
+    },
+  ],
+  refusalReasons: [],
+};
+
+test("ExecutionWorkspaceCleanupApplier refuses missing confirmation", async () => {
+  const applier = new ExecutionWorkspaceCleanupApplier();
+
+  const result = await applier.apply({ plan: directoryPlan, confirm: false });
+
+  assert.equal(result.status, "refused");
+  assert.equal(result.applied, false);
+  assert.deepEqual(result.operations, []);
+  assert.deepEqual(result.refusalReasons, ["Workspace cleanup apply requires explicit confirmation"]);
+});
+
+test("ExecutionWorkspaceCleanupApplier refuses ineligible plans", async () => {
+  const applier = new ExecutionWorkspaceCleanupApplier();
+
+  const result = await applier.apply({
+    plan: {
+      ...directoryPlan,
+      eligible: false,
+      operations: [],
+      refusalReasons: ["Execution status running is not eligible for workspace cleanup"],
+    },
+    confirm: true,
+  });
+
+  assert.equal(result.status, "refused");
+  assert.deepEqual(result.refusalReasons, [
+    "Execution status running is not eligible for workspace cleanup",
+    "Workspace cleanup plan has no operations to apply",
+  ]);
+});
+
+test("ExecutionWorkspaceCleanupApplier applies directory cleanup through injected runner", async () => {
+  const removedPaths: string[] = [];
+  const applier = new ExecutionWorkspaceCleanupApplier({
+    fileSystemRunner: {
+      async removeDirectory(path) {
+        removedPaths.push(path);
+      },
+    },
+  });
+
+  const result = await applier.apply({ plan: directoryPlan, confirm: true });
+
+  assert.equal(result.status, "applied");
+  assert.equal(result.applied, true);
+  assert.deepEqual(removedPaths, ["/tmp/specrail-workspaces/run-cleanup-a"]);
+  assert.deepEqual(result.operations, [{ operation: directoryPlan.operations[0], status: "applied" }]);
+});
+
+test("ExecutionWorkspaceCleanupApplier applies git cleanup operations in order", async () => {
+  const commands: Array<{ cwd: string; command: string; args: string[] }> = [];
+  const applier = new ExecutionWorkspaceCleanupApplier({
+    gitRunner: {
+      async run(input) {
+        commands.push(input);
+      },
+    },
+  });
+
+  const result = await applier.apply({ plan: gitWorktreePlan, confirm: true });
+
+  assert.equal(result.status, "applied");
+  assert.deepEqual(commands, [
+    { cwd: "/tmp/specrail-repo", command: "git", args: ["worktree", "remove", "/tmp/specrail-workspaces/run-cleanup-b"] },
+    { cwd: "/tmp/specrail-repo", command: "git", args: ["branch", "-D", "specrail/run-cleanup-b"] },
+  ]);
+});
+
+test("ExecutionWorkspaceCleanupApplier returns partial failure details without retrying remaining operations", async () => {
+  const commands: Array<{ cwd: string; command: string; args: string[] }> = [];
+  const applier = new ExecutionWorkspaceCleanupApplier({
+    gitRunner: {
+      async run(input) {
+        commands.push(input);
+        throw new Error("fatal: worktree contains modified files");
+      },
+    },
+  });
+
+  const result = await applier.apply({ plan: gitWorktreePlan, confirm: true });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.applied, false);
+  assert.equal(commands.length, 1);
+  assert.deepEqual(result.operations, [
+    {
+      operation: gitWorktreePlan.operations[0],
+      status: "failed",
+      error: "fatal: worktree contains modified files",
+    },
+  ]);
+});

--- a/packages/core/src/services/execution-workspace-cleanup-applier.ts
+++ b/packages/core/src/services/execution-workspace-cleanup-applier.ts
@@ -1,0 +1,128 @@
+import { rm } from "node:fs/promises";
+
+import type {
+  ExecutionWorkspaceCleanupOperation,
+  ExecutionWorkspaceCleanupPlan,
+} from "./execution-workspace-cleanup-planner.js";
+import { NodeGitCommandRunner, type GitCommandRunner } from "./execution-workspace-manager.js";
+
+export interface FileSystemCleanupRunner {
+  removeDirectory(path: string): Promise<void>;
+}
+
+export class NodeFileSystemCleanupRunner implements FileSystemCleanupRunner {
+  async removeDirectory(path: string): Promise<void> {
+    await rm(path, { recursive: true, force: false });
+  }
+}
+
+export interface ApplyExecutionWorkspaceCleanupInput {
+  plan: ExecutionWorkspaceCleanupPlan;
+  confirm: boolean;
+}
+
+export interface AppliedExecutionWorkspaceCleanupOperation {
+  operation: ExecutionWorkspaceCleanupOperation;
+  status: "applied" | "failed";
+  error?: string;
+}
+
+export interface ApplyExecutionWorkspaceCleanupResult {
+  executionId: string;
+  applied: boolean;
+  status: "applied" | "refused" | "failed";
+  summary: string;
+  operations: AppliedExecutionWorkspaceCleanupOperation[];
+  refusalReasons: string[];
+}
+
+export class ExecutionWorkspaceCleanupApplier {
+  private readonly fileSystemRunner: FileSystemCleanupRunner;
+  private readonly gitRunner: GitCommandRunner;
+
+  constructor(input: { fileSystemRunner?: FileSystemCleanupRunner; gitRunner?: GitCommandRunner } = {}) {
+    this.fileSystemRunner = input.fileSystemRunner ?? new NodeFileSystemCleanupRunner();
+    this.gitRunner = input.gitRunner ?? new NodeGitCommandRunner();
+  }
+
+  async apply(input: ApplyExecutionWorkspaceCleanupInput): Promise<ApplyExecutionWorkspaceCleanupResult> {
+    const refusalReasons = collectRefusalReasons(input);
+
+    if (refusalReasons.length > 0) {
+      return {
+        executionId: input.plan.executionId,
+        applied: false,
+        status: "refused",
+        summary: `Workspace cleanup refused for execution ${input.plan.executionId}`,
+        operations: [],
+        refusalReasons,
+      };
+    }
+
+    const operations: AppliedExecutionWorkspaceCleanupOperation[] = [];
+
+    for (const operation of input.plan.operations) {
+      try {
+        await this.applyOperation(operation);
+        operations.push({ operation, status: "applied" });
+      } catch (error) {
+        operations.push({ operation, status: "failed", error: formatErrorMessage(error) });
+        return {
+          executionId: input.plan.executionId,
+          applied: false,
+          status: "failed",
+          summary: `Workspace cleanup failed for execution ${input.plan.executionId}`,
+          operations,
+          refusalReasons: [],
+        };
+      }
+    }
+
+    return {
+      executionId: input.plan.executionId,
+      applied: true,
+      status: "applied",
+      summary: `Workspace cleanup applied for execution ${input.plan.executionId}`,
+      operations,
+      refusalReasons: [],
+    };
+  }
+
+  private async applyOperation(operation: ExecutionWorkspaceCleanupOperation): Promise<void> {
+    switch (operation.kind) {
+      case "remove_directory":
+        await this.fileSystemRunner.removeDirectory(operation.path);
+        return;
+      case "git_worktree_remove":
+      case "git_branch_delete":
+        await this.gitRunner.run({ cwd: operation.cwd, command: operation.command, args: operation.args });
+        return;
+    }
+  }
+}
+
+function collectRefusalReasons(input: ApplyExecutionWorkspaceCleanupInput): string[] {
+  const refusalReasons: string[] = [];
+
+  if (!input.confirm) {
+    refusalReasons.push("Workspace cleanup apply requires explicit confirmation");
+  }
+
+  if (!input.plan.dryRun) {
+    refusalReasons.push("Workspace cleanup apply requires a dry-run plan as input");
+  }
+
+  if (!input.plan.eligible) {
+    refusalReasons.push(...input.plan.refusalReasons);
+  }
+
+  if (input.plan.operations.length === 0) {
+    refusalReasons.push("Workspace cleanup plan has no operations to apply");
+  }
+
+  return refusalReasons;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- add an explicit `ExecutionWorkspaceCleanupApplier` for previewed cleanup plans
- require confirmation before applying cleanup operations
- execute directory and git cleanup through injected runners
- return structured applied/refused/failed results with partial-failure details
- keep HTTP exposure deferred and update the roadmap to the next API apply slice

Closes #166

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build