### PR TITLE
feat: expose project management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Current limitation: runtime approval resolution is still adapter-mediated, not a
 
 Current endpoints in `apps/api/src/index.ts`:
 
+### Projects
+- `GET /projects`
+  - list projects, bootstrapping the default project if needed
+- `POST /projects`
+  - create a project
+  - body: `{ name, repoUrl?, localRepoPath?, defaultWorkflowPolicy?, defaultPlanningSystem? }`
+  - `defaultPlanningSystem` supports `native`, `openspec`, and `speckit`
+- `GET /projects/:projectId`
+  - return project metadata
+- `PATCH /projects/:projectId`
+  - update project metadata
+  - body: any of `{ name, repoUrl, localRepoPath, defaultWorkflowPolicy, defaultPlanningSystem }`
+  - nullable optional fields clear the stored value
+
 ### Tracks
 - `POST /tracks`
   - create a track
@@ -130,7 +144,7 @@ Current endpoints in `apps/api/src/index.ts`:
 
 ### Error contract
 - `400` for malformed JSON
-- `404` for missing tracks/runs
+- `404` for missing projects/tracks/runs
 - `422` for validation failures
   - includes invalid pagination/sort params
 - `500` for unexpected server errors

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -178,6 +178,97 @@ async function openSseStream(url: string): Promise<{
   });
 }
 
+test("API supports project create, list, get, and update", async () => {
+  await withServer(async (baseUrl) => {
+    const initialListResponse = await fetch(`${baseUrl}/projects`);
+    assert.equal(initialListResponse.status, 200);
+    const initialListPayload = (await initialListResponse.json()) as { projects: Array<{ id: string; name: string }> };
+    assert.deepEqual(initialListPayload.projects.map((project) => project.id), ["project-default"]);
+
+    const createResponse = await fetch(`${baseUrl}/projects`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Operator UI",
+        repoUrl: "https://github.com/yoophi-a/specrail-operator",
+        localRepoPath: "/work/specrail-operator",
+        defaultWorkflowPolicy: "artifact-first-mvp",
+        defaultPlanningSystem: "openspec",
+      }),
+    });
+    assert.equal(createResponse.status, 201);
+    const createPayload = (await createResponse.json()) as {
+      project: { id: string; name: string; repoUrl?: string; localRepoPath?: string; defaultPlanningSystem?: string };
+    };
+    assert.match(createPayload.project.id, /^project-/);
+    assert.equal(createPayload.project.name, "Operator UI");
+    assert.equal(createPayload.project.defaultPlanningSystem, "openspec");
+
+    const getResponse = await fetch(`${baseUrl}/projects/${createPayload.project.id}`);
+    assert.equal(getResponse.status, 200);
+    const getPayload = (await getResponse.json()) as { project: { id: string; repoUrl?: string } };
+    assert.equal(getPayload.project.id, createPayload.project.id);
+    assert.equal(getPayload.project.repoUrl, "https://github.com/yoophi-a/specrail-operator");
+
+    const updateResponse = await fetch(`${baseUrl}/projects/${createPayload.project.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Operator Console",
+        repoUrl: null,
+        defaultPlanningSystem: "speckit",
+      }),
+    });
+    assert.equal(updateResponse.status, 200);
+    const updatePayload = (await updateResponse.json()) as {
+      project: { id: string; name: string; repoUrl?: string; defaultPlanningSystem?: string; updatedAt: string };
+    };
+    assert.equal(updatePayload.project.name, "Operator Console");
+    assert.equal(updatePayload.project.repoUrl, undefined);
+    assert.equal(updatePayload.project.defaultPlanningSystem, "speckit");
+
+    const listResponse = await fetch(`${baseUrl}/projects`);
+    assert.equal(listResponse.status, 200);
+    const listPayload = (await listResponse.json()) as { projects: Array<{ id: string; name: string }> };
+    assert.deepEqual(
+      listPayload.projects.map((project) => project.id).sort(),
+      ["project-default", createPayload.project.id].sort(),
+    );
+  });
+});
+
+test("API validates project payloads and returns 404s for missing projects", async () => {
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/projects`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "", defaultPlanningSystem: "unknown" }),
+    });
+    assert.equal(createResponse.status, 422);
+    const createPayload = (await createResponse.json()) as { error: { details: Array<{ field: string }> } };
+    assert.deepEqual(createPayload.error.details.map((detail) => detail.field), ["name", "defaultPlanningSystem"]);
+
+    const updateResponse = await fetch(`${baseUrl}/projects/project-missing`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Missing" }),
+    });
+    assert.equal(updateResponse.status, 404);
+    const updatePayload = (await updateResponse.json()) as { error: { message: string } };
+    assert.equal(updatePayload.error.message, "Project not found: project-missing");
+
+    const emptyUpdateResponse = await fetch(`${baseUrl}/projects/project-default`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(emptyUpdateResponse.status, 422);
+
+    const getResponse = await fetch(`${baseUrl}/projects/project-missing`);
+    assert.equal(getResponse.status, 404);
+  });
+});
+
 test("API supports creating tracks, planning sessions, messages, starting runs, and listing run events", async () => {
   await withServer(async (baseUrl, paths) => {
     const trackResponse = await fetch(`${baseUrl}/tracks`, {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import {
   ARTIFACT_KINDS,
   ATTACHMENT_SOURCE_TYPES,
   CHANNEL_TYPES,
+  PLANNING_SYSTEMS,
   FileAttachmentReferenceRepository,
   FileApprovalRequestRepository,
   FileArtifactRevisionRepository,
@@ -43,6 +44,7 @@ import {
   type ArtifactKind,
   type PlanningMessage,
   type PlanningMessageKind,
+  type PlanningSystem,
   type PlanningSessionStatus,
   type SpecRailServiceDependencies,
   type TrackStatus,
@@ -62,6 +64,22 @@ interface TrackRequestBody {
   title: string;
   description: string;
   priority?: "low" | "medium" | "high";
+}
+
+interface ProjectCreateRequestBody {
+  name: string;
+  repoUrl?: string;
+  localRepoPath?: string;
+  defaultWorkflowPolicy?: string;
+  defaultPlanningSystem?: PlanningSystem;
+}
+
+interface ProjectUpdateRequestBody {
+  name?: string;
+  repoUrl?: string | null;
+  localRepoPath?: string | null;
+  defaultWorkflowPolicy?: string | null;
+  defaultPlanningSystem?: PlanningSystem | null;
 }
 
 interface RunRequestBody {
@@ -401,6 +419,10 @@ function isPlanningMessageKind(value: unknown): value is PlanningMessageKind {
   return typeof value === "string" && PLANNING_MESSAGE_KINDS.includes(value as PlanningMessageKind);
 }
 
+function isPlanningSystem(value: unknown): value is PlanningSystem {
+  return typeof value === "string" && PLANNING_SYSTEMS.includes(value as PlanningSystem);
+}
+
 function isArtifactKind(value: unknown): value is ArtifactKind {
   return typeof value === "string" && ARTIFACT_KINDS.includes(value as ArtifactKind);
 }
@@ -465,6 +487,74 @@ function assertValidTrackCreateBody(body: TrackRequestBody): void {
 
   if (body.priority !== undefined && !["low", "medium", "high"].includes(body.priority)) {
     details.push({ field: "priority", message: "must be one of low, medium, high" });
+  }
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
+  }
+}
+
+function assertValidProjectCreateBody(body: ProjectCreateRequestBody): void {
+  const details: ApiErrorDetail[] = [];
+
+  const nameDetail = getNonEmptyStringDetail("name", body.name);
+  if (nameDetail) {
+    details.push(nameDetail);
+  } else if (body.name.trim().length > 120) {
+    details.push({ field: "name", message: "must be 120 characters or fewer" });
+  }
+
+  for (const field of ["repoUrl", "localRepoPath", "defaultWorkflowPolicy"] as const) {
+    if (body[field] !== undefined) {
+      const detail = getNonEmptyStringDetail(field, body[field]);
+      if (detail) {
+        details.push(detail);
+      }
+    }
+  }
+
+  if (body.defaultPlanningSystem !== undefined && !isPlanningSystem(body.defaultPlanningSystem)) {
+    details.push({ field: "defaultPlanningSystem", message: `must be one of: ${PLANNING_SYSTEMS.join(", ")}` });
+  }
+
+  if (details.length > 0) {
+    throw new RequestValidationError("request validation failed", details);
+  }
+}
+
+function assertValidProjectUpdateBody(body: ProjectUpdateRequestBody): void {
+  const details: ApiErrorDetail[] = [];
+
+  if (
+    body.name === undefined &&
+    body.repoUrl === undefined &&
+    body.localRepoPath === undefined &&
+    body.defaultWorkflowPolicy === undefined &&
+    body.defaultPlanningSystem === undefined
+  ) {
+    details.push({ field: "body", message: "at least one project field is required" });
+  }
+
+  if (body.name !== undefined) {
+    const nameDetail = getNonEmptyStringDetail("name", body.name);
+    if (nameDetail) {
+      details.push(nameDetail);
+    } else if (body.name.trim().length > 120) {
+      details.push({ field: "name", message: "must be 120 characters or fewer" });
+    }
+  }
+
+  for (const field of ["repoUrl", "localRepoPath", "defaultWorkflowPolicy"] as const) {
+    if (body[field] !== undefined && body[field] !== null) {
+      const detail = getNonEmptyStringDetail(field, body[field]);
+      if (detail) {
+        details.push(detail);
+      }
+    }
+  }
+
+  if (body.defaultPlanningSystem !== undefined && body.defaultPlanningSystem !== null && !isPlanningSystem(body.defaultPlanningSystem)) {
+    details.push({ field: "defaultPlanningSystem", message: `must be one of: ${PLANNING_SYSTEMS.join(", ")}` });
   }
 
   if (details.length > 0) {
@@ -926,6 +1016,48 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
     try {
       const method = request.method ?? "GET";
       const segments = getPathSegments(request);
+
+      if (method === "GET" && segments.length === 1 && segments[0] === "projects") {
+        const projects = await deps.service.listProjects();
+        sendJson(response, 200, { projects });
+        return;
+      }
+
+      if (method === "POST" && segments.length === 1 && segments[0] === "projects") {
+        const body = await readJson<ProjectCreateRequestBody>(request);
+        assertValidProjectCreateBody(body);
+
+        const project = await deps.service.createProject(body);
+        sendJson(response, 201, { project });
+        return;
+      }
+
+      if (method === "GET" && segments.length === 2 && segments[0] === "projects") {
+        const project = await deps.service.getProject(segments[1] ?? "");
+        if (!project) {
+          sendError(response, 404, "not_found", "project not found");
+          return;
+        }
+
+        sendJson(response, 200, { project });
+        return;
+      }
+
+      if (method === "PATCH" && segments.length === 2 && segments[0] === "projects") {
+        const body = await readJson<ProjectUpdateRequestBody>(request);
+        assertValidProjectUpdateBody(body);
+
+        const project = await deps.service.updateProject({
+          projectId: segments[1] ?? "",
+          name: body.name,
+          repoUrl: body.repoUrl,
+          localRepoPath: body.localRepoPath,
+          defaultWorkflowPolicy: body.defaultWorkflowPolicy,
+          defaultPlanningSystem: body.defaultPlanningSystem,
+        });
+        sendJson(response, 200, { project });
+        return;
+      }
 
       if (method === "POST" && segments.length === 1 && segments[0] === "tracks") {
         const body = await readJson<TrackRequestBody>(request);

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -41,7 +41,6 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
   - hosted web UI and GitHub app/webhook entrypoints are still deferred
 
 ### Not started
-- project management APIs beyond the default bootstrap project
 - database-backed persistence
 - production auth system
 - production deployment manifests
@@ -80,9 +79,9 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - terminal cleanup controls have an integration-style keypress flow test for preview, confirmation, apply, and refresh
 
 ### Milestone D — Project management APIs
-- expose project create/list/get/update endpoints
-- define how tracks are scoped and filtered by project
-- add API and service tests for multi-project behavior
+- project create/list/get/update endpoints expose basic project metadata beyond the bootstrap default
+- next: define how tracks are scoped and filtered by project
+- next: add deeper service tests for multi-project behavior once track scoping is introduced
 
 ### Milestone E — Hosted operator UI / GitHub entrypoints
 - introduce a web UI or GitHub-facing entrypoint after the core state contracts stabilize
@@ -91,9 +90,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add project management APIs**
-   - move beyond the default bootstrap project.
-3. **Add project management APIs**
-   - move beyond the default bootstrap project.
-5. **Plan the first hosted operator UI slice**
+1. **Scope tracks by project in list/create APIs**
+   - let clients target non-default projects and filter tracks per project.
+2. **Plan the first hosted operator UI slice**
    - build on the stabilized HTTP/SSE API rather than adding new core behavior.

--- a/packages/core/src/services/__tests__/file-repositories.test.ts
+++ b/packages/core/src/services/__tests__/file-repositories.test.ts
@@ -62,10 +62,11 @@ test("file repositories persist and reload project/track/execution state", async
   await trackRepository.create(track);
   await executionRepository.create(execution);
 
+  await projectRepository.update({ ...project, name: "SpecRail Updated", updatedAt: "2026-04-09T00:09:00.000Z" });
   await trackRepository.update({ ...track, status: "in_progress", updatedAt: "2026-04-09T00:10:00.000Z" });
   await executionRepository.update({ ...execution, status: "running", startedAt: "2026-04-09T00:11:00.000Z" });
 
-  assert.deepEqual(await projectRepository.getById(project.id), project);
+  assert.deepEqual(await projectRepository.getById(project.id), { ...project, name: "SpecRail Updated", updatedAt: "2026-04-09T00:09:00.000Z" });
   assert.deepEqual(await trackRepository.getById(track.id), {
     ...track,
     status: "in_progress",
@@ -77,6 +78,9 @@ test("file repositories persist and reload project/track/execution state", async
     startedAt: "2026-04-09T00:11:00.000Z",
   });
 
+  assert.deepEqual(await projectRepository.list(), [
+    { ...project, name: "SpecRail Updated", updatedAt: "2026-04-09T00:09:00.000Z" },
+  ]);
   assert.deepEqual(await trackRepository.list(), [
     {
       ...track,

--- a/packages/core/src/services/file-repositories.ts
+++ b/packages/core/src/services/file-repositories.ts
@@ -132,6 +132,14 @@ export class FileProjectRepository implements ProjectRepository {
   getById(projectId: string): Promise<Project | null> {
     return this.repository.getById(projectId);
   }
+
+  list(): Promise<Project[]> {
+    return this.repository.list();
+  }
+
+  update(project: Project): Promise<void> {
+    return this.repository.update(project);
+  }
 }
 
 export class FileTrackRepository implements TrackRepository {

--- a/packages/core/src/services/ports.ts
+++ b/packages/core/src/services/ports.ts
@@ -14,6 +14,8 @@ import type {
 export interface ProjectRepository {
   create(project: Project): Promise<void>;
   getById(projectId: string): Promise<Project | null>;
+  list(): Promise<Project[]>;
+  update(project: Project): Promise<void>;
 }
 
 export interface TrackRepository {

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -21,6 +21,7 @@ import type {
   ExecutionStatus,
   PlanningMessage,
   PlanningMessageKind,
+  PlanningSystem,
   PlanningSession,
   PlanningSessionStatus,
   Project,
@@ -126,6 +127,23 @@ export interface SpecRailServiceDependencies {
   workspaceManager?: ExecutionWorkspaceManager;
   now?: () => string;
   idGenerator?: () => string;
+}
+
+export interface CreateProjectInput {
+  name: string;
+  repoUrl?: string;
+  localRepoPath?: string;
+  defaultWorkflowPolicy?: string;
+  defaultPlanningSystem?: PlanningSystem;
+}
+
+export interface UpdateProjectInput {
+  projectId: string;
+  name?: string;
+  repoUrl?: string | null;
+  localRepoPath?: string | null;
+  defaultWorkflowPolicy?: string | null;
+  defaultPlanningSystem?: PlanningSystem | null;
 }
 
 export interface CreateTrackInput {
@@ -420,6 +438,84 @@ export class SpecRailService {
     this.now = dependencies.now ?? (() => new Date().toISOString());
     this.idGenerator = dependencies.idGenerator ?? randomUUID;
     this.workspaceManager = dependencies.workspaceManager ?? new DirectoryExecutionWorkspaceManager();
+  }
+
+  async createProject(input: CreateProjectInput): Promise<Project> {
+    const timestamp = this.now();
+    const project: Project = {
+      id: `project-${this.idGenerator()}`,
+      name: normalizeRequiredString(input.name),
+      ...(input.repoUrl !== undefined ? { repoUrl: normalizeRequiredString(input.repoUrl) } : {}),
+      ...(input.localRepoPath !== undefined ? { localRepoPath: normalizeRequiredString(input.localRepoPath) } : {}),
+      ...(input.defaultWorkflowPolicy !== undefined ? { defaultWorkflowPolicy: normalizeRequiredString(input.defaultWorkflowPolicy) } : {}),
+      ...(input.defaultPlanningSystem !== undefined ? { defaultPlanningSystem: input.defaultPlanningSystem } : {}),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    await this.dependencies.projectRepository.create(project);
+    return project;
+  }
+
+  async getProject(projectId: string): Promise<Project | null> {
+    return this.dependencies.projectRepository.getById(projectId);
+  }
+
+  async listProjects(): Promise<Project[]> {
+    await this.ensureDefaultProject();
+    return (await this.dependencies.projectRepository.list())
+      .sort((left, right) => compareValues(left.updatedAt, right.updatedAt, "desc"));
+  }
+
+  async updateProject(input: UpdateProjectInput): Promise<Project> {
+    const existing = await this.dependencies.projectRepository.getById(input.projectId);
+    if (!existing) {
+      throw new NotFoundError(`Project not found: ${input.projectId}`);
+    }
+
+    const next: Project = {
+      ...existing,
+      updatedAt: this.now(),
+    };
+
+    if (input.name !== undefined) {
+      next.name = normalizeRequiredString(input.name);
+    }
+
+    if (input.repoUrl !== undefined) {
+      if (input.repoUrl === null) {
+        delete next.repoUrl;
+      } else {
+        next.repoUrl = normalizeRequiredString(input.repoUrl);
+      }
+    }
+
+    if (input.localRepoPath !== undefined) {
+      if (input.localRepoPath === null) {
+        delete next.localRepoPath;
+      } else {
+        next.localRepoPath = normalizeRequiredString(input.localRepoPath);
+      }
+    }
+
+    if (input.defaultWorkflowPolicy !== undefined) {
+      if (input.defaultWorkflowPolicy === null) {
+        delete next.defaultWorkflowPolicy;
+      } else {
+        next.defaultWorkflowPolicy = normalizeRequiredString(input.defaultWorkflowPolicy);
+      }
+    }
+
+    if (input.defaultPlanningSystem !== undefined) {
+      if (input.defaultPlanningSystem === null) {
+        delete next.defaultPlanningSystem;
+      } else {
+        next.defaultPlanningSystem = input.defaultPlanningSystem;
+      }
+    }
+
+    await this.dependencies.projectRepository.update(next);
+    return next;
   }
 
   async createTrack(input: CreateTrackInput): Promise<Track> {


### PR DESCRIPTION
## Summary
- Add project repository list/update support and SpecRailService project create/list/get/update methods.
- Expose HTTP project APIs: `GET /projects`, `POST /projects`, `GET /projects/:projectId`, `PATCH /projects/:projectId`.
- Validate project payloads, preserve default project bootstrap on listing, and document the new API surface.

Closes #182

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (99 tests: 98 pass, 1 skipped)
- `pnpm build`
