### PR TITLE
feat: add hosted track controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - loads projects, tracks, and runs from the same HTTP API
   - can create/update projects through the existing project APIs
   - project selection filters tracks via `GET /tracks?projectId=...`
+  - can create tracks and update selected-track workflow/approval state through existing track APIs
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
   - selected tracks can propose spec/plan/tasks revisions through the existing `POST /tracks/:trackId/artifacts/:artifact` endpoint
   - selecting a track can approve/reject pending artifact approval requests through the existing `POST /approval-requests/:approvalRequestId/(approve|reject)` endpoints

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -189,6 +189,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Project scope/);
     assert.match(body, /Create project/);
     assert.match(body, /Update selected project/);
+    assert.match(body, /Create track/);
+    assert.match(body, /Update track workflow/);
     assert.match(body, /Spec preview/);
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
@@ -206,6 +208,7 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /loadTrackDetail/);
     assert.match(body, /loadRunDetail/);
     assert.match(body, /\/projects/);
+    assert.match(body, /\/tracks/);
     assert.match(body, /\/tracks\?page=1&pageSize=20/);
     assert.match(body, /\/runs\/.*\/events/);
     assert.match(body, /\/workspace-cleanup\/preview/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -15,6 +15,8 @@ import {
   operatorUiRunCreatePath,
   operatorUiRunEventStreamPath,
   operatorUiRunResumePath,
+  operatorUiTrackCreatePath,
+  operatorUiTrackUpdatePath,
   renderOperatorUiHtml,
 } from "../operator-ui.js";
 
@@ -28,6 +30,8 @@ test("operator UI helpers escape metadata and previews", () => {
 test("operator UI helpers build encoded action URLs", () => {
   assert.equal(operatorUiProjectCreatePath(), "/projects");
   assert.equal(operatorUiProjectUpdatePath("project/1"), "/projects/project%2F1");
+  assert.equal(operatorUiTrackCreatePath(), "/tracks");
+  assert.equal(operatorUiTrackUpdatePath("track/1"), "/tracks/track%2F1");
   assert.equal(operatorUiApprovalDecisionPath("approval/request 1", "approve"), "/approval-requests/approval%2Frequest%201/approve");
   assert.equal(operatorUiArtifactProposalPath("track/1", "spec"), "/tracks/track%2F1/artifacts/spec");
   assert.equal(operatorUiRunCreatePath(), "/runs");
@@ -44,6 +48,8 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /SpecRail Operator/);
   assert.match(body, /id="project-create"/);
   assert.match(body, /id="project-update"/);
+  assert.match(body, /id="track-create"/);
+  assert.match(body, /data-track-update/);
   assert.match(body, /method: 'PATCH'/);
   assert.match(body, /defaultWorkflowPolicy/);
   assert.match(body, /defaultPlanningSystem/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -33,6 +33,14 @@ export function operatorUiProjectUpdatePath(projectId: string): string {
   return `/projects/${encodeURIComponent(projectId)}`;
 }
 
+export function operatorUiTrackCreatePath(): string {
+  return "/tracks";
+}
+
+export function operatorUiTrackUpdatePath(trackId: string): string {
+  return `/tracks/${encodeURIComponent(trackId)}`;
+}
+
 export function operatorUiApprovalDecisionPath(approvalRequestId: string, decision: "approve" | "reject"): string {
   return `/approval-requests/${encodeURIComponent(approvalRequestId)}/${decision}`;
 }
@@ -107,7 +115,7 @@ export function renderOperatorUiHtml(): string {
       <label>Project scope
         <select id="project-scope"><option value="">All projects</option></select>
       </label>
-      <p><button id="project-create">Create project</button> <button id="project-update">Update selected project</button></p>
+      <p><button id="project-create">Create project</button> <button id="project-update">Update selected project</button> <button id="track-create">Create track</button></p>
       <p id="status" class="muted">Loading…</p>
     </section>
     <div class="grid">
@@ -125,6 +133,7 @@ export function renderOperatorUiHtml(): string {
     const refresh = document.querySelector('#refresh');
     const projectCreate = document.querySelector('#project-create');
     const projectUpdate = document.querySelector('#project-update');
+    const trackCreate = document.querySelector('#track-create');
     let activeEventStream = null;
     let projectsById = new Map();
 
@@ -207,12 +216,38 @@ export function renderOperatorUiHtml(): string {
           ['Pending planning changes', planning.hasPendingChanges ? 'yes' : 'no'],
           ['Updated', track.updatedAt],
         ])
+        + '<h3>Track workflow</h3><button data-track-update="workflow">Update track workflow</button>'
         + '<h3>Artifact proposals</h3><button data-artifact-proposal="spec">Propose spec</button> <button data-artifact-proposal="plan">Propose plan</button> <button data-artifact-proposal="tasks">Propose tasks</button>'
         + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
         + artifactApprovalActions(artifactPayloads)
         + preview('Spec preview', payload.artifacts?.spec)
         + preview('Plan preview', payload.artifacts?.plan)
         + preview('Tasks preview', payload.artifacts?.tasks);
+      detail.querySelector('[data-track-update]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const statusInput = window.prompt('Track status for ' + track.id + ' (new, planned, ready, in_progress, blocked, review, done, failed)', track.status ?? 'new');
+        if (!statusInput) {
+          status.textContent = 'Track update cancelled for ' + track.id + '.';
+          return;
+        }
+        const specStatusInput = window.prompt('Spec status for ' + track.id + ' (draft, pending, approved, rejected)', track.specStatus ?? 'draft');
+        const planStatusInput = window.prompt('Plan status for ' + track.id + ' (draft, pending, approved, rejected)', track.planStatus ?? 'draft');
+        button.disabled = true;
+        try {
+          status.textContent = 'Updating track ' + track.id + '…';
+          await patchJson('/tracks/' + encodeURIComponent(track.id), {
+            status: statusInput,
+            specStatus: specStatusInput || undefined,
+            planStatus: planStatusInput || undefined,
+          });
+          await load();
+          await loadTrackDetail(track.id);
+          status.textContent = 'Updated track ' + track.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
       detail.querySelectorAll('[data-artifact-proposal]').forEach((button) => {
         button.addEventListener('click', async () => {
           const artifact = button.getAttribute('data-artifact-proposal');
@@ -467,6 +502,29 @@ export function renderOperatorUiHtml(): string {
         status.textContent = 'Created project ' + payload.project.id + '.';
       } catch (error) {
         projectCreate.disabled = false;
+        status.textContent = error instanceof Error ? error.message : String(error);
+      }
+    });
+
+    trackCreate.addEventListener('click', async () => {
+      const title = window.prompt('New track title');
+      if (!title) {
+        status.textContent = 'Track creation cancelled.';
+        return;
+      }
+      const description = window.prompt('New track description', '') ?? '';
+      const priority = window.prompt('Track priority (low, medium, high)', 'medium') ?? 'medium';
+      const projectId = scope.value || undefined;
+      trackCreate.disabled = true;
+      try {
+        status.textContent = 'Creating track ' + title + '…';
+        const payload = await postJson('/tracks', { projectId, title, description, priority });
+        await load();
+        await loadTrackDetail(payload.track.id);
+        trackCreate.disabled = false;
+        status.textContent = 'Created track ' + payload.track.id + '.';
+      } catch (error) {
+        trackCreate.disabled = false;
         status.textContent = error instanceof Error ? error.message : String(error);
       }
     });

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -90,6 +90,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI loads project, track, and run summary state from the existing HTTP API
 - hosted UI can create/update projects through existing project APIs
 - hosted UI project selection filters tracks via the same `GET /tracks?projectId=...` contract used by thin clients
+- hosted UI can create tracks and update selected-track workflow/approval state through existing track APIs
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
 - hosted UI selected-track detail can propose spec/plan/tasks revisions through existing artifact proposal APIs
 - hosted UI selected-track detail can approve/reject pending artifact requests through existing approval endpoints


### PR DESCRIPTION
## Summary
- add hosted UI track creation that respects the selected project scope
- add selected-track workflow/approval status update controls through existing `PATCH /tracks/:trackId`
- refresh track list and selected track detail after track create/update actions
- document hosted track management controls

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (105 tests: 104 pass, 1 skipped)
- `pnpm build`

Closes #206
