### PR TITLE
feat: stream hosted operator run events

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
   - selecting a track can approve/reject pending artifact approval requests through the existing `POST /approval-requests/:approvalRequestId/(approve|reject)` endpoints
   - selecting a run shows run metadata and recent event summaries from `GET /runs/:runId` plus `GET /runs/:runId/events`
+  - selected runs stay live with incremental updates from `GET /runs/:runId/events/stream` while selected
   - selected runs can request workspace cleanup preview/apply through the existing guarded confirmation flow
 
 ### Projects

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -191,6 +191,9 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
     assert.match(body, /Recent events/);
+    assert.match(body, /EventSource/);
+    assert.match(body, /events\/stream/);
+    assert.match(body, /Live event stream disconnected/);
     assert.match(body, /Workspace cleanup/);
     assert.match(body, /data-cleanup-apply/);
     assert.match(body, /loadTrackDetail/);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -435,6 +435,7 @@ function renderOperatorUiHtml(): string {
     const runs = document.querySelector('#runs');
     const detail = document.querySelector('#detail');
     const refresh = document.querySelector('#refresh');
+    let activeEventStream = null;
 
     async function api(path, init) {
       const response = await fetch(path, { headers: { accept: 'application/json', 'content-type': 'application/json' }, ...init });
@@ -487,7 +488,15 @@ function renderOperatorUiHtml(): string {
       return '<h3>Approval actions</h3><ul>' + pending.map((request) => '<li><strong>' + escapeHtml(request.artifact) + ' approval</strong><br><span class="muted">' + escapeHtml(request.id) + '</span><br><button data-approval-id="' + escapeHtml(request.id) + '" data-decision="approve">Approve</button> <button data-approval-id="' + escapeHtml(request.id) + '" data-decision="reject">Reject</button></li>').join('') + '</ul>';
     }
 
+    function closeEventStream() {
+      if (activeEventStream) {
+        activeEventStream.close();
+        activeEventStream = null;
+      }
+    }
+
     function renderTrackDetail(payload, artifactPayloads) {
+      closeEventStream();
       const track = payload.track;
       const planning = payload.planningContext ?? {};
       detail.className = 'detail-grid';
@@ -519,6 +528,32 @@ function renderOperatorUiHtml(): string {
       });
     }
 
+    function appendRunEvent(event) {
+      const list = detail.querySelector('#run-events');
+      if (!list) return;
+      list.append(item(event.type, (event.summary ?? '') + ' · ' + (event.timestamp ?? ''), () => {}));
+      while (list.children.length > 20) {
+        list.firstElementChild?.remove();
+      }
+    }
+
+    function startRunEventStream(runId) {
+      closeEventStream();
+      if (typeof EventSource === 'undefined') {
+        status.textContent = 'Live event stream unavailable in this browser.';
+        return;
+      }
+      activeEventStream = new EventSource('/runs/' + encodeURIComponent(runId) + '/events/stream');
+      activeEventStream.addEventListener('execution-event', (message) => {
+        appendRunEvent(JSON.parse(message.data));
+        status.textContent = 'Live event received for ' + runId + '.';
+      });
+      activeEventStream.onerror = () => {
+        status.textContent = 'Live event stream disconnected for ' + runId + '; recent events remain visible.';
+        closeEventStream();
+      };
+    }
+
     function renderRunDetail(runPayload, eventsPayload, cleanupPayload) {
       const run = runPayload.run;
       const events = eventsPayload.events ?? [];
@@ -545,12 +580,13 @@ function renderOperatorUiHtml(): string {
           ['Finished', run.finishedAt],
         ])
         + cleanupSection
-        + '<h3>Recent events</h3><ul>' + events.slice(-10).map((event) => '<li><span class="pill">' + escapeHtml(event.type) + '</span> ' + escapeHtml(event.summary) + '<br><span class="muted">' + escapeHtml(event.timestamp) + '</span></li>').join('') + '</ul>';
+        + '<h3>Recent events</h3><p class="muted">Live updates use <code>GET /runs/:runId/events/stream</code> while this run is selected.</p><ul id="run-events">' + events.slice(-10).map((event) => '<li><span class="pill">' + escapeHtml(event.type) + '</span> ' + escapeHtml(event.summary) + '<br><span class="muted">' + escapeHtml(event.timestamp) + '</span></li>').join('') + '</ul>';
       detail.querySelector('[data-cleanup-preview]')?.addEventListener('click', async () => {
         status.textContent = 'Loading cleanup preview for ' + run.id + '…';
         await loadRunDetail(run.id, true);
         status.textContent = 'Cleanup preview refreshed for ' + run.id + '.';
       });
+      startRunEventStream(run.id);
       detail.querySelector('[data-cleanup-apply]')?.addEventListener('click', async () => {
         status.textContent = 'Requesting cleanup confirmation for ' + run.id + '…';
         const confirmationPayload = await postJson('/runs/' + encodeURIComponent(run.id) + '/workspace-cleanup/apply', { confirm: '' });
@@ -590,6 +626,7 @@ function renderOperatorUiHtml(): string {
     }
 
     async function load() {
+      closeEventStream();
       status.textContent = 'Loading…';
       const projectId = scope.value;
       const query = projectId ? '&projectId=' + encodeURIComponent(projectId) : '';

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -92,11 +92,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
 - hosted UI selected-track detail can approve/reject pending artifact requests through existing approval endpoints
 - hosted UI selected-run detail shows run metadata and recent events from existing run/event APIs
+- hosted UI selected-run detail appends live SSE event updates while a run is selected
 - hosted UI selected-run detail can request cleanup preview/apply through the existing explicit confirmation flow
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Add hosted operator UI streaming event updates**
-   - replace manual detail refresh for selected runs with SSE-backed incremental event updates.
+1. **Harden hosted operator UI state and error handling**
+   - split the inline UI into testable client helpers and improve action/loading edge cases.


### PR DESCRIPTION
## Summary
- stream selected hosted UI run events from `GET /runs/:runId/events/stream`
- close and replace event streams when switching selections or refreshing the summary
- document live hosted run event updates and update the roadmap next step

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (102 tests: 101 pass, 1 skipped)
- `pnpm build`

Closes #196
