### PR TITLE
feat: add hosted planning controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - can create/update projects through the existing project APIs
   - project selection filters tracks via `GET /tracks?projectId=...`
   - can create tracks and update selected-track workflow/approval state through existing track APIs
+  - can create planning sessions and append planning messages through existing planning APIs
   - selecting a track shows artifact/planning context previews from `GET /tracks/:trackId`
   - selected tracks can propose spec/plan/tasks revisions through the existing `POST /tracks/:trackId/artifacts/:artifact` endpoint
   - selecting a track can approve/reject pending artifact approval requests through the existing `POST /approval-requests/:approvalRequestId/(approve|reject)` endpoints

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -191,6 +191,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Update selected project/);
     assert.match(body, /Create track/);
     assert.match(body, /Update track workflow/);
+    assert.match(body, /Create planning session/);
+    assert.match(body, /Append planning message/);
     assert.match(body, /Spec preview/);
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
@@ -214,6 +216,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /\/workspace-cleanup\/preview/);
     assert.match(body, /\/workspace-cleanup\/apply/);
     assert.match(body, /\/approval-requests\//);
+    assert.match(body, /\/tracks\/.*\/planning-sessions/);
+    assert.match(body, /\/planning-sessions\/.*\/messages/);
     assert.match(body, /\/tracks\/.*\/artifacts\//);
     assert.match(body, /\/runs/);
     assert.match(body, /\/resume/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -8,6 +8,8 @@ import {
   operatorUiCleanupPreviewPath,
   operatorUiEscapeHtml,
   operatorUiMetadataHtml,
+  operatorUiPlanningMessageAppendPath,
+  operatorUiPlanningSessionCreatePath,
   operatorUiPreviewHtml,
   operatorUiProjectCreatePath,
   operatorUiProjectUpdatePath,
@@ -32,6 +34,8 @@ test("operator UI helpers build encoded action URLs", () => {
   assert.equal(operatorUiProjectUpdatePath("project/1"), "/projects/project%2F1");
   assert.equal(operatorUiTrackCreatePath(), "/tracks");
   assert.equal(operatorUiTrackUpdatePath("track/1"), "/tracks/track%2F1");
+  assert.equal(operatorUiPlanningSessionCreatePath("track/1"), "/tracks/track%2F1/planning-sessions");
+  assert.equal(operatorUiPlanningMessageAppendPath("planning/1"), "/planning-sessions/planning%2F1/messages");
   assert.equal(operatorUiApprovalDecisionPath("approval/request 1", "approve"), "/approval-requests/approval%2Frequest%201/approve");
   assert.equal(operatorUiArtifactProposalPath("track/1", "spec"), "/tracks/track%2F1/artifacts/spec");
   assert.equal(operatorUiRunCreatePath(), "/runs");
@@ -50,6 +54,8 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /id="project-update"/);
   assert.match(body, /id="track-create"/);
   assert.match(body, /data-track-update/);
+  assert.match(body, /data-planning-session-create/);
+  assert.match(body, /data-planning-message-append/);
   assert.match(body, /method: 'PATCH'/);
   assert.match(body, /defaultWorkflowPolicy/);
   assert.match(body, /defaultPlanningSystem/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -41,6 +41,14 @@ export function operatorUiTrackUpdatePath(trackId: string): string {
   return `/tracks/${encodeURIComponent(trackId)}`;
 }
 
+export function operatorUiPlanningSessionCreatePath(trackId: string): string {
+  return `/tracks/${encodeURIComponent(trackId)}/planning-sessions`;
+}
+
+export function operatorUiPlanningMessageAppendPath(planningSessionId: string): string {
+  return `/planning-sessions/${encodeURIComponent(planningSessionId)}/messages`;
+}
+
 export function operatorUiApprovalDecisionPath(approvalRequestId: string, decision: "approve" | "reject"): string {
   return `/approval-requests/${encodeURIComponent(approvalRequestId)}/${decision}`;
 }
@@ -217,6 +225,7 @@ export function renderOperatorUiHtml(): string {
           ['Updated', track.updatedAt],
         ])
         + '<h3>Track workflow</h3><button data-track-update="workflow">Update track workflow</button>'
+        + '<h3>Planning</h3><button data-planning-session-create="' + escapeHtml(track.id) + '">Create planning session</button> <button data-planning-message-append="' + escapeHtml(planning.planningSessionId ?? '') + '">Append planning message</button>'
         + '<h3>Artifact proposals</h3><button data-artifact-proposal="spec">Propose spec</button> <button data-artifact-proposal="plan">Propose plan</button> <button data-artifact-proposal="tasks">Propose tasks</button>'
         + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
         + artifactApprovalActions(artifactPayloads)
@@ -243,6 +252,46 @@ export function renderOperatorUiHtml(): string {
           await load();
           await loadTrackDetail(track.id);
           status.textContent = 'Updated track ' + track.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
+      detail.querySelector('[data-planning-session-create]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const planningStatus = window.prompt('Planning session status (active, waiting_user, waiting_agent, approved, archived)', 'active') ?? 'active';
+        button.disabled = true;
+        try {
+          status.textContent = 'Creating planning session for ' + track.id + '…';
+          await postJson('/tracks/' + encodeURIComponent(track.id) + '/planning-sessions', { status: planningStatus });
+          await loadTrackDetail(track.id);
+          status.textContent = 'Created planning session for ' + track.id + '.';
+        } catch (error) {
+          button.disabled = false;
+          status.textContent = error instanceof Error ? error.message : String(error);
+        }
+      });
+      detail.querySelector('[data-planning-message-append]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const planningSessionId = button.getAttribute('data-planning-message-append');
+        if (!planningSessionId) {
+          status.textContent = 'Create a planning session before appending a message for ' + track.id + '.';
+          return;
+        }
+        const body = window.prompt('Planning message body for ' + track.id);
+        if (!body) {
+          status.textContent = 'Planning message cancelled for ' + track.id + '.';
+          return;
+        }
+        const authorType = window.prompt('Planning message author (user, agent, system)', 'user') ?? 'user';
+        const kind = window.prompt('Planning message kind (message, question, decision, note)', 'message') ?? 'message';
+        const relatedArtifact = window.prompt('Related artifact (spec, plan, tasks; blank for none)', '') || undefined;
+        button.disabled = true;
+        try {
+          status.textContent = 'Appending planning message for ' + track.id + '…';
+          await postJson('/planning-sessions/' + encodeURIComponent(planningSessionId) + '/messages', { authorType, kind, body, relatedArtifact });
+          await loadTrackDetail(track.id);
+          status.textContent = 'Appended planning message for ' + track.id + '.';
         } catch (error) {
           button.disabled = false;
           status.textContent = error instanceof Error ? error.message : String(error);

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -91,6 +91,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI can create/update projects through existing project APIs
 - hosted UI project selection filters tracks via the same `GET /tracks?projectId=...` contract used by thin clients
 - hosted UI can create tracks and update selected-track workflow/approval state through existing track APIs
+- hosted UI can create planning sessions and append planning messages through existing planning APIs
 - hosted UI selected-track detail shows artifact/planning context previews from existing track detail APIs
 - hosted UI selected-track detail can propose spec/plan/tasks revisions through existing artifact proposal APIs
 - hosted UI selected-track detail can approve/reject pending artifact requests through existing approval endpoints


### PR DESCRIPTION
## Summary
- add hosted UI controls to create planning sessions for selected tracks
- add hosted UI controls to append planning messages to the current planning session
- refresh selected track planning context after planning actions
- document hosted planning controls

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (105 tests: 104 pass, 1 skipped)
- `pnpm build`

Closes #208
