### PR TITLE
feat: expose cleanup client methods

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -136,6 +136,82 @@ test("SpecRailTerminalApiClient submits artifact revision proposals", async () =
   assert.equal(result.approvalRequest.id, "approval-2");
 });
 
+test("SpecRailTerminalApiClient previews and applies workspace cleanup with explicit confirmation", async () => {
+  const requests: Array<{ url: string; method?: string; body?: string }> = [];
+  const client = new SpecRailTerminalApiClient("http://example.test", async (input, init) => {
+    const url = String(input);
+    requests.push({ url, method: init?.method, body: init?.body?.toString() });
+
+    if (url.endsWith("/runs/run-cleanup-a/workspace-cleanup/preview") && !init?.method) {
+      return new Response(
+        JSON.stringify({
+          cleanupPlan: {
+            dryRun: true,
+            eligible: true,
+            operations: [{ kind: "remove_directory", path: "/tmp/specrail-workspaces/run-cleanup-a" }],
+            refusalReasons: [],
+          },
+        }),
+        { status: 200 },
+      );
+    }
+
+    if (url.endsWith("/runs/run-cleanup-a/workspace-cleanup/apply") && init?.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          cleanupResult: {
+            applied: true,
+            status: "applied",
+            operations: [{ kind: "remove_directory", path: "/tmp/specrail-workspaces/run-cleanup-a", status: "applied" }],
+            refusalReasons: [],
+          },
+          expectedConfirmation: "apply workspace cleanup for run-cleanup-a",
+        }),
+        { status: 200 },
+      );
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  const preview = await client.previewWorkspaceCleanup("run-cleanup-a");
+  assert.equal(preview.cleanupPlan.eligible, true);
+  assert.equal(preview.cleanupPlan.operations[0]?.kind, "remove_directory");
+
+  const apply = await client.applyWorkspaceCleanup("run-cleanup-a", "apply workspace cleanup for run-cleanup-a");
+  assert.equal(apply.cleanupResult.status, "applied");
+  assert.equal(apply.expectedConfirmation, "apply workspace cleanup for run-cleanup-a");
+  assert.equal(requests[1]?.body, JSON.stringify({ confirm: "apply workspace cleanup for run-cleanup-a" }));
+});
+
+test("SpecRailTerminalApiClient preserves server refusal details for workspace cleanup apply", async () => {
+  const client = new SpecRailTerminalApiClient("http://example.test", async (input, init) => {
+    const url = String(input);
+
+    if (url.endsWith("/runs/run-cleanup-a/workspace-cleanup/apply") && init?.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          cleanupResult: {
+            applied: false,
+            status: "refused",
+            operations: [],
+            refusalReasons: ["Workspace cleanup apply requires explicit confirmation"],
+          },
+          expectedConfirmation: "apply workspace cleanup for run-cleanup-a",
+        }),
+        { status: 200 },
+      );
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  const result = await client.applyWorkspaceCleanup("run-cleanup-a", "cleanup");
+  assert.equal(result.cleanupResult.status, "refused");
+  assert.deepEqual(result.cleanupResult.refusalReasons, ["Workspace cleanup apply requires explicit confirmation"]);
+  assert.equal(result.expectedConfirmation, "apply workspace cleanup for run-cleanup-a");
+});
+
 test("SpecRailTerminalApiClient parses SSE frames from run event streams", async () => {
   const encoder = new TextEncoder();
   const chunks = [

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -60,6 +60,41 @@ export interface ExecutionEvent {
   payload?: Record<string, unknown>;
 }
 
+export interface WorkspaceCleanupOperation {
+  kind: "remove_directory" | "git_worktree_remove" | "git_branch_delete";
+  path?: string;
+  branchName?: string;
+  command?: string;
+}
+
+export interface WorkspaceCleanupPlan {
+  dryRun: true;
+  eligible: boolean;
+  operations: WorkspaceCleanupOperation[];
+  refusalReasons: string[];
+}
+
+export interface WorkspaceCleanupPreviewResponse {
+  cleanupPlan: WorkspaceCleanupPlan;
+}
+
+export interface AppliedWorkspaceCleanupOperation extends WorkspaceCleanupOperation {
+  status: "applied" | "failed";
+  error?: string;
+}
+
+export interface WorkspaceCleanupApplyResult {
+  applied: boolean;
+  status: "applied" | "refused" | "failed";
+  operations: AppliedWorkspaceCleanupOperation[];
+  refusalReasons: string[];
+}
+
+export interface WorkspaceCleanupApplyResponse {
+  cleanupResult: WorkspaceCleanupApplyResult;
+  expectedConfirmation: string;
+}
+
 export interface PlanningSessionSummary {
   id: string;
   trackId: string;
@@ -416,6 +451,18 @@ export class SpecRailTerminalApiClient {
     });
 
     return { run: payload.run };
+  }
+
+  async previewWorkspaceCleanup(runId: string): Promise<WorkspaceCleanupPreviewResponse> {
+    return this.request<WorkspaceCleanupPreviewResponse>(`/runs/${runId}/workspace-cleanup/preview`);
+  }
+
+  async applyWorkspaceCleanup(runId: string, confirmation: string): Promise<WorkspaceCleanupApplyResponse> {
+    return this.request<WorkspaceCleanupApplyResponse>(`/runs/${runId}/workspace-cleanup/apply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirm: confirmation }),
+    });
   }
 
   async *streamRunEvents(runId: string, signal?: AbortSignal): AsyncGenerator<ExecutionEvent> {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -73,6 +73,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - core cleanup applier requires explicit confirmation and injectable filesystem/git runners before applying previewed operations
 - API cleanup apply endpoint requires a run-id-specific confirmation phrase and reconstructs the plan server-side
 - cleanup apply attempts are recorded as run summary events for applied, refused, and failed outcomes
+- terminal API client exposes cleanup preview/apply methods and preserves server-provided confirmation/refusal details
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -86,8 +87,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add cleanup apply visibility to clients**
-   - surface cleanup preview/apply summaries in operator clients without requiring raw API calls.
+1. **Add interactive cleanup controls to the terminal UI**
+   - wire preview/apply client methods into guarded keyboard actions or command prompts.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**


### PR DESCRIPTION
## Summary
- add terminal API client types and methods for workspace cleanup preview/apply
- preserve server-provided expected confirmation and refusal details
- cover preview parsing, confirmation payload submission, and refused cleanup result handling
- update the roadmap toward interactive terminal cleanup controls

Closes #172

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build