### PR TITLE
feat: add hosted artifact proposal controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - loads projects, tracks, and runs from the same HTTP API
   - project selection filters tracks via `GET /tracks?projectId=...`
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
+  - selected tracks can propose spec/plan/tasks revisions through the existing `POST /tracks/:trackId/artifacts/:artifact` endpoint
   - selecting a track can approve/reject pending artifact approval requests through the existing `POST /approval-requests/:approvalRequestId/(approve|reject)` endpoints
   - selecting a run shows run metadata and recent event summaries from `GET /runs/:runId` plus `GET /runs/:runId/events`
   - selected tracks can start runs through the existing `POST /runs` endpoint

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -190,6 +190,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Spec preview/);
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
+    assert.match(body, /data-artifact-proposal/);
+    assert.match(body, /Propose tasks/);
     assert.match(body, /data-run-start/);
     assert.match(body, /data-run-resume/);
     assert.match(body, /data-run-cancel/);
@@ -206,6 +208,7 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /\/workspace-cleanup\/preview/);
     assert.match(body, /\/workspace-cleanup\/apply/);
     assert.match(body, /\/approval-requests\//);
+    assert.match(body, /\/tracks\/.*\/artifacts\//);
     assert.match(body, /\/runs/);
     assert.match(body, /\/resume/);
     assert.match(body, /\/cancel/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   operatorUiApprovalDecisionPath,
+  operatorUiArtifactProposalPath,
   operatorUiCleanupApplyPath,
   operatorUiCleanupPreviewPath,
   operatorUiEscapeHtml,
@@ -24,6 +25,7 @@ test("operator UI helpers escape metadata and previews", () => {
 
 test("operator UI helpers build encoded action URLs", () => {
   assert.equal(operatorUiApprovalDecisionPath("approval/request 1", "approve"), "/approval-requests/approval%2Frequest%201/approve");
+  assert.equal(operatorUiArtifactProposalPath("track/1", "spec"), "/tracks/track%2F1/artifacts/spec");
   assert.equal(operatorUiRunCreatePath(), "/runs");
   assert.equal(operatorUiRunResumePath("run/1"), "/runs/run%2F1/resume");
   assert.equal(operatorUiRunCancelPath("run/1"), "/runs/run%2F1/cancel");
@@ -37,6 +39,9 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
 
   assert.match(body, /SpecRail Operator/);
   assert.match(body, /data-approval-id/);
+  assert.match(body, /data-artifact-proposal/);
+  assert.match(body, /Propose spec/);
+  assert.match(body, /createdBy: 'user'/);
   assert.match(body, /data-run-start/);
   assert.match(body, /data-run-resume/);
   assert.match(body, /data-run-cancel/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -29,6 +29,10 @@ export function operatorUiApprovalDecisionPath(approvalRequestId: string, decisi
   return `/approval-requests/${encodeURIComponent(approvalRequestId)}/${decision}`;
 }
 
+export function operatorUiArtifactProposalPath(trackId: string, artifact: "spec" | "plan" | "tasks"): string {
+  return `/tracks/${encodeURIComponent(trackId)}/artifacts/${artifact}`;
+}
+
 export function operatorUiRunCreatePath(): string {
   return "/runs";
 }
@@ -187,11 +191,33 @@ export function renderOperatorUiHtml(): string {
           ['Pending planning changes', planning.hasPendingChanges ? 'yes' : 'no'],
           ['Updated', track.updatedAt],
         ])
+        + '<h3>Artifact proposals</h3><button data-artifact-proposal="spec">Propose spec</button> <button data-artifact-proposal="plan">Propose plan</button> <button data-artifact-proposal="tasks">Propose tasks</button>'
         + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
         + artifactApprovalActions(artifactPayloads)
         + preview('Spec preview', payload.artifacts?.spec)
         + preview('Plan preview', payload.artifacts?.plan)
         + preview('Tasks preview', payload.artifacts?.tasks);
+      detail.querySelectorAll('[data-artifact-proposal]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const artifact = button.getAttribute('data-artifact-proposal');
+          const content = window.prompt('New ' + artifact + ' content for ' + track.id, payload.artifacts?.[artifact] ?? '');
+          if (!content) {
+            status.textContent = 'Artifact proposal cancelled for ' + artifact + '.';
+            return;
+          }
+          const summaryText = window.prompt('Proposal summary for ' + artifact, 'Proposed from hosted operator UI') ?? undefined;
+          button.disabled = true;
+          try {
+            status.textContent = 'Proposing ' + artifact + ' revision for ' + track.id + '…';
+            await postJson('/tracks/' + encodeURIComponent(track.id) + '/artifacts/' + artifact, { content, summary: summaryText, createdBy: 'user' });
+            await loadTrackDetail(track.id);
+            status.textContent = 'Proposed ' + artifact + ' revision for ' + track.id + '.';
+          } catch (error) {
+            button.disabled = false;
+            status.textContent = error instanceof Error ? error.message : String(error);
+          }
+        });
+      });
       detail.querySelector('[data-run-start]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
         const promptText = window.prompt('Prompt for the new run on ' + track.id, 'Implement the selected track.');

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -90,6 +90,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI loads project, track, and run summary state from the existing HTTP API
 - hosted UI project selection filters tracks via the same `GET /tracks?projectId=...` contract used by thin clients
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
+- hosted UI selected-track detail can propose spec/plan/tasks revisions through existing artifact proposal APIs
 - hosted UI selected-track detail can approve/reject pending artifact requests through existing approval endpoints
 - hosted UI selected-track detail can start runs through the existing run creation API
 - hosted UI selected-run detail shows run metadata and recent events from existing run/event APIs


### PR DESCRIPTION
## Summary
- add hosted UI proposal controls for spec, plan, and tasks revisions on selected tracks
- submit proposals through existing `POST /tracks/:trackId/artifacts/:artifact` endpoints with `createdBy: "user"`
- refresh track detail after proposals so pending approval requests become visible
- document hosted artifact proposal controls

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (105 tests: 104 pass, 1 skipped)
- `pnpm build`

Closes #202
