### PR TITLE
feat: expose cleanup apply API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /runs/:runId/workspace-cleanup/preview`
   - return a non-destructive cleanup plan for the run workspace
   - response includes `cleanupPlan: { dryRun: true, eligible, operations, refusalReasons }`
+- `POST /runs/:runId/workspace-cleanup/apply`
+  - apply the server-side cleanup plan for the run workspace
+  - body: `{ confirm: "apply workspace cleanup for <runId>" }`
+  - response includes `cleanupResult` plus the exact `expectedConfirmation`
 - `POST /runs/:runId/approval-requests/:requestId/approve`
   - resolve a pending runtime approval request as approved
   - body: `{ decidedBy, comment? }`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import http from "node:http";
-import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,7 +32,7 @@ async function withServer(
 process.on("SIGTERM", () => process.exit(0));
 process.on("SIGINT", () => process.exit(0));
 console.log(JSON.stringify({ session_id: "fake-codex-" + process.pid }));
-setTimeout(() => process.exit(0), 1_000);
+setTimeout(() => process.exit(0), 10_000);
 `,
     "utf8",
   );
@@ -483,6 +483,37 @@ test("API supports resuming and cancelling a run", async () => {
     assert.equal(cleanupPreviewPayload.cleanupPlan.mode, "directory");
     assert.equal(cleanupPreviewPayload.cleanupPlan.operations[0]?.kind, "remove_directory");
     assert.deepEqual(cleanupPreviewPayload.cleanupPlan.refusalReasons, []);
+
+    const refusedCleanupResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/workspace-cleanup/apply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirm: "cleanup" }),
+    });
+    assert.equal(refusedCleanupResponse.status, 200);
+    const refusedCleanupPayload = (await refusedCleanupResponse.json()) as {
+      cleanupResult: { status: string; applied: boolean; refusalReasons: string[] };
+      expectedConfirmation: string;
+    };
+    assert.equal(refusedCleanupPayload.expectedConfirmation, `apply workspace cleanup for ${runPayload.run.id}`);
+    assert.equal(refusedCleanupPayload.cleanupResult.status, "refused");
+    assert.equal(refusedCleanupPayload.cleanupResult.applied, false);
+    assert.deepEqual(refusedCleanupPayload.cleanupResult.refusalReasons, [
+      "Workspace cleanup apply requires explicit confirmation",
+    ]);
+
+    const appliedCleanupResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/workspace-cleanup/apply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirm: `apply workspace cleanup for ${runPayload.run.id}` }),
+    });
+    assert.equal(appliedCleanupResponse.status, 200);
+    const appliedCleanupPayload = (await appliedCleanupResponse.json()) as {
+      cleanupResult: { status: string; applied: boolean; operations: Array<{ status: string }> };
+    };
+    assert.equal(appliedCleanupPayload.cleanupResult.status, "applied");
+    assert.equal(appliedCleanupPayload.cleanupResult.applied, true);
+    assert.deepEqual(appliedCleanupPayload.cleanupResult.operations.map((operation) => operation.status), ["applied"]);
+    await assert.rejects(() => access(cleanupPreviewPayload.cleanupPlan.operations[0]?.path ?? ""));
   });
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -34,6 +34,7 @@ import {
   SpecRailService,
   TRACK_STATUSES,
   createExecutionWorkspaceManager,
+  ExecutionWorkspaceCleanupApplier,
   planExecutionWorkspaceCleanup,
   type ExecutionWorkspaceMode,
   type ExecutionEvent,
@@ -53,6 +54,7 @@ interface ApiDeps {
   workspaceRoot: string;
   executionWorkspaceMode: ExecutionWorkspaceMode;
   localRepoPath?: string;
+  cleanupApplier: ExecutionWorkspaceCleanupApplier;
 }
 
 interface TrackRequestBody {
@@ -108,6 +110,10 @@ interface DecideApprovalRequestBody {
 interface ResolveRuntimeApprovalRequestBody {
   decidedBy: "user" | "agent" | "system";
   comment?: string;
+}
+
+interface ApplyWorkspaceCleanupRequestBody {
+  confirm: string;
 }
 
 interface BindChannelRequestBody {
@@ -299,6 +305,10 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
     localRepoPath: serviceDependencies.defaultProject.localRepoPath,
     serviceDependencies,
   };
+}
+
+function buildWorkspaceCleanupConfirmation(runId: string): string {
+  return `apply workspace cleanup for ${runId}`;
 }
 
 async function readJson<T>(request: IncomingMessage): Promise<T> {
@@ -1224,6 +1234,30 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         return;
       }
 
+      if (method === "POST" && segments.length === 4 && segments[0] === "runs" && segments[2] === "workspace-cleanup" && segments[3] === "apply") {
+        const run = await deps.service.getRun(segments[1] ?? "");
+
+        if (!run) {
+          sendError(response, 404, "not_found", "run not found");
+          return;
+        }
+
+        const body = await readJson<ApplyWorkspaceCleanupRequestBody>(request);
+        const expectedConfirmation = buildWorkspaceCleanupConfirmation(run.id);
+        const cleanupPlan = planExecutionWorkspaceCleanup({
+          execution: run,
+          workspaceRoot: deps.workspaceRoot,
+          mode: deps.executionWorkspaceMode,
+          localRepoPath: deps.localRepoPath,
+        });
+        const cleanupResult = await deps.cleanupApplier.apply({
+          plan: cleanupPlan,
+          confirm: body.confirm === expectedConfirmation,
+        });
+        sendJson(response, 200, { cleanupResult, expectedConfirmation });
+        return;
+      }
+
       if (method === "GET" && segments.length === 2 && segments[0] === "runs") {
         const run = await deps.service.getRun(segments[1] ?? "");
 
@@ -1300,6 +1334,7 @@ export function createDefaultServer(): http.Server {
     workspaceRoot: dependencies.workspaceRoot,
     executionWorkspaceMode: dependencies.executionWorkspaceMode,
     localRepoPath: dependencies.localRepoPath,
+    cleanupApplier: new ExecutionWorkspaceCleanupApplier(),
   });
 }
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -71,6 +71,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - non-destructive cleanup planner previews directory and git worktree operations with guardrail refusal reasons
 - API cleanup preview endpoint exposes dry-run plans without filesystem or git side effects
 - core cleanup applier requires explicit confirmation and injectable filesystem/git runners before applying previewed operations
+- API cleanup apply endpoint requires a run-id-specific confirmation phrase and reconstructs the plan server-side
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -84,8 +85,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Expose execution workspace cleanup apply API**
-   - require a fresh preview/confirmation token before applying owned workspace/branch cleanup through HTTP.
+1. **Record workspace cleanup apply events**
+   - append normalized summary events for applied/refused/failed cleanup attempts.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**


### PR DESCRIPTION
## Summary
- add `POST /runs/:runId/workspace-cleanup/apply`
- require the run-id-specific confirmation phrase `apply workspace cleanup for <runId>`
- reconstruct the cleanup plan server-side before applying operations
- return structured cleanup results and expected confirmation text
- add API coverage for confirmation refusal and successful temp-directory cleanup
- document the apply endpoint and update the roadmap

Closes #168

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build