### PR TITLE
feat: add terminal project scope selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,14 +300,15 @@ pnpm dev:terminal
 ```
 
 Current shell behavior:
-- loads recent tracks and runs from the API
+- loads projects, recent tracks, and recent runs from the API
 - renders navigable track and run list views with selected detail panes
+- cycles track list project scope with `P` while preserving all-project behavior by default
 - filters runs between all, active, and terminal states
 - auto-selects the current track/run and refreshes detail snapshots from the API
 - tails live selected-run events over SSE with cached recent activity and reconnect attempts when the stream drops
 - allows pausing and resuming the live tail without losing the selected run context
 - shows richer run status context including event counts, last event, planning-context staleness, and failure focus where available
-- supports `1-4` to switch screens, `j/k` or arrow keys to move selection, `f` to cycle run filters, `Space` to pause/resume the tail, `r` to refresh, `q` to quit
+- supports `1-4` to switch screens, `j/k` or arrow keys to move selection, `P` to cycle project scope, `f` to cycle run filters, `Space` to pause/resume the tail, `r` to refresh, `q` to quit
 - supports `s` on tracks to compose a new run, `e` on runs to resume a completed/failed/cancelled run, and `c` on runs to cancel an active run
 - exposes backend/profile choices in the terminal action composer, with validation feedback surfaced directly in the shell status and composer note
 - surfaces loading, streaming, and refresh failures in the status line and detail panes

--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -22,8 +22,13 @@ test("SpecRailTerminalApiClient loads a summary snapshot", async () => {
   const client = new SpecRailTerminalApiClient("http://example.test", async (input) => {
     const url = String(input);
 
+    if (url.endsWith("/projects")) {
+      return new Response(JSON.stringify({ projects: [{ id: "project-1", name: "SpecRail" }] }), { status: 200 });
+    }
+
     if (url.includes("/tracks?page=")) {
-      return new Response(JSON.stringify({ tracks: [{ id: "track-1", title: "Terminal shell", status: "ready" }] }), { status: 200 });
+      assert.ok(url.includes("projectId=project-1"));
+      return new Response(JSON.stringify({ tracks: [{ id: "track-1", projectId: "project-1", title: "Terminal shell", status: "ready" }] }), { status: 200 });
     }
 
     if (url.includes("/runs?page=")) {
@@ -35,7 +40,8 @@ test("SpecRailTerminalApiClient loads a summary snapshot", async () => {
     throw new Error(`Unexpected request: ${url}`);
   });
 
-  const summary = await client.loadSummary();
+  const summary = await client.loadSummary("project-1");
+  assert.equal(summary.projects?.[0]?.id, "project-1");
   assert.equal(summary.tracks[0]?.id, "track-1");
   assert.equal(summary.runs[0]?.id, "run-1");
 });
@@ -389,7 +395,7 @@ test("renderAppShell renders track list and selected detail preview", () => {
 
   assert.match(rendered, /SpecRail Terminal/);
   assert.match(rendered, /\[TRACKS\]/);
-  assert.match(rendered, /> track-1 \| ready \| high \| Terminal shell/);
+  assert.match(rendered, /> track-1 \| project\? \| ready \| high \| Terminal shell/);
   assert.match(rendered, /planning session: plan-1/);
   assert.match(rendered, /pending planning changes: yes/);
   assert.match(rendered, /execution context signal: new approvals needed before new runs/);
@@ -401,7 +407,7 @@ test("renderAppShell renders track list and selected detail preview", () => {
   assert.match(rendered, /press a to approve or x to reject selected pending request/);
   assert.match(rendered, /execution actions: press s to start a run for this track/);
   assert.match(rendered, /spec preview: # Spec Terminal shell/);
-  assert.match(rendered, /Keys: 1 home, 2 tracks, 3 runs, 4 settings, j\/k or ↑\/↓ select, h\/l artifact, \[\/\] revision, v propose, f run filter, Space tail pause\/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit/);
+  assert.match(rendered, /Keys: 1 home, 2 tracks, 3 runs, 4 settings, j\/k or ↑\/↓ select, P project scope, h\/l artifact, \[\/\] revision, v propose, f run filter, Space tail pause\/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit/);
 });
 
 test("renderAppShell renders run event monitor details", () => {
@@ -764,8 +770,13 @@ test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh th
     requests.push(`${request.method ?? "GET"} ${request.url ?? "/"}`);
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
+    if (request.method === "GET" && url.pathname === "/projects") {
+      sendJson(response, { projects: [{ id: "project-default", name: "SpecRail" }] });
+      return;
+    }
+
     if (request.method === "GET" && url.pathname === "/tracks") {
-      sendJson(response, { tracks: [{ id: "track-cleanup-a", title: "Cleanup track", status: "ready" }] });
+      sendJson(response, { tracks: [{ id: "track-cleanup-a", projectId: "project-default", title: "Cleanup track", status: "ready" }] });
       return;
     }
 

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -16,6 +16,7 @@ const EXECUTION_PROFILE_OPTIONS: Record<string, string[]> = {
 
 export interface TrackListItem {
   id: string;
+  projectId?: string;
   title: string;
   description?: string;
   status?: string;
@@ -24,6 +25,13 @@ export interface TrackListItem {
   planStatus?: string;
   updatedAt?: string;
   createdAt?: string;
+}
+
+export interface ProjectListItem {
+  id: string;
+  name: string;
+  defaultPlanningSystem?: string;
+  updatedAt?: string;
 }
 
 export interface RunListItem {
@@ -172,6 +180,7 @@ export interface RunDetailSnapshot {
 }
 
 export interface TerminalSummarySnapshot {
+  projects?: ProjectListItem[];
   tracks: TrackListItem[];
   runs: RunListItem[];
   fetchedAt: string;
@@ -237,6 +246,7 @@ export interface TerminalAppState {
   screen: TerminalScreenId;
   statusLine: string;
   summary: TerminalSummarySnapshot | null;
+  selectedProjectId?: string | null;
   apiBaseUrl: string;
   refreshIntervalMs: number;
   loading: boolean;
@@ -253,6 +263,10 @@ export interface TerminalAppState {
 
 interface TracksResponse {
   tracks: TrackListItem[];
+}
+
+interface ProjectsResponse {
+  projects: ProjectListItem[];
 }
 
 interface RunsResponse {
@@ -352,13 +366,16 @@ export class SpecRailTerminalApiClient {
     return fallback;
   }
 
-  async loadSummary(): Promise<TerminalSummarySnapshot> {
-    const [tracksPayload, runsPayload] = await Promise.all([
-      this.request<TracksResponse>("/tracks?page=1&pageSize=20"),
+  async loadSummary(projectId?: string | null): Promise<TerminalSummarySnapshot> {
+    const projectQuery = projectId ? `&projectId=${encodeURIComponent(projectId)}` : "";
+    const [projectsPayload, tracksPayload, runsPayload] = await Promise.all([
+      this.request<ProjectsResponse>("/projects"),
+      this.request<TracksResponse>(`/tracks?page=1&pageSize=20${projectQuery}`),
       this.request<RunsResponse>("/runs?page=1&pageSize=20"),
     ]);
 
     return {
+      projects: projectsPayload.projects,
       tracks: tracksPayload.tracks,
       runs: runsPayload.runs,
       fetchedAt: new Date().toISOString(),
@@ -569,6 +586,7 @@ export function createEmptyTerminalState(config: SpecRailTerminalClientConfig): 
     screen: config.initialScreen,
     statusLine: "Loading terminal snapshot...",
     summary: null,
+    selectedProjectId: null,
     apiBaseUrl: config.apiBaseUrl,
     refreshIntervalMs: config.refreshIntervalMs,
     loading: true,
@@ -640,7 +658,7 @@ export async function bootstrapTerminalState(
   config: SpecRailTerminalClientConfig,
   client: Pick<SpecRailTerminalApiClient, "loadSummary" | "loadTrackDetail" | "loadRunDetail">,
 ): Promise<TerminalAppState> {
-  const summary = await client.loadSummary();
+  const summary = await client.loadSummary(null);
   const tracks = await populateTrackPanel(createEmptyDetailState<TrackDetailSnapshot>(), summary, client);
   const runs = await populateRunPanel(createEmptyDetailState<RunDetailSnapshot>(), summary, client, "all");
 
@@ -648,6 +666,7 @@ export async function bootstrapTerminalState(
     screen: config.initialScreen,
     statusLine: `Loaded ${summary.tracks.length} tracks and ${summary.runs.length} runs.`,
     summary,
+    selectedProjectId: null,
     apiBaseUrl: config.apiBaseUrl,
     refreshIntervalMs: config.refreshIntervalMs,
     loading: false,
@@ -666,7 +685,7 @@ export async function refreshTerminalState(
   state: TerminalAppState,
   client: Pick<SpecRailTerminalApiClient, "loadSummary" | "loadTrackDetail" | "loadRunDetail">,
 ): Promise<TerminalAppState> {
-  const summary = await client.loadSummary();
+  const summary = await client.loadSummary(state.selectedProjectId);
   const tracks = await populateTrackPanel(state.tracks, summary, client);
   const runs = await populateRunPanel(state.runs, summary, client, state.runFilter);
 
@@ -843,6 +862,23 @@ export function setRunFilter(state: TerminalAppState, filter: RunFilterMode): Te
   });
 }
 
+async function cycleProjectScope(
+  state: TerminalAppState,
+  client: Pick<SpecRailTerminalApiClient, "loadSummary" | "loadTrackDetail" | "loadRunDetail">,
+): Promise<TerminalAppState> {
+  const projects = state.summary?.projects ?? [];
+  const projectIds = [null, ...projects.map((project) => project.id)] as Array<string | null>;
+  const currentIndex = Math.max(0, projectIds.findIndex((projectId) => projectId === state.selectedProjectId));
+  const selectedProjectId = projectIds[(currentIndex + 1) % projectIds.length] ?? null;
+
+  return refreshTerminalState({
+    ...state,
+    selectedProjectId,
+    tracks: createEmptyDetailState<TrackDetailSnapshot>(),
+    statusLine: selectedProjectId ? `Filtering tracks to project ${selectedProjectId}...` : "Showing tracks from all projects...",
+  }, client);
+}
+
 export function renderAppShell(state: TerminalAppState): string {
   const tabs: TerminalScreenId[] = ["home", "tracks", "runs", "settings"];
   const nav = tabs.map((tab) => (tab === state.screen ? `[${tab.toUpperCase()}]` : tab)).join("  ");
@@ -857,7 +893,7 @@ export function renderAppShell(state: TerminalAppState): string {
     ...body,
     "",
     `Status: ${state.statusLine}`,
-    `Keys: 1 home, 2 tracks, 3 runs, 4 settings, j/k or ↑/↓ select, h/l artifact, [/] revision, v propose, f run filter, Space tail pause/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit | Refresh ${state.refreshIntervalMs}ms`,
+    `Keys: 1 home, 2 tracks, 3 runs, 4 settings, j/k or ↑/↓ select, P project scope, h/l artifact, [/] revision, v propose, f run filter, Space tail pause/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit | Refresh ${state.refreshIntervalMs}ms`,
     ...renderExecutionActionComposer(state.pendingExecutionAction),
     ...renderProposalActionComposer(state.pendingProposalAction),
     ...renderWorkspaceCleanupComposer(state.pendingWorkspaceCleanupAction ?? null),
@@ -966,6 +1002,7 @@ function renderScreenBody(state: TerminalAppState): string[] {
         `- API base URL: ${state.apiBaseUrl}`,
         `- Refresh interval: ${state.refreshIntervalMs}ms`,
         "- Navigation: use j/k or arrow keys to move through track/run selections.",
+        "- Press P to cycle project scope for track listings.",
         "- Tracks view surfaces planning sessions, revision history, and pending approvals.",
         "- Press a/x on the tracks screen to approve or reject the next pending request.",
         "- Press s on tracks to start a run, e on runs to resume, c on runs to cancel.",
@@ -977,6 +1014,8 @@ function renderScreenBody(state: TerminalAppState): string[] {
     default:
       return [
         "Overview",
+        `- Project scope: ${formatProjectScope(state)}`,
+        `- Projects loaded: ${state.summary.projects?.length ?? 0}`,
         `- Tracks loaded: ${state.summary.tracks.length}`,
         `- Runs loaded: ${state.summary.runs.length}`,
         `- Last fetch: ${state.summary.fetchedAt}`,
@@ -993,9 +1032,9 @@ function renderScreenBody(state: TerminalAppState): string[] {
 function renderTracksScreen(state: TerminalAppState): string[] {
   const selectedTrack = state.summary?.tracks[state.tracks.selectedIndex] ?? null;
   return [
-    `Tracks (${state.summary?.tracks.length ?? 0})`,
+    `Tracks (${state.summary?.tracks.length ?? 0}, project=${formatProjectScope(state)})`,
     ...renderSelectableList(
-      state.summary?.tracks.map((track) => `${track.id} | ${track.status ?? "unknown"} | ${track.priority ?? "medium"} | ${track.title}`) ?? [],
+      state.summary?.tracks.map((track) => `${track.id} | ${track.projectId ?? "project?"} | ${track.status ?? "unknown"} | ${track.priority ?? "medium"} | ${track.title}`) ?? [],
       state.tracks.selectedIndex,
       "No tracks yet.",
     ),
@@ -1003,6 +1042,15 @@ function renderTracksScreen(state: TerminalAppState): string[] {
     "Track detail",
     ...renderTrackDetail(selectedTrack?.id === state.tracks.data?.track.id ? state.tracks.data : null, state.tracks, selectedTrack?.id ?? null),
   ];
+}
+
+function formatProjectScope(state: TerminalAppState): string {
+  if (!state.selectedProjectId) {
+    return "all projects";
+  }
+
+  const project = state.summary?.projects?.find((item) => item.id === state.selectedProjectId);
+  return project ? `${project.name} (${project.id})` : state.selectedProjectId;
 }
 
 function renderRunsScreen(state: TerminalAppState): string[] {
@@ -2146,6 +2194,17 @@ export async function runTerminalApp(
 
       if (key.name === "f") {
         updateState(setRunFilter(state, cycleRunFilterMode(state.runFilter)));
+        return;
+      }
+
+      if (input === "P") {
+        void cycleProjectScope(state, client)
+          .then(updateState)
+          .catch((error) => updateState({
+            ...state,
+            error: error instanceof Error ? error.message : "Failed to cycle project scope.",
+            statusLine: error instanceof Error ? error.message : "Failed to cycle project scope.",
+          }));
         return;
       }
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -81,7 +81,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 ### Milestone D — Project management APIs
 - project create/list/get/update endpoints expose basic project metadata beyond the bootstrap default
 - track create/list APIs accept project scope while preserving default-project behavior for existing clients
-- next: propagate project selection into thin clients and hosted UI entrypoints
+- terminal client can load projects and cycle project-scoped track listings while preserving all-project behavior by default
+- next: propagate project selection into Telegram/ACP flows and hosted UI entrypoints
 
 ### Milestone E — Hosted operator UI / GitHub entrypoints
 - introduce a web UI or GitHub-facing entrypoint after the core state contracts stabilize
@@ -90,7 +91,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Add project selection to thin clients**
-   - let Telegram/terminal/ACP flows opt into non-default project contexts.
+1. **Propagate project selection into Telegram and ACP flows**
+   - let non-terminal thin clients opt into non-default project contexts.
 2. **Plan the first hosted operator UI slice**
    - build on the stabilized HTTP/SSE API rather than adding new core behavior.


### PR DESCRIPTION
## Summary
- load project metadata in the terminal summary snapshot
- add `P` project-scope cycling for terminal track listings while keeping all-project behavior as the default
- update terminal tests and docs for project-scoped track browsing

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (100 tests: 99 pass, 1 skipped)
- `pnpm build`

Closes #186
