### PR TITLE
feat: propagate project selection to thin clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ SpecRail remembers what the AI did, whether it succeeded or failed, and lets you
 ## ACP edge adapter status
 
 `apps/acp-server` now projects SpecRail runs into richer ACP session updates:
+- `_meta.specrail.trackId` can target an existing track, while `_meta.specrail.projectId` lets the first prompt create a new track in a non-default project
 - task status changes refresh ACP `session_info_update` metadata
 - runtime `approval_requested` events emit ACP `session/request_permission`
 - client permission decisions can round-trip back through `session/prompt` via `_meta.specrail.permissionResolution`
@@ -333,7 +334,7 @@ By default this smoke path stays out of `pnpm test` so local and CI runs do not 
 For GitHub Actions, use the opt-in stub at `.github/workflows/claude-smoke.yml` together with `scripts/run-claude-smoke-ci.sh`.
 That workflow is intentionally gated behind repository variable `SPECRAIL_ENABLE_CLAUDE_SMOKE=1` so the default CI path stays stable when Claude credentials are unavailable on runners.
 
-For the Telegram frontend, set `SPECRAIL_API_BASE_URL`, `TELEGRAM_BOT_TOKEN`, and optionally `TELEGRAM_APP_PORT` / `TELEGRAM_WEBHOOK_PATH` before `pnpm dev:telegram`.
+For the Telegram frontend, set `SPECRAIL_API_BASE_URL`, `TELEGRAM_BOT_TOKEN`, and optionally `TELEGRAM_APP_PORT` / `TELEGRAM_WEBHOOK_PATH` before `pnpm dev:telegram`. Set `SPECRAIL_TELEGRAM_PROJECT_ID` (or shared `SPECRAIL_PROJECT_ID`) to create new Telegram-bound tracks in a non-default project; omit it to keep the default-project behavior.
 
 For the API server, you can set `SPECRAIL_EXECUTION_BACKEND` and `SPECRAIL_EXECUTION_PROFILE` to choose the default executor/backend and profile used when callers omit them.
 Set `SPECRAIL_EXECUTION_WORKSPACE_MODE=directory` for the default plain workspace directory behavior, or `SPECRAIL_EXECUTION_WORKSPACE_MODE=git_worktree` to allocate execution workspaces with `git worktree add -b specrail/<runId> workspaces/<runId>` from the configured local repo path.

--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -22,6 +22,7 @@ function createFakeService() {
     updatedAt: "2026-04-13T00:00:00.000Z",
   };
 
+  const tracks = new Map<string, Track>([[track.id, track]]);
   const runs = new Map<string, Execution>();
   const events = new Map<string, ExecutionEvent[]>();
   let runCounter = 1;
@@ -37,8 +38,24 @@ function createFakeService() {
   };
 
   const service = {
+    async createTrack(input: { title: string; description: string; priority?: "low" | "medium" | "high"; projectId?: string }) {
+      const created: Track = {
+        id: `track-${tracks.size + 1}`,
+        projectId: input.projectId ?? "project-default",
+        title: input.title,
+        description: input.description,
+        status: "planned",
+        specStatus: "pending",
+        planStatus: "pending",
+        priority: input.priority ?? "medium",
+        createdAt: "2026-04-13T00:00:00.000Z",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+      };
+      tracks.set(created.id, created);
+      return created;
+    },
     async getTrack(trackId: string) {
-      return trackId === track.id ? track : null;
+      return tracks.get(trackId) ?? null;
     },
     async startRun(input: { trackId: string; prompt: string; backend?: string; profile?: string; planningSessionId?: string }) {
       const runId = `run-${runCounter++}`;
@@ -191,6 +208,7 @@ function createFakeService() {
     },
   } satisfies Pick<
     SpecRailService,
+    | "createTrack"
     | "getTrack"
     | "startRun"
     | "resumeRun"
@@ -285,6 +303,62 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   );
   assert.equal(loadResponse?.error, undefined);
   assert.ok(loadNotifications.some((payload) => JSON.stringify(payload).includes("Started run-1")));
+});
+
+test("ACP server creates a project-scoped track when session/new omits trackId", async () => {
+  const stateDir = await mkdtemp(path.join(os.tmpdir(), "specrail-acp-state-"));
+  const server = new SpecRailAcpServer({
+    service: createFakeService() as unknown as SpecRailService,
+    stateDir,
+    now: () => "2026-04-13T12:00:00.000Z",
+    pollIntervalMs: 1,
+  });
+
+  const newResponse = await server.handleMessage(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "session/new",
+      params: {
+        cwd: "/tmp/specrail",
+        _meta: {
+          specrail: {
+            projectId: "project-non-default",
+            title: "Non-default ACP work",
+            backend: "codex",
+          },
+        },
+      },
+    },
+    () => {},
+  );
+
+  assert.equal(newResponse?.error, undefined);
+  const sessionId = (newResponse?.result as { sessionId: string }).sessionId;
+  const notifications: unknown[] = [];
+  const promptResponse = await server.handleMessage(
+    {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "session/prompt",
+      params: {
+        sessionId,
+        prompt: [{ type: "text", text: "Create a track in a non-default project" }],
+      },
+    },
+    (payload) => notifications.push(payload),
+  );
+
+  assert.deepEqual(promptResponse?.result, { stopReason: "end_turn" });
+  assert.ok(JSON.stringify(notifications).includes('"projectId":"project-non-default"'));
+  assert.ok(JSON.stringify(notifications).includes('"trackId":"track-2"'));
+
+  const listResponse = await server.handleMessage(
+    { jsonrpc: "2.0", id: 3, method: "session/list", params: { cwd: "/tmp/specrail" } },
+    () => {},
+  );
+  assert.ok(JSON.stringify(listResponse?.result).includes('"projectId":"project-non-default"'));
+  assert.ok(JSON.stringify(listResponse?.result).includes('"trackId":"track-2"'));
 });
 
 test("ACP server emits richer permission request and resolution updates", async () => {

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -29,7 +29,8 @@ interface JsonRpcResponse {
 interface AcpSessionRecord {
   sessionId: string;
   cwd: string;
-  trackId: string;
+  projectId?: string;
+  trackId?: string;
   planningSessionId?: string;
   backend?: string;
   profile?: string;
@@ -56,6 +57,7 @@ interface SessionNewParams {
   mcpServers?: unknown[];
   _meta?: {
     specrail?: {
+      projectId?: string;
       trackId?: string;
       planningSessionId?: string;
       backend?: string;
@@ -186,12 +188,13 @@ export class SpecRailAcpServer {
     const body = (params ?? {}) as SessionNewParams;
     const cwd = this.requireAbsolutePath(body.cwd, "cwd");
     const specrail = body._meta?.specrail;
-    const trackId = this.requireNonEmptyString(specrail?.trackId, "_meta.specrail.trackId");
+    const trackId = this.optionalString(specrail?.trackId);
     const sessionId = `specrail-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     const createdAt = this.now();
     const session: AcpSessionRecord = {
       sessionId,
       cwd,
+      projectId: this.optionalString(specrail?.projectId),
       trackId,
       planningSessionId: this.optionalString(specrail?.planningSessionId),
       backend: this.optionalString(specrail?.backend),
@@ -241,6 +244,7 @@ export class SpecRailAcpServer {
         updatedAt: session.updatedAt,
         _meta: {
           specrail: {
+            projectId: session.projectId,
             trackId: session.trackId,
             planningSessionId: session.planningSessionId,
             backend: session.backend,
@@ -281,8 +285,14 @@ export class SpecRailAcpServer {
         execution = await this.options.service.resumeRun({ runId: session.runId, prompt, profile: session.profile, backend: session.backend });
         startingEventCount = (await this.options.service.listRunEvents(execution.id)).length;
       } else {
+        const trackId = session.trackId ?? (await this.options.service.createTrack({
+          title: session.title ?? this.deriveTrackTitle(prompt),
+          description: prompt,
+          priority: "medium",
+          projectId: session.projectId,
+        })).id;
         execution = await this.options.service.startRun({
-          trackId: session.trackId,
+          trackId,
           prompt,
           backend: session.backend,
           profile: session.profile,
@@ -295,6 +305,8 @@ export class SpecRailAcpServer {
       let updatedSession: AcpSessionRecord = {
         ...session,
         title,
+        projectId: track?.projectId ?? session.projectId,
+        trackId: execution.trackId,
         runId: execution.id,
         status: execution.status,
         updatedAt: this.now(),
@@ -389,6 +401,7 @@ export class SpecRailAcpServer {
           _meta: {
             specrail: {
               runId: execution.id,
+              projectId: session.projectId,
               trackId: execution.trackId,
               backend: execution.backend,
               profile: execution.profile,
@@ -460,7 +473,7 @@ export class SpecRailAcpServer {
       notifications.push(
         this.toSessionInfoUpdate(session, {
           id: session.runId ?? event.executionId,
-          trackId: session.trackId,
+          trackId: session.trackId ?? "",
           backend: session.backend ?? event.source,
           profile: session.profile ?? "default",
           workspacePath: "",
@@ -544,6 +557,11 @@ export class SpecRailAcpServer {
       })
       .filter(Boolean)
       .join("\n\n");
+  }
+
+  private deriveTrackTitle(prompt: string): string {
+    const line = prompt.split(/\r?\n/u).find((candidate) => candidate.trim().length > 0)?.trim() ?? "ACP request";
+    return line.length > 80 ? `${line.slice(0, 77)}...` : line;
   }
 
   private requireAbsolutePath(value: unknown, field: string): string {

--- a/apps/telegram/src/__tests__/telegram-app.test.ts
+++ b/apps/telegram/src/__tests__/telegram-app.test.ts
@@ -44,12 +44,12 @@ test("handleTelegramUpdate creates a track, binds the chat, registers attachment
           return null;
         },
         async createTrack(input) {
-          calls.push(`createTrack:${input.title}`);
+          calls.push(`createTrack:${input.title}:${input.projectId}`);
           assert.equal(input.description, "Build Telegram frontend\nNeed thin adapter app");
-          return { track: { id: "track-1", title: input.title } };
+          return { track: { id: "track-1", projectId: "project-non-default", title: input.title } };
         },
         async bindChannel(input) {
-          calls.push(`bindChannel:${input.trackId}`);
+          calls.push(`bindChannel:${input.trackId}:${input.projectId}`);
           assert.equal(input.externalThreadId, "7");
           return { binding: { id: "binding-1", trackId: "track-1" } };
         },
@@ -72,13 +72,14 @@ test("handleTelegramUpdate creates a track, binds the chat, registers attachment
           telegramMessages.push(`${input.messageThreadId}:${input.text}`);
         },
       },
+      projectId: "project-non-default",
     },
   );
 
   assert.deepEqual(calls, [
     "findChannelBinding",
-    "createTrack:Build Telegram frontend",
-    "bindChannel:track-1",
+    "createTrack:Build Telegram frontend:project-non-default",
+    "bindChannel:track-1:project-non-default",
     "registerAttachment:file-1:track-1",
     "startRun:track-1",
   ]);

--- a/apps/telegram/src/index.ts
+++ b/apps/telegram/src/index.ts
@@ -6,6 +6,7 @@ export interface TelegramAppConfig {
   telegramBotToken: string;
   port: number;
   webhookPath: string;
+  projectId?: string;
 }
 
 export interface TelegramUser {
@@ -45,7 +46,7 @@ export interface TelegramUpdate {
 }
 
 interface TrackResponse {
-  track: { id: string; title: string };
+  track: { id: string; title: string; projectId?: string };
 }
 
 interface RunResponse {
@@ -66,6 +67,7 @@ export function loadTelegramAppConfig(env: NodeJS.ProcessEnv = process.env): Tel
     telegramBotToken: env.TELEGRAM_BOT_TOKEN ?? "",
     port: Number(env.TELEGRAM_APP_PORT ?? 4100),
     webhookPath: env.TELEGRAM_WEBHOOK_PATH ?? "/telegram/webhook",
+    projectId: env.SPECRAIL_TELEGRAM_PROJECT_ID ?? env.SPECRAIL_PROJECT_ID,
   };
 }
 
@@ -185,7 +187,7 @@ export class SpecRailApiClient {
       .then((payload) => payload?.binding ?? null);
   }
 
-  createTrack(input: { title: string; description: string; priority?: "low" | "medium" | "high" }) {
+  createTrack(input: { title: string; description: string; priority?: "low" | "medium" | "high"; projectId?: string }) {
     return this.request<TrackResponse>("/tracks", { method: "POST", body: JSON.stringify(input) });
   }
 
@@ -315,6 +317,7 @@ export interface TelegramFrontendDeps {
     "findChannelBinding" | "createTrack" | "bindChannel" | "registerAttachment" | "startRun" | "streamRunEvents"
   >;
   telegram: Pick<TelegramBotClient, "sendMessage">;
+  projectId?: string;
 }
 
 export async function handleTelegramUpdate(update: TelegramUpdate, deps: TelegramFrontendDeps): Promise<void> {
@@ -331,15 +334,18 @@ export async function handleTelegramUpdate(update: TelegramUpdate, deps: Telegra
     externalThreadId: refs.threadId,
   });
 
+  const projectId = deps.projectId;
+
   if (!binding?.trackId) {
     const track = await deps.specRail.createTrack({
       title: deriveTrackTitle(prompt),
       description: prompt,
       priority: "medium",
+      projectId,
     });
 
     const bound = await deps.specRail.bindChannel({
-      projectId: "project-default",
+      projectId: track.track.projectId ?? projectId ?? "project-default",
       channelType: "telegram",
       externalChatId: refs.chatId,
       externalThreadId: refs.threadId,
@@ -432,7 +438,7 @@ export function createTelegramWebhookServer(config: TelegramAppConfig, deps: Tel
 export function createDefaultTelegramServer(config: TelegramAppConfig = loadTelegramAppConfig()): http.Server {
   const specRail = new SpecRailApiClient(config.apiBaseUrl);
   const telegram = new TelegramBotClient(config.telegramBotToken);
-  return createTelegramWebhookServer(config, { specRail, telegram });
+  return createTelegramWebhookServer(config, { specRail, telegram, projectId: config.projectId });
 }
 
 const isMainModule = process.argv[1] ? pathToFileURL(process.argv[1]).href === import.meta.url : false;

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -82,7 +82,8 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - project create/list/get/update endpoints expose basic project metadata beyond the bootstrap default
 - track create/list APIs accept project scope while preserving default-project behavior for existing clients
 - terminal client can load projects and cycle project-scoped track listings while preserving all-project behavior by default
-- next: propagate project selection into Telegram/ACP flows and hosted UI entrypoints
+- Telegram and ACP entrypoints can opt into explicit project context while preserving default behavior when omitted
+- next: propagate project selection into hosted UI entrypoints
 
 ### Milestone E — Hosted operator UI / GitHub entrypoints
 - introduce a web UI or GitHub-facing entrypoint after the core state contracts stabilize
@@ -91,7 +92,5 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Propagate project selection into Telegram and ACP flows**
-   - let non-terminal thin clients opt into non-default project contexts.
-2. **Plan the first hosted operator UI slice**
+1. **Plan the first hosted operator UI slice**
    - build on the stabilized HTTP/SSE API rather than adding new core behavior.


### PR DESCRIPTION
## Summary
- let Telegram track creation opt into an explicit project via `SPECRAIL_TELEGRAM_PROJECT_ID` / `SPECRAIL_PROJECT_ID`
- let ACP `session/new` carry `_meta.specrail.projectId` and create a project-scoped track on the first prompt when no `trackId` is supplied
- update thin-client tests and docs for explicit project context while preserving default behavior when omitted

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (101 tests: 100 pass, 1 skipped)
- `pnpm build`

Closes #188
