### PR TITLE
feat: record cleanup apply events

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - apply the server-side cleanup plan for the run workspace
   - body: `{ confirm: "apply workspace cleanup for <runId>" }`
   - response includes `cleanupResult` plus the exact `expectedConfirmation`
+  - appends a `summary` run event for applied, refused, and failed cleanup attempts
 - `POST /runs/:runId/approval-requests/:requestId/approve`
   - resolve a pending runtime approval request as approved
   - body: `{ decidedBy, comment? }`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -501,6 +501,19 @@ test("API supports resuming and cancelling a run", async () => {
       "Workspace cleanup apply requires explicit confirmation",
     ]);
 
+    const refusedEventsResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/events`);
+    const refusedEventsPayload = (await refusedEventsResponse.json()) as {
+      events: Array<{ summary: string; payload?: { status?: string; refusalReasons?: string[] } }>;
+    };
+    assert.ok(
+      refusedEventsPayload.events.some(
+        (event) =>
+          event.summary === `Workspace cleanup refused for execution ${runPayload.run.id}` &&
+          event.payload?.status === "refused" &&
+          event.payload.refusalReasons?.includes("Workspace cleanup apply requires explicit confirmation"),
+      ),
+    );
+
     const appliedCleanupResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/workspace-cleanup/apply`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -514,6 +527,19 @@ test("API supports resuming and cancelling a run", async () => {
     assert.equal(appliedCleanupPayload.cleanupResult.applied, true);
     assert.deepEqual(appliedCleanupPayload.cleanupResult.operations.map((operation) => operation.status), ["applied"]);
     await assert.rejects(() => access(cleanupPreviewPayload.cleanupPlan.operations[0]?.path ?? ""));
+
+    const appliedEventsResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/events`);
+    const appliedEventsPayload = (await appliedEventsResponse.json()) as {
+      events: Array<{ summary: string; payload?: { status?: string; operationCount?: number } }>;
+    };
+    assert.ok(
+      appliedEventsPayload.events.some(
+        (event) =>
+          event.summary === `Workspace cleanup applied for execution ${runPayload.run.id}` &&
+          event.payload?.status === "applied" &&
+          event.payload.operationCount === 1,
+      ),
+    );
   });
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -37,6 +37,7 @@ import {
   ExecutionWorkspaceCleanupApplier,
   planExecutionWorkspaceCleanup,
   type ExecutionWorkspaceMode,
+  type ApplyExecutionWorkspaceCleanupResult,
   type ExecutionEvent,
   type ApprovalStatus,
   type ArtifactKind,
@@ -309,6 +310,26 @@ function createDependencies(dataDir: string, repoArtifactRoot: string): DefaultD
 
 function buildWorkspaceCleanupConfirmation(runId: string): string {
   return `apply workspace cleanup for ${runId}`;
+}
+
+function buildWorkspaceCleanupEvent(runId: string, result: ApplyExecutionWorkspaceCleanupResult): ExecutionEvent {
+  const timestamp = new Date().toISOString();
+
+  return {
+    id: `${runId}:workspace-cleanup:${timestamp}`,
+    executionId: runId,
+    type: "summary",
+    timestamp,
+    source: "specrail",
+    summary: `Workspace cleanup ${result.status} for execution ${runId}`,
+    payload: {
+      status: result.status,
+      applied: result.applied,
+      operationCount: result.operations.length,
+      operations: result.operations,
+      refusalReasons: result.refusalReasons,
+    },
+  };
 }
 
 async function readJson<T>(request: IncomingMessage): Promise<T> {
@@ -1254,6 +1275,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
           plan: cleanupPlan,
           confirm: body.confirm === expectedConfirmation,
         });
+        await deps.service.recordExecutionEvent(buildWorkspaceCleanupEvent(run.id, cleanupResult));
         sendJson(response, 200, { cleanupResult, expectedConfirmation });
         return;
       }

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -72,6 +72,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - API cleanup preview endpoint exposes dry-run plans without filesystem or git side effects
 - core cleanup applier requires explicit confirmation and injectable filesystem/git runners before applying previewed operations
 - API cleanup apply endpoint requires a run-id-specific confirmation phrase and reconstructs the plan server-side
+- cleanup apply attempts are recorded as run summary events for applied, refused, and failed outcomes
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -85,8 +86,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Record workspace cleanup apply events**
-   - append normalized summary events for applied/refused/failed cleanup attempts.
+1. **Add cleanup apply visibility to clients**
+   - surface cleanup preview/apply summaries in operator clients without requiring raw API calls.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**


### PR DESCRIPTION
## Summary
- append a run `summary` event after workspace cleanup apply attempts
- record applied/refused/failed status, operation count, operations, and refusal reasons
- add API coverage for refused and applied cleanup event audit trails
- document cleanup apply event behavior and update the roadmap

Closes #170

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build