### PR TITLE
feat: add selected-track inline forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - shared action-state handling disables buttons while requests are in flight and preserves cleanup apply results if post-apply refresh fails
   - HTML shell rendering composes separately testable hosted UI style and client script helpers while keeping `GET /operator` as a single served page
   - top-level project and track actions use inline form controls while preserving the same HTTP API calls
+  - selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -206,7 +206,8 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Approval actions/);
     assert.match(body, /data-approval-id/);
     assert.match(body, /data-artifact-proposal/);
-    assert.match(body, /Propose tasks/);
+    assert.match(body, /id="artifact-proposal-kind"/);
+    assert.match(body, /Propose artifact/);
     assert.match(body, /data-run-start/);
     assert.match(body, /data-run-resume/);
     assert.match(body, /data-run-cancel/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -55,6 +55,7 @@ test("operator UI renderer exposes style and client script helpers", () => {
   assert.match(style, /\.detail-grid/);
   assert.match(style, /\.artifact-preview/);
   assert.match(style, /\.form-grid/);
+  assert.match(style, /textarea/);
   assert.match(script, /async function withAction/);
   assert.match(script, /populateProjectForm/);
   assert.match(script, /new EventSource/);
@@ -76,14 +77,19 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /id="track-priority"/);
   assert.match(body, /data-track-update/);
   assert.match(body, /data-planning-session-create/);
+  assert.match(body, /id="planning-session-status"/);
   assert.match(body, /data-planning-message-append/);
+  assert.match(body, /id="planning-message-body"/);
+  assert.match(body, /id="planning-message-author"/);
   assert.match(body, /method: 'PATCH'/);
   assert.match(body, /defaultWorkflowPolicy/);
   assert.match(body, /defaultPlanningSystem/);
   assert.match(body, /optionalNullableInputValue/);
   assert.match(body, /data-approval-id/);
   assert.match(body, /data-artifact-proposal/);
-  assert.match(body, /Propose spec/);
+  assert.match(body, /id="artifact-proposal-kind"/);
+  assert.match(body, /id="artifact-proposal-content"/);
+  assert.match(body, /Propose artifact/);
   assert.match(body, /createdBy: 'user'/);
   assert.match(body, /data-run-start/);
   assert.match(body, /data-run-resume/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -91,8 +91,9 @@ export function renderOperatorUiStyleCss(): string {
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
     label { display: grid; gap: 0.35rem; font-weight: 600; }
     .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; align-items: end; }
-    select, input, button { font: inherit; padding: 0.5rem 0.65rem; border-radius: 0.5rem; border: 1px solid color-mix(in srgb, CanvasText 25%, transparent); }
-    input { background: Canvas; color: CanvasText; }
+    select, input, textarea, button { font: inherit; padding: 0.5rem 0.65rem; border-radius: 0.5rem; border: 1px solid color-mix(in srgb, CanvasText 25%, transparent); }
+    input, textarea { background: Canvas; color: CanvasText; }
+    textarea { min-height: 5rem; resize: vertical; }
     button { cursor: pointer; }
     ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.5rem; }
     li { padding: 0.65rem; border-radius: 0.5rem; background: color-mix(in srgb, Canvas 90%, CanvasText 10%); }
@@ -249,8 +250,8 @@ export function renderOperatorUiClientScript(): string {
           ['Updated', track.updatedAt],
         ])
         + '<h3>Track workflow</h3><button data-track-update="workflow">Update track workflow</button>'
-        + '<h3>Planning</h3><button data-planning-session-create="' + escapeHtml(track.id) + '">Create planning session</button> <button data-planning-message-append="' + escapeHtml(planning.planningSessionId ?? '') + '">Append planning message</button>'
-        + '<h3>Artifact proposals</h3><button data-artifact-proposal="spec">Propose spec</button> <button data-artifact-proposal="plan">Propose plan</button> <button data-artifact-proposal="tasks">Propose tasks</button>'
+        + '<h3>Planning</h3><div class="form-grid"><label>Session status <select id="planning-session-status"><option value="active">active</option><option value="waiting_user">waiting_user</option><option value="waiting_agent">waiting_agent</option><option value="approved">approved</option><option value="archived">archived</option></select></label><p><button data-planning-session-create="' + escapeHtml(track.id) + '">Create planning session</button></p><label>Author <select id="planning-message-author"><option value="user">user</option><option value="agent">agent</option><option value="system">system</option></select></label><label>Kind <select id="planning-message-kind"><option value="message">message</option><option value="question">question</option><option value="decision">decision</option><option value="note">note</option></select></label><label>Related artifact <select id="planning-message-artifact"><option value="">none</option><option value="spec">spec</option><option value="plan">plan</option><option value="tasks">tasks</option></select></label><label>Message <textarea id="planning-message-body" placeholder="Planning message"></textarea></label><p><button data-planning-message-append="' + escapeHtml(planning.planningSessionId ?? '') + '">Append planning message</button></p></div>'
+        + '<h3>Artifact proposals</h3><div class="form-grid"><label>Artifact <select id="artifact-proposal-kind"><option value="spec">spec</option><option value="plan">plan</option><option value="tasks">tasks</option></select></label><label>Summary <input id="artifact-proposal-summary" value="Proposed from hosted operator UI" /></label><label>Content <textarea id="artifact-proposal-content" placeholder="New artifact content"></textarea></label><p><button data-artifact-proposal="inline">Propose artifact</button></p></div>'
         + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
         + artifactApprovalActions(artifactPayloads)
         + preview('Spec preview', payload.artifacts?.spec)
@@ -277,7 +278,7 @@ export function renderOperatorUiClientScript(): string {
       });
       detail.querySelector('[data-planning-session-create]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
-        const planningStatus = window.prompt('Planning session status (active, waiting_user, waiting_agent, approved, archived)', 'active') ?? 'active';
+        const planningStatus = detail.querySelector('#planning-session-status')?.value || 'active';
         await withAction(button, 'Creating planning session for ' + track.id + '…', async () => {
           await postJson('/tracks/' + encodeURIComponent(track.id) + '/planning-sessions', { status: planningStatus });
           await loadTrackDetail(track.id);
@@ -290,14 +291,14 @@ export function renderOperatorUiClientScript(): string {
           status.textContent = 'Create a planning session before appending a message for ' + track.id + '.';
           return;
         }
-        const body = window.prompt('Planning message body for ' + track.id);
+        const body = detail.querySelector('#planning-message-body')?.value.trim();
         if (!body) {
-          status.textContent = 'Planning message cancelled for ' + track.id + '.';
+          status.textContent = 'Planning message body is required for ' + track.id + '.';
           return;
         }
-        const authorType = window.prompt('Planning message author (user, agent, system)', 'user') ?? 'user';
-        const kind = window.prompt('Planning message kind (message, question, decision, note)', 'message') ?? 'message';
-        const relatedArtifact = window.prompt('Related artifact (spec, plan, tasks; blank for none)', '') || undefined;
+        const authorType = detail.querySelector('#planning-message-author')?.value || 'user';
+        const kind = detail.querySelector('#planning-message-kind')?.value || 'message';
+        const relatedArtifact = detail.querySelector('#planning-message-artifact')?.value || undefined;
         await withAction(button, 'Appending planning message for ' + track.id + '…', async () => {
           await postJson('/planning-sessions/' + encodeURIComponent(planningSessionId) + '/messages', { authorType, kind, body, relatedArtifact });
           await loadTrackDetail(track.id);
@@ -305,13 +306,13 @@ export function renderOperatorUiClientScript(): string {
       });
       detail.querySelectorAll('[data-artifact-proposal]').forEach((button) => {
         button.addEventListener('click', async () => {
-          const artifact = button.getAttribute('data-artifact-proposal');
-          const content = window.prompt('New ' + artifact + ' content for ' + track.id, payload.artifacts?.[artifact] ?? '');
+          const artifact = detail.querySelector('#artifact-proposal-kind')?.value || 'spec';
+          const content = detail.querySelector('#artifact-proposal-content')?.value.trim();
           if (!content) {
-            status.textContent = 'Artifact proposal cancelled for ' + artifact + '.';
+            status.textContent = 'Artifact proposal content is required for ' + artifact + '.';
             return;
           }
-          const summaryText = window.prompt('Proposal summary for ' + artifact, 'Proposed from hosted operator UI') ?? undefined;
+          const summaryText = detail.querySelector('#artifact-proposal-summary')?.value.trim() || undefined;
           await withAction(button, 'Proposing ' + artifact + ' revision for ' + track.id + '…', async () => {
             await postJson('/tracks/' + encodeURIComponent(track.id) + '/artifacts/' + artifact, { content, summary: summaryText, createdBy: 'user' });
             await loadTrackDetail(track.id);

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -103,10 +103,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI action controls use shared in-flight/error handling and preserve cleanup apply results if post-apply refresh fails
 - hosted UI shell rendering composes separately testable style and client script helpers without adding a new frontend build pipeline
 - hosted UI top-level project and track actions use inline form controls while preserving the same HTTP API calls
+- hosted UI selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI selected-detail form polish**
-   - replace remaining selected-detail prompt dialogs for planning, artifact, run, and cleanup-adjacent actions with clearer inline controls while continuing to reuse the same HTTP/SSE contracts.
+1. **Hosted operator UI run/action form polish**
+   - replace remaining selected-detail prompt dialogs for track workflow and run resume/start actions with clearer inline controls while continuing to reuse the same HTTP/SSE contracts.


### PR DESCRIPTION
## Summary
- replace selected-track planning session/message prompt dialogs with inline controls
- replace selected-track artifact proposal prompt dialogs with inline artifact/summary/content controls
- keep existing planning/artifact HTTP calls and refresh behavior intact
- update hosted shell tests and roadmap docs

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (106 tests: 105 pass, 1 skipped)
- `pnpm build`

Closes #218
