### PR TITLE
refactor: split hosted UI renderer helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - selected runs stay live with incremental updates from `GET /runs/:runId/events/stream` while selected
   - selected runs can request workspace cleanup preview/apply through the existing guarded confirmation flow
   - shared action-state handling disables buttons while requests are in flight and preserves cleanup apply results if post-apply refresh fails
+  - HTML shell rendering composes separately testable hosted UI style and client script helpers while keeping `GET /operator` as a single served page
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -19,7 +19,9 @@ import {
   operatorUiRunResumePath,
   operatorUiTrackCreatePath,
   operatorUiTrackUpdatePath,
+  renderOperatorUiClientScript,
   renderOperatorUiHtml,
+  renderOperatorUiStyleCss,
 } from "../operator-ui.js";
 
 test("operator UI helpers escape metadata and previews", () => {
@@ -46,10 +48,23 @@ test("operator UI helpers build encoded action URLs", () => {
   assert.equal(operatorUiRunEventStreamPath("run/1"), "/runs/run%2F1/events/stream");
 });
 
+test("operator UI renderer exposes style and client script helpers", () => {
+  const style = renderOperatorUiStyleCss();
+  const script = renderOperatorUiClientScript();
+
+  assert.match(style, /\.detail-grid/);
+  assert.match(style, /\.artifact-preview/);
+  assert.match(script, /async function withAction/);
+  assert.match(script, /new EventSource/);
+  assert.match(script, /workspace-cleanup\/apply/);
+});
+
 test("operator UI shell keeps hosted action and stream wiring", () => {
   const body = renderOperatorUiHtml();
 
   assert.match(body, /SpecRail Operator/);
+  assert.match(body, /<style>\n/);
+  assert.match(body, /<script type="module">\n/);
   assert.match(body, /id="project-create"/);
   assert.match(body, /id="project-update"/);
   assert.match(body, /id="track-create"/);
@@ -69,6 +84,7 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /workspace-cleanup\/preview/);
   assert.match(body, /workspace-cleanup\/apply/);
   assert.match(body, /new EventSource/);
+  assert.match(body, /\.artifact-preview/);
   assert.match(body, /events\/stream/);
   assert.match(body, /async function withAction/);
   assert.match(body, /function errorMessage/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -81,15 +81,8 @@ export function operatorUiRunEventStreamPath(runId: string): string {
   return `/runs/${encodeURIComponent(runId)}/events/stream`;
 }
 
-export function renderOperatorUiHtml(): string {
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SpecRail Operator</title>
-  <style>
-    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+export function renderOperatorUiStyleCss(): string {
+  return `:root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     body { margin: 0; padding: 2rem; background: Canvas; color: CanvasText; }
     main { max-width: 1120px; margin: 0 auto; display: grid; gap: 1rem; }
     header { display: flex; align-items: end; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
@@ -108,32 +101,11 @@ export function renderOperatorUiHtml(): string {
     .detail-grid dt { font-weight: 700; }
     .artifact-preview { max-height: 12rem; overflow: auto; padding: 0.65rem; border-radius: 0.5rem; background: color-mix(in srgb, Canvas 88%, CanvasText 12%); white-space: pre-wrap; }
     pre { white-space: pre-wrap; overflow-wrap: anywhere; }
-  </style>
-</head>
-<body>
-  <main>
-    <header>
-      <div>
-        <h1>SpecRail Operator</h1>
-        <p class="muted">Thin hosted slice over the existing HTTP/SSE API.</p>
-      </div>
-      <button id="refresh">Refresh</button>
-    </header>
-    <section>
-      <label>Project scope
-        <select id="project-scope"><option value="">All projects</option></select>
-      </label>
-      <p><button id="project-create">Create project</button> <button id="project-update">Update selected project</button> <button id="track-create">Create track</button></p>
-      <p id="status" class="muted">Loading…</p>
-    </section>
-    <div class="grid">
-      <section><h2>Tracks</h2><ul id="tracks"></ul></section>
-      <section><h2>Runs</h2><ul id="runs"></ul></section>
-    </div>
-    <section><h2>Selected detail</h2><div id="detail" class="muted">Select a track or run.</div></section>
-  </main>
-  <script type="module">
-    const scope = document.querySelector('#project-scope');
+`;
+}
+
+export function renderOperatorUiClientScript(): string {
+  return `const scope = document.querySelector('#project-scope');
     const status = document.querySelector('#status');
     const tracks = document.querySelector('#tracks');
     const runs = document.querySelector('#runs');
@@ -574,6 +546,44 @@ export function renderOperatorUiHtml(): string {
     scope.addEventListener('change', load);
     refresh.addEventListener('click', load);
     load().catch((error) => { status.textContent = error instanceof Error ? error.message : String(error); });
+`;
+}
+
+export function renderOperatorUiHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SpecRail Operator</title>
+  <style>
+${renderOperatorUiStyleCss()}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>SpecRail Operator</h1>
+        <p class="muted">Thin hosted slice over the existing HTTP/SSE API.</p>
+      </div>
+      <button id="refresh">Refresh</button>
+    </header>
+    <section>
+      <label>Project scope
+        <select id="project-scope"><option value="">All projects</option></select>
+      </label>
+      <p><button id="project-create">Create project</button> <button id="project-update">Update selected project</button> <button id="track-create">Create track</button></p>
+      <p id="status" class="muted">Loading…</p>
+    </section>
+    <div class="grid">
+      <section><h2>Tracks</h2><ul id="tracks"></ul></section>
+      <section><h2>Runs</h2><ul id="runs"></ul></section>
+    </div>
+    <section><h2>Selected detail</h2><div id="detail" class="muted">Select a track or run.</div></section>
+  </main>
+  <script type="module">
+${renderOperatorUiClientScript()}
   </script>
 </body>
 </html>`;

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -101,10 +101,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI selected-run detail appends live SSE event updates while a run is selected
 - hosted UI selected-run detail can request cleanup preview/apply through the existing explicit confirmation flow
 - hosted UI action controls use shared in-flight/error handling and preserve cleanup apply results if post-apply refresh fails
+- hosted UI shell rendering composes separately testable style and client script helpers without adding a new frontend build pipeline
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Split hosted operator UI into smaller client modules**
-   - move the inline UI script/style toward separately testable browser helpers once the hosted shell grows beyond the current API-only slice.
+1. **Hosted operator UI interaction polish**
+   - improve browser form affordances beyond prompt dialogs while continuing to reuse the same HTTP/SSE contracts.


### PR DESCRIPTION
## Summary
- extract hosted operator UI CSS into `renderOperatorUiStyleCss()`
- extract hosted operator UI browser script into `renderOperatorUiClientScript()`
- keep `renderOperatorUiHtml()` as the single composed shell served by `GET /operator`
- add helper-level tests and update hosted UI docs/roadmap

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (106 tests: 105 pass, 1 skipped)
- `pnpm build`

Closes #214
