### PR TITLE
feat: add hosted project controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Current endpoints in `apps/api/src/index.ts`:
 - `GET /operator`
   - serves the first thin hosted operator UI slice from `apps/api/src/operator-ui.ts`
   - loads projects, tracks, and runs from the same HTTP API
+  - can create/update projects through the existing project APIs
   - project selection filters tracks via `GET /tracks?projectId=...`
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
   - selected tracks can propose spec/plan/tasks revisions through the existing `POST /tracks/:trackId/artifacts/:artifact` endpoint

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -187,6 +187,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(response.headers.get("content-type") ?? "", /text\/html/);
     assert.match(body, /SpecRail Operator/);
     assert.match(body, /Project scope/);
+    assert.match(body, /Create project/);
+    assert.match(body, /Update selected project/);
     assert.match(body, /Spec preview/);
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
@@ -203,6 +205,7 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /data-cleanup-apply/);
     assert.match(body, /loadTrackDetail/);
     assert.match(body, /loadRunDetail/);
+    assert.match(body, /\/projects/);
     assert.match(body, /\/tracks\?page=1&pageSize=20/);
     assert.match(body, /\/runs\/.*\/events/);
     assert.match(body, /\/workspace-cleanup\/preview/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -9,6 +9,8 @@ import {
   operatorUiEscapeHtml,
   operatorUiMetadataHtml,
   operatorUiPreviewHtml,
+  operatorUiProjectCreatePath,
+  operatorUiProjectUpdatePath,
   operatorUiRunCancelPath,
   operatorUiRunCreatePath,
   operatorUiRunEventStreamPath,
@@ -24,6 +26,8 @@ test("operator UI helpers escape metadata and previews", () => {
 });
 
 test("operator UI helpers build encoded action URLs", () => {
+  assert.equal(operatorUiProjectCreatePath(), "/projects");
+  assert.equal(operatorUiProjectUpdatePath("project/1"), "/projects/project%2F1");
   assert.equal(operatorUiApprovalDecisionPath("approval/request 1", "approve"), "/approval-requests/approval%2Frequest%201/approve");
   assert.equal(operatorUiArtifactProposalPath("track/1", "spec"), "/tracks/track%2F1/artifacts/spec");
   assert.equal(operatorUiRunCreatePath(), "/runs");
@@ -38,6 +42,11 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   const body = renderOperatorUiHtml();
 
   assert.match(body, /SpecRail Operator/);
+  assert.match(body, /id="project-create"/);
+  assert.match(body, /id="project-update"/);
+  assert.match(body, /method: 'PATCH'/);
+  assert.match(body, /defaultWorkflowPolicy/);
+  assert.match(body, /defaultPlanningSystem/);
   assert.match(body, /data-approval-id/);
   assert.match(body, /data-artifact-proposal/);
   assert.match(body, /Propose spec/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -25,6 +25,14 @@ export function operatorUiPreviewHtml(label: string, value: unknown): string {
   return `<h3>${operatorUiEscapeHtml(label)}</h3><div class="artifact-preview">${operatorUiEscapeHtml(String(value).slice(0, 2_000))}</div>`;
 }
 
+export function operatorUiProjectCreatePath(): string {
+  return "/projects";
+}
+
+export function operatorUiProjectUpdatePath(projectId: string): string {
+  return `/projects/${encodeURIComponent(projectId)}`;
+}
+
 export function operatorUiApprovalDecisionPath(approvalRequestId: string, decision: "approve" | "reject"): string {
   return `/approval-requests/${encodeURIComponent(approvalRequestId)}/${decision}`;
 }
@@ -99,6 +107,7 @@ export function renderOperatorUiHtml(): string {
       <label>Project scope
         <select id="project-scope"><option value="">All projects</option></select>
       </label>
+      <p><button id="project-create">Create project</button> <button id="project-update">Update selected project</button></p>
       <p id="status" class="muted">Loading…</p>
     </section>
     <div class="grid">
@@ -114,7 +123,10 @@ export function renderOperatorUiHtml(): string {
     const runs = document.querySelector('#runs');
     const detail = document.querySelector('#detail');
     const refresh = document.querySelector('#refresh');
+    const projectCreate = document.querySelector('#project-create');
+    const projectUpdate = document.querySelector('#project-update');
     let activeEventStream = null;
+    let projectsById = new Map();
 
     async function api(path, init) {
       const response = await fetch(path, { headers: { accept: 'application/json', 'content-type': 'application/json' }, ...init });
@@ -124,6 +136,10 @@ export function renderOperatorUiHtml(): string {
 
     function postJson(path, body) {
       return api(path, { method: 'POST', body: JSON.stringify(body ?? {}) });
+    }
+
+    function patchJson(path, body) {
+      return api(path, { method: 'PATCH', body: JSON.stringify(body ?? {}) });
     }
 
     function item(label, meta, onClick) {
@@ -418,6 +434,7 @@ export function renderOperatorUiHtml(): string {
       ]);
 
       const selectedProject = scope.value;
+      projectsById = new Map(projectPayload.projects.map((project) => [project.id, project]));
       scope.replaceChildren(new Option('All projects', ''), ...projectPayload.projects.map((project) => new Option(project.name + ' (' + project.id + ')', project.id)));
       scope.value = selectedProject;
 
@@ -433,6 +450,65 @@ export function renderOperatorUiHtml(): string {
       )));
       status.textContent = 'Loaded ' + projectPayload.projects.length + ' projects, ' + trackPayload.tracks.length + ' tracks, and ' + runPayload.runs.length + ' runs.';
     }
+
+    projectCreate.addEventListener('click', async () => {
+      const name = window.prompt('New project name');
+      if (!name) {
+        status.textContent = 'Project creation cancelled.';
+        return;
+      }
+      projectCreate.disabled = true;
+      try {
+        status.textContent = 'Creating project ' + name + '…';
+        const payload = await postJson('/projects', { name });
+        scope.value = payload.project.id;
+        await load();
+        projectCreate.disabled = false;
+        status.textContent = 'Created project ' + payload.project.id + '.';
+      } catch (error) {
+        projectCreate.disabled = false;
+        status.textContent = error instanceof Error ? error.message : String(error);
+      }
+    });
+
+    projectUpdate.addEventListener('click', async () => {
+      const projectId = scope.value;
+      if (!projectId) {
+        status.textContent = 'Select a project before updating it.';
+        return;
+      }
+      const currentProject = projectsById.get(projectId) ?? {};
+      const currentLabel = scope.selectedOptions[0]?.textContent ?? projectId;
+      const currentName = currentProject.name ?? currentLabel.replace(/ \([^)]*\)$/, '');
+      const name = window.prompt('Updated project name for ' + projectId, currentName);
+      if (!name) {
+        status.textContent = 'Project update cancelled for ' + projectId + '.';
+        return;
+      }
+      const repoUrlInput = window.prompt('Repository URL for ' + projectId + ' (blank clears)', currentProject.repoUrl ?? '');
+      const localRepoPathInput = window.prompt('Local repository path for ' + projectId + ' (blank clears)', currentProject.localRepoPath ?? '');
+      const workflowPolicyInput = window.prompt('Default workflow policy for ' + projectId + ' (blank clears)', currentProject.defaultWorkflowPolicy ?? '');
+      const planningSystemInput = window.prompt('Default planning system for ' + projectId + ' (blank clears)', currentProject.defaultPlanningSystem ?? '');
+      const optionalText = (value) => value === null ? undefined : value.trim() === '' ? null : value.trim();
+      projectUpdate.disabled = true;
+      try {
+        status.textContent = 'Updating project ' + projectId + '…';
+        const payload = await patchJson('/projects/' + encodeURIComponent(projectId), {
+          name,
+          repoUrl: optionalText(repoUrlInput),
+          localRepoPath: optionalText(localRepoPathInput),
+          defaultWorkflowPolicy: optionalText(workflowPolicyInput),
+          defaultPlanningSystem: optionalText(planningSystemInput),
+        });
+        scope.value = payload.project.id;
+        await load();
+        projectUpdate.disabled = false;
+        status.textContent = 'Updated project ' + payload.project.id + '.';
+      } catch (error) {
+        projectUpdate.disabled = false;
+        status.textContent = error instanceof Error ? error.message : String(error);
+      }
+    });
 
     scope.addEventListener('change', load);
     refresh.addEventListener('click', load);

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -88,6 +88,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 ### Milestone E — Hosted operator UI / GitHub entrypoints
 - first hosted operator UI slice is served from `GET /operator` with HTML/script helpers isolated in `apps/api/src/operator-ui.ts`
 - hosted UI loads project, track, and run summary state from the existing HTTP API
+- hosted UI can create/update projects through existing project APIs
 - hosted UI project selection filters tracks via the same `GET /tracks?projectId=...` contract used by thin clients
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
 - hosted UI selected-track detail can propose spec/plan/tasks revisions through existing artifact proposal APIs


### PR DESCRIPTION
## Summary
- add hosted UI project create and selected-project update controls
- wire create/update through existing `POST /projects` and `PATCH /projects/:projectId` API contracts
- preserve selected project scope and refresh project/track/run state after project changes
- document hosted project management controls

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (105 tests: 104 pass, 1 skipped)
- `pnpm build`

Closes #204
