### PR TITLE
feat: scope tracks by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Current endpoints in `apps/api/src/index.ts`:
 ### Tracks
 - `POST /tracks`
   - create a track
-  - body: `{ title, description, priority? }`
+  - body: `{ projectId?, title, description, priority? }`
+  - `projectId` defaults to the bootstrap project when omitted
 - `GET /tracks`
   - list tracks with pagination and explicit sorting
   - default sort: `sortBy=updatedAt&sortOrder=desc`
-  - query: `status?`, `priority?`, `page?=1`, `pageSize?=20`, `sortBy?=updatedAt|createdAt|title|priority|status`, `sortOrder?=asc|desc`
+  - query: `projectId?`, `status?`, `priority?`, `page?=1`, `pageSize?=20`, `sortBy?=updatedAt|createdAt|title|priority|status`, `sortOrder?=asc|desc`
   - response includes `meta: { page, pageSize, sortBy, sortOrder, total, totalPages, hasNextPage, hasPrevPage }`
 - `GET /tracks/:trackId`
   - return track metadata plus `spec`, `plan`, and `tasks` artifact contents

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -269,6 +269,73 @@ test("API validates project payloads and returns 404s for missing projects", asy
   });
 });
 
+test("API creates and filters tracks by project", async () => {
+  await withServer(async (baseUrl) => {
+    const createProjectResponse = await fetch(`${baseUrl}/projects`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Project-scoped tracks",
+        defaultPlanningSystem: "speckit",
+      }),
+    });
+    assert.equal(createProjectResponse.status, 201);
+    const createProjectPayload = (await createProjectResponse.json()) as { project: { id: string } };
+
+    const defaultTrackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Default project track",
+        description: "Keeps old clients on the bootstrap project.",
+      }),
+    });
+    assert.equal(defaultTrackResponse.status, 201);
+    const defaultTrackPayload = (await defaultTrackResponse.json()) as {
+      track: { id: string; projectId: string; planningSystem: string };
+    };
+    assert.equal(defaultTrackPayload.track.projectId, "project-default");
+    assert.equal(defaultTrackPayload.track.planningSystem, "native");
+
+    const scopedTrackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        projectId: createProjectPayload.project.id,
+        title: "Scoped project track",
+        description: "Uses the requested project metadata.",
+      }),
+    });
+    assert.equal(scopedTrackResponse.status, 201);
+    const scopedTrackPayload = (await scopedTrackResponse.json()) as {
+      track: { id: string; projectId: string; planningSystem: string };
+    };
+    assert.equal(scopedTrackPayload.track.projectId, createProjectPayload.project.id);
+    assert.equal(scopedTrackPayload.track.planningSystem, "speckit");
+
+    const filteredTracksResponse = await fetch(`${baseUrl}/tracks?projectId=${createProjectPayload.project.id}`);
+    assert.equal(filteredTracksResponse.status, 200);
+    const filteredTracksPayload = (await filteredTracksResponse.json()) as { tracks: Array<{ id: string; projectId: string }> };
+    assert.deepEqual(filteredTracksPayload.tracks.map((track) => track.id), [scopedTrackPayload.track.id]);
+
+    const missingProjectTrackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        projectId: "project-missing",
+        title: "Missing project track",
+        description: "This should fail before artifact creation.",
+      }),
+    });
+    assert.equal(missingProjectTrackResponse.status, 404);
+    const missingProjectTrackPayload = (await missingProjectTrackResponse.json()) as { error: { message: string } };
+    assert.equal(missingProjectTrackPayload.error.message, "Project not found: project-missing");
+
+    const emptyProjectFilterResponse = await fetch(`${baseUrl}/tracks?projectId=`);
+    assert.equal(emptyProjectFilterResponse.status, 422);
+  });
+});
+
 test("API supports creating tracks, planning sessions, messages, starting runs, and listing run events", async () => {
   await withServer(async (baseUrl, paths) => {
     const trackResponse = await fetch(`${baseUrl}/tracks`, {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -61,6 +61,7 @@ interface ApiDeps {
 }
 
 interface TrackRequestBody {
+  projectId?: string;
   title: string;
   description: string;
   priority?: "low" | "medium" | "high";
@@ -156,6 +157,7 @@ interface RegisterAttachmentRequestBody {
 }
 
 interface TrackListQuery {
+  projectId?: string;
   status?: TrackStatus;
   priority?: TrackRequestBody["priority"];
   page?: number;
@@ -487,6 +489,10 @@ function assertValidTrackCreateBody(body: TrackRequestBody): void {
 
   if (body.priority !== undefined && !["low", "medium", "high"].includes(body.priority)) {
     details.push({ field: "priority", message: "must be one of low, medium, high" });
+  }
+
+  if (body.projectId !== undefined && !body.projectId.trim()) {
+    details.push({ field: "projectId", message: "must not be empty" });
   }
 
   if (details.length > 0) {
@@ -825,6 +831,10 @@ function assertValidTrackListQuery(query: TrackListQuery): void {
     details.push({ field: "priority", message: "must be one of low, medium, high" });
   }
 
+  if (query.projectId !== undefined && !query.projectId.trim()) {
+    details.push({ field: "projectId", message: "must not be empty" });
+  }
+
   if (query.page !== undefined && (!Number.isInteger(query.page) || query.page < 1)) {
     details.push({ field: "page", message: "must be an integer greater than or equal to 1" });
   }
@@ -1071,6 +1081,7 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
       if (method === "GET" && segments.length === 1 && segments[0] === "tracks") {
         const searchParams = getSearchParams(request);
         const query: TrackListQuery = {
+          projectId: searchParams.get("projectId") ?? undefined,
           status: (searchParams.get("status") ?? undefined) as TrackStatus | undefined,
           priority: (searchParams.get("priority") ?? undefined) as TrackRequestBody["priority"] | undefined,
           page: parsePositiveInteger(searchParams.get("page")),

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -80,8 +80,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ### Milestone D — Project management APIs
 - project create/list/get/update endpoints expose basic project metadata beyond the bootstrap default
-- next: define how tracks are scoped and filtered by project
-- next: add deeper service tests for multi-project behavior once track scoping is introduced
+- track create/list APIs accept project scope while preserving default-project behavior for existing clients
+- next: propagate project selection into thin clients and hosted UI entrypoints
 
 ### Milestone E — Hosted operator UI / GitHub entrypoints
 - introduce a web UI or GitHub-facing entrypoint after the core state contracts stabilize
@@ -90,7 +90,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Scope tracks by project in list/create APIs**
-   - let clients target non-default projects and filter tracks per project.
+1. **Add project selection to thin clients**
+   - let Telegram/terminal/ACP flows opt into non-default project contexts.
 2. **Plan the first hosted operator UI slice**
    - build on the stabilized HTTP/SSE API rather than adding new core behavior.

--- a/packages/core/src/services/__tests__/specrail-service.test.ts
+++ b/packages/core/src/services/__tests__/specrail-service.test.ts
@@ -1274,7 +1274,7 @@ test("SpecRailService lists tracks and runs with basic filters", async () => {
       return () => values.shift() ?? "2026-04-09T05:15:00.000Z";
     })(),
     idGenerator: (() => {
-      const values = ["track-one", "track-two", "run-one", "run-two"];
+      const values = ["track-one", "track-two", "project-extra", "track-extra", "run-one", "run-two"];
       return () => values.shift() ?? "extra";
     })(),
   });
@@ -1289,6 +1289,15 @@ test("SpecRailService lists tracks and runs with basic filters", async () => {
     description: "Track two",
     priority: "low",
   });
+  const extraProject = await service.createProject({ name: "Extra project", defaultPlanningSystem: "openspec" });
+  const projectTrack = await service.createTrack({
+    projectId: extraProject.id,
+    title: "Project-specific track",
+    description: "Track scoped to an explicit project",
+  });
+
+  assert.equal(projectTrack.projectId, extraProject.id);
+  assert.equal(projectTrack.planningSystem, "openspec");
 
   await service.updateTrack({ trackId: trackOne.id, status: "review" });
 
@@ -1308,11 +1317,15 @@ test("SpecRailService lists tracks and runs with basic filters", async () => {
   const tracks = await service.listTracks();
   assert.deepEqual(
     tracks.map((track) => track.id),
-    [trackTwo.id, trackOne.id],
+    [trackTwo.id, trackOne.id, projectTrack.id],
   );
   assert.deepEqual(
     (await service.listTracks({ priority: "low" })).map((track) => track.id),
     [trackTwo.id],
+  );
+  assert.deepEqual(
+    (await service.listTracks({ projectId: extraProject.id })).map((track) => track.id),
+    [projectTrack.id],
   );
   assert.deepEqual(
     (await service.listTracks({ status: "review" })).map((track) => track.id),

--- a/packages/core/src/services/specrail-service.ts
+++ b/packages/core/src/services/specrail-service.ts
@@ -147,6 +147,7 @@ export interface UpdateProjectInput {
 }
 
 export interface CreateTrackInput {
+  projectId?: string;
   title: string;
   description: string;
   priority?: Track["priority"];
@@ -247,6 +248,7 @@ export interface RegisterAttachmentReferenceInput {
 export type SortOrder = "asc" | "desc";
 
 export interface ListTracksInput {
+  projectId?: string;
   status?: TrackStatus;
   priority?: Track["priority"];
   page?: number;
@@ -519,7 +521,11 @@ export class SpecRailService {
   }
 
   async createTrack(input: CreateTrackInput): Promise<Track> {
-    const project = await this.ensureDefaultProject();
+    const project = input.projectId === undefined ? await this.ensureDefaultProject() : await this.dependencies.projectRepository.getById(input.projectId);
+    if (!project) {
+      throw new NotFoundError(`Project not found: ${input.projectId}`);
+    }
+
     const timestamp = this.now();
     const track: Track = {
       id: `track-${this.idGenerator()}`,
@@ -564,6 +570,7 @@ export class SpecRailService {
     const sortOrder = input.sortOrder ?? "desc";
 
     const sorted = tracks
+      .filter((track) => (input.projectId ? track.projectId === input.projectId : true))
       .filter((track) => (input.status ? track.status === input.status : true))
       .filter((track) => (input.priority ? track.priority === input.priority : true))
       .sort((left, right) => {


### PR DESCRIPTION
## Summary
- Add optional `projectId` support for track creation while preserving bootstrap default behavior.
- Add `projectId` filtering to track listing APIs and service queries.
- Validate missing/empty project scope and document the multi-project track contract.

Closes #184

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (100 tests: 99 pass, 1 skipped)
- `pnpm build`
