### PR TITLE
feat: refresh terminal cleanup state

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -212,6 +212,37 @@ test("SpecRailTerminalApiClient preserves server refusal details for workspace c
   assert.equal(result.expectedConfirmation, "apply workspace cleanup for run-cleanup-a");
 });
 
+test("SpecRailTerminalApiClient loads run events for post-action refresh", async () => {
+  const client = new SpecRailTerminalApiClient("http://example.test", async (input) => {
+    const url = String(input);
+
+    if (url.endsWith("/runs/run-cleanup-a/events")) {
+      return new Response(
+        JSON.stringify({
+          events: [
+            {
+              id: "run-cleanup-a:workspace-cleanup:2026-05-03T00:00:00.000Z",
+              executionId: "run-cleanup-a",
+              type: "summary",
+              timestamp: "2026-05-03T00:00:00.000Z",
+              source: "specrail",
+              summary: "Workspace cleanup applied for execution run-cleanup-a",
+              payload: { status: "applied" },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  const events = await client.loadRunEvents("run-cleanup-a");
+  assert.equal(events[0]?.summary, "Workspace cleanup applied for execution run-cleanup-a");
+  assert.equal(events[0]?.payload?.status, "applied");
+});
+
 test("SpecRailTerminalApiClient parses SSE frames from run event streams", async () => {
   const encoder = new TextEncoder();
   const chunks = [

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -287,6 +287,10 @@ interface RunDetailResponse {
   run: RunListItem;
 }
 
+interface RunEventsResponse {
+  events: ExecutionEvent[];
+}
+
 interface ApiErrorResponse {
   error?: {
     message?: string;
@@ -433,6 +437,11 @@ export class SpecRailTerminalApiClient {
   async loadRunDetail(runId: string): Promise<RunDetailSnapshot> {
     const payload = await this.request<RunDetailResponse>(`/runs/${runId}`);
     return { run: payload.run };
+  }
+
+  async loadRunEvents(runId: string): Promise<ExecutionEvent[]> {
+    const payload = await this.request<RunEventsResponse>(`/runs/${runId}/events`);
+    return payload.events;
   }
 
   async startRun(input: { trackId: string; prompt: string; backend?: string; profile?: string; planningSessionId?: string }): Promise<RunDetailSnapshot> {
@@ -1854,7 +1863,7 @@ export async function runTerminalApp(
     try {
       const result = await client.applyWorkspaceCleanup(action.runId, confirmation);
       const nextPhase = confirmation && result.cleanupResult.applied ? "done" : "confirmation_ready";
-      updateWorkspaceCleanupComposer({
+      const nextCleanupAction: PendingWorkspaceCleanupActionState = {
         ...action,
         result,
         phase: nextPhase,
@@ -1862,7 +1871,40 @@ export async function runTerminalApp(
         message: confirmation
           ? `Cleanup ${result.cleanupResult.status}; ${result.cleanupResult.operations.length} operation(s) returned.`
           : "Server confirmation phrase received. Press Enter again to apply cleanup with that exact phrase.",
-      }, confirmation ? `Workspace cleanup ${result.cleanupResult.status} for ${action.runId}.` : `Workspace cleanup confirmation ready for ${action.runId}.`);
+      };
+
+      if (!confirmation) {
+        updateWorkspaceCleanupComposer(nextCleanupAction, `Workspace cleanup confirmation ready for ${action.runId}.`);
+        return;
+      }
+
+      try {
+        const [runDetail, events] = await Promise.all([
+          client.loadRunDetail(action.runId),
+          client.loadRunEvents(action.runId),
+        ]);
+        updateState(syncRunEventSelection({
+          ...state,
+          pendingWorkspaceCleanupAction: nextCleanupAction,
+          runs: {
+            ...state.runs,
+            data: runDetail,
+            error: null,
+          },
+          runEvents: appendRunEvents(createEmptyRunEventFeedState(action.runId, state.runEvents.paused), events),
+          statusLine: `Workspace cleanup ${result.cleanupResult.status} for ${action.runId}; detail and events refreshed.`,
+        }));
+      } catch (refreshError) {
+        updateState({
+          ...state,
+          pendingWorkspaceCleanupAction: {
+            ...nextCleanupAction,
+            message: `${nextCleanupAction.message} Follow-up refresh failed: ${refreshError instanceof Error ? refreshError.message : "unknown error"}`,
+          },
+          error: refreshError instanceof Error ? refreshError.message : "Failed to refresh cleanup state.",
+          statusLine: `Workspace cleanup ${result.cleanupResult.status} for ${action.runId}; follow-up refresh failed.`,
+        });
+      }
     } catch (error) {
       updateState({
         ...state,

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -76,6 +76,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - terminal API client exposes cleanup preview/apply methods and preserves server-provided confirmation/refusal details
 - terminal UI exposes guarded cleanup preview/apply controls for selected terminal runs
 - GitHub Actions workflows opt JavaScript actions into the Node.js 24 runtime ahead of runner defaults
+- terminal cleanup apply refreshes selected run detail/events immediately after apply attempts when possible
 
 ### Milestone D — Project management APIs
 - expose project create/list/get/update endpoints
@@ -89,8 +90,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add cleanup action result refresh to terminal UI**
-   - refresh the selected run event feed/detail immediately after cleanup apply completes.
+1. **Add terminal cleanup control integration tests**
+   - exercise the keypress-driven preview/confirmation/apply flow with a fake terminal IO harness.
 3. **Add project management APIs**
    - move beyond the default bootstrap project.
 5. **Plan the first hosted operator UI slice**


### PR DESCRIPTION
## Summary
- add terminal API client support for loading run events on demand
- refresh selected run detail and event feed after cleanup apply attempts
- keep cleanup apply results visible when follow-up refresh fails
- update roadmap with the completed cleanup refresh follow-up

Closes #178

## Validation
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build