### PR TITLE
feat: add hosted operator run controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Current endpoints in `apps/api/src/index.ts`:
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
   - selecting a track can approve/reject pending artifact approval requests through the existing `POST /approval-requests/:approvalRequestId/(approve|reject)` endpoints
   - selecting a run shows run metadata and recent event summaries from `GET /runs/:runId` plus `GET /runs/:runId/events`
+  - selected tracks can start runs through the existing `POST /runs` endpoint
+  - selected runs can resume or cancel through the existing `POST /runs/:runId/resume` and `POST /runs/:runId/cancel` endpoints
   - selected runs stay live with incremental updates from `GET /runs/:runId/events/stream` while selected
   - selected runs can request workspace cleanup preview/apply through the existing guarded confirmation flow
 

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -190,6 +190,9 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Spec preview/);
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
+    assert.match(body, /data-run-start/);
+    assert.match(body, /data-run-resume/);
+    assert.match(body, /data-run-cancel/);
     assert.match(body, /Recent events/);
     assert.match(body, /EventSource/);
     assert.match(body, /events\/stream/);
@@ -203,6 +206,9 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /\/workspace-cleanup\/preview/);
     assert.match(body, /\/workspace-cleanup\/apply/);
     assert.match(body, /\/approval-requests\//);
+    assert.match(body, /\/runs/);
+    assert.match(body, /\/resume/);
+    assert.match(body, /\/cancel/);
     assert.match(body, /projectId=/);
   });
 });

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -8,7 +8,10 @@ import {
   operatorUiEscapeHtml,
   operatorUiMetadataHtml,
   operatorUiPreviewHtml,
+  operatorUiRunCancelPath,
+  operatorUiRunCreatePath,
   operatorUiRunEventStreamPath,
+  operatorUiRunResumePath,
   renderOperatorUiHtml,
 } from "../operator-ui.js";
 
@@ -21,6 +24,9 @@ test("operator UI helpers escape metadata and previews", () => {
 
 test("operator UI helpers build encoded action URLs", () => {
   assert.equal(operatorUiApprovalDecisionPath("approval/request 1", "approve"), "/approval-requests/approval%2Frequest%201/approve");
+  assert.equal(operatorUiRunCreatePath(), "/runs");
+  assert.equal(operatorUiRunResumePath("run/1"), "/runs/run%2F1/resume");
+  assert.equal(operatorUiRunCancelPath("run/1"), "/runs/run%2F1/cancel");
   assert.equal(operatorUiCleanupPreviewPath("run/1"), "/runs/run%2F1/workspace-cleanup/preview");
   assert.equal(operatorUiCleanupApplyPath("run/1"), "/runs/run%2F1/workspace-cleanup/apply");
   assert.equal(operatorUiRunEventStreamPath("run/1"), "/runs/run%2F1/events/stream");
@@ -31,6 +37,9 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
 
   assert.match(body, /SpecRail Operator/);
   assert.match(body, /data-approval-id/);
+  assert.match(body, /data-run-start/);
+  assert.match(body, /data-run-resume/);
+  assert.match(body, /data-run-cancel/);
   assert.match(body, /workspace-cleanup\/preview/);
   assert.match(body, /workspace-cleanup\/apply/);
   assert.match(body, /new EventSource/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -29,6 +29,18 @@ export function operatorUiApprovalDecisionPath(approvalRequestId: string, decisi
   return `/approval-requests/${encodeURIComponent(approvalRequestId)}/${decision}`;
 }
 
+export function operatorUiRunCreatePath(): string {
+  return "/runs";
+}
+
+export function operatorUiRunResumePath(runId: string): string {
+  return `/runs/${encodeURIComponent(runId)}/resume`;
+}
+
+export function operatorUiRunCancelPath(runId: string): string {
+  return `/runs/${encodeURIComponent(runId)}/cancel`;
+}
+
 export function operatorUiCleanupPreviewPath(runId: string): string {
   return `/runs/${encodeURIComponent(runId)}/workspace-cleanup/preview`;
 }
@@ -175,10 +187,30 @@ export function renderOperatorUiHtml(): string {
           ['Pending planning changes', planning.hasPendingChanges ? 'yes' : 'no'],
           ['Updated', track.updatedAt],
         ])
+        + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
         + artifactApprovalActions(artifactPayloads)
         + preview('Spec preview', payload.artifacts?.spec)
         + preview('Plan preview', payload.artifacts?.plan)
         + preview('Tasks preview', payload.artifacts?.tasks);
+      detail.querySelector('[data-run-start]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const promptText = window.prompt('Prompt for the new run on ' + track.id, 'Implement the selected track.');
+        if (!promptText) {
+          status.textContent = 'Run start cancelled for ' + track.id + '.';
+          return;
+        }
+        button.disabled = true;
+        try {
+          status.textContent = 'Starting run for ' + track.id + '…';
+          const runPayload = await postJson('/runs', { trackId: track.id, prompt: promptText });
+          await load();
+          await loadRunDetail(runPayload.run.id);
+          status.textContent = 'Started run ' + runPayload.run.id + ' for ' + track.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
       detail.querySelectorAll('[data-approval-id]').forEach((button) => {
         button.addEventListener('click', async () => {
           const approvalId = button.getAttribute('data-approval-id');
@@ -248,8 +280,47 @@ export function renderOperatorUiHtml(): string {
           ['Started', run.startedAt],
           ['Finished', run.finishedAt],
         ])
+        + '<h3>Run lifecycle</h3><button data-run-resume="' + escapeHtml(run.id) + '">Resume run</button> <button data-run-cancel="' + escapeHtml(run.id) + '">Cancel run</button>'
         + cleanupSection
         + '<h3>Recent events</h3><p class="muted">Live updates use <code>GET /runs/:runId/events/stream</code> while this run is selected.</p><ul id="run-events">' + events.slice(-10).map((event) => '<li><span class="pill">' + escapeHtml(event.type) + '</span> ' + escapeHtml(event.summary) + '<br><span class="muted">' + escapeHtml(event.timestamp) + '</span></li>').join('') + '</ul>';
+      detail.querySelector('[data-run-resume]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const promptText = window.prompt('Resume prompt for ' + run.id, 'Continue with verification.');
+        if (!promptText) {
+          status.textContent = 'Run resume cancelled for ' + run.id + '.';
+          return;
+        }
+        button.disabled = true;
+        try {
+          status.textContent = 'Resuming run ' + run.id + '…';
+          await postJson('/runs/' + encodeURIComponent(run.id) + '/resume', { prompt: promptText });
+          await load();
+          await loadRunDetail(run.id);
+          status.textContent = 'Resumed run ' + run.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
+      detail.querySelector('[data-run-cancel]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const accepted = window.confirm('Cancel run ' + run.id + '?');
+        if (!accepted) {
+          status.textContent = 'Run cancel skipped for ' + run.id + '.';
+          return;
+        }
+        button.disabled = true;
+        try {
+          status.textContent = 'Cancelling run ' + run.id + '…';
+          await postJson('/runs/' + encodeURIComponent(run.id) + '/cancel', {});
+          await load();
+          await loadRunDetail(run.id);
+          status.textContent = 'Cancelled run ' + run.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
       detail.querySelector('[data-cleanup-preview]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
         button.disabled = true;

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -91,7 +91,9 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI project selection filters tracks via the same `GET /tracks?projectId=...` contract used by thin clients
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
 - hosted UI selected-track detail can approve/reject pending artifact requests through existing approval endpoints
+- hosted UI selected-track detail can start runs through the existing run creation API
 - hosted UI selected-run detail shows run metadata and recent events from existing run/event APIs
+- hosted UI selected-run detail can resume/cancel runs through existing lifecycle APIs
 - hosted UI selected-run detail appends live SSE event updates while a run is selected
 - hosted UI selected-run detail can request cleanup preview/apply through the existing explicit confirmation flow
 - keep HTTP/SSE as the system of record for new clients


### PR DESCRIPTION
## Summary
- add hosted UI start-run control for selected tracks using `POST /runs`
- add hosted UI resume/cancel controls for selected runs using existing lifecycle endpoints
- refresh summaries/details after lifecycle actions and disable action buttons while requests are in flight
- document hosted lifecycle controls

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (105 tests: 104 pass, 1 skipped)
- `pnpm build`

Closes #200
