### PR TITLE
feat: add workflow and run inline controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - HTML shell rendering composes separately testable hosted UI style and client script helpers while keeping `GET /operator` as a single served page
   - top-level project and track actions use inline form controls while preserving the same HTTP API calls
   - selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
+  - selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -200,6 +200,7 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /Update selected project/);
     assert.match(body, /Create track/);
     assert.match(body, /Update track workflow/);
+    assert.match(body, /track-workflow-status/);
     assert.match(body, /Create planning session/);
     assert.match(body, /Append planning message/);
     assert.match(body, /Spec preview/);
@@ -209,7 +210,9 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /id="artifact-proposal-kind"/);
     assert.match(body, /Propose artifact/);
     assert.match(body, /data-run-start/);
+    assert.match(body, /run-start-prompt/);
     assert.match(body, /data-run-resume/);
+    assert.match(body, /run-resume-prompt/);
     assert.match(body, /data-run-cancel/);
     assert.match(body, /Recent events/);
     assert.match(body, /EventSource/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -58,6 +58,7 @@ test("operator UI renderer exposes style and client script helpers", () => {
   assert.match(style, /textarea/);
   assert.match(script, /async function withAction/);
   assert.match(script, /populateProjectForm/);
+  assert.match(script, /function option/);
   assert.match(script, /new EventSource/);
   assert.match(script, /workspace-cleanup\/apply/);
 });
@@ -76,6 +77,8 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /id="track-title"/);
   assert.match(body, /id="track-priority"/);
   assert.match(body, /data-track-update/);
+  assert.match(body, /id="track-workflow-status"/);
+  assert.match(body, /id="track-workflow-spec-status"/);
   assert.match(body, /data-planning-session-create/);
   assert.match(body, /id="planning-session-status"/);
   assert.match(body, /data-planning-message-append/);
@@ -92,7 +95,9 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /Propose artifact/);
   assert.match(body, /createdBy: 'user'/);
   assert.match(body, /data-run-start/);
+  assert.match(body, /id="run-start-prompt"/);
   assert.match(body, /data-run-resume/);
+  assert.match(body, /id="run-resume-prompt"/);
   assert.match(body, /data-run-cancel/);
   assert.match(body, /workspace-cleanup\/preview/);
   assert.match(body, /workspace-cleanup\/apply/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -198,6 +198,10 @@ export function renderOperatorUiClientScript(): string {
       return '<h3>' + escapeHtml(label) + '</h3><div class="artifact-preview">' + escapeHtml(String(value).slice(0, 2000)) + '</div>';
     }
 
+    function option(value, label, selectedValue) {
+      return '<option value="' + escapeHtml(value) + '"' + (value === selectedValue ? ' selected' : '') + '>' + escapeHtml(label) + '</option>';
+    }
+
     function optionalInputValue(input) {
       return input.value.trim() === '' ? undefined : input.value.trim();
     }
@@ -249,28 +253,24 @@ export function renderOperatorUiClientScript(): string {
           ['Pending planning changes', planning.hasPendingChanges ? 'yes' : 'no'],
           ['Updated', track.updatedAt],
         ])
-        + '<h3>Track workflow</h3><button data-track-update="workflow">Update track workflow</button>'
+        + '<h3>Track workflow</h3><div class="form-grid"><label>Status <select id="track-workflow-status">' + ['new', 'planned', 'ready', 'in_progress', 'blocked', 'review', 'done', 'failed'].map((value) => option(value, value, track.status ?? 'new')).join('') + '</select></label><label>Spec approval <select id="track-workflow-spec-status">' + ['draft', 'pending', 'approved', 'rejected'].map((value) => option(value, value, track.specStatus ?? 'draft')).join('') + '</select></label><label>Plan approval <select id="track-workflow-plan-status">' + ['draft', 'pending', 'approved', 'rejected'].map((value) => option(value, value, track.planStatus ?? 'draft')).join('') + '</select></label><p><button data-track-update="workflow">Update track workflow</button></p></div>'
         + '<h3>Planning</h3><div class="form-grid"><label>Session status <select id="planning-session-status"><option value="active">active</option><option value="waiting_user">waiting_user</option><option value="waiting_agent">waiting_agent</option><option value="approved">approved</option><option value="archived">archived</option></select></label><p><button data-planning-session-create="' + escapeHtml(track.id) + '">Create planning session</button></p><label>Author <select id="planning-message-author"><option value="user">user</option><option value="agent">agent</option><option value="system">system</option></select></label><label>Kind <select id="planning-message-kind"><option value="message">message</option><option value="question">question</option><option value="decision">decision</option><option value="note">note</option></select></label><label>Related artifact <select id="planning-message-artifact"><option value="">none</option><option value="spec">spec</option><option value="plan">plan</option><option value="tasks">tasks</option></select></label><label>Message <textarea id="planning-message-body" placeholder="Planning message"></textarea></label><p><button data-planning-message-append="' + escapeHtml(planning.planningSessionId ?? '') + '">Append planning message</button></p></div>'
         + '<h3>Artifact proposals</h3><div class="form-grid"><label>Artifact <select id="artifact-proposal-kind"><option value="spec">spec</option><option value="plan">plan</option><option value="tasks">tasks</option></select></label><label>Summary <input id="artifact-proposal-summary" value="Proposed from hosted operator UI" /></label><label>Content <textarea id="artifact-proposal-content" placeholder="New artifact content"></textarea></label><p><button data-artifact-proposal="inline">Propose artifact</button></p></div>'
-        + '<h3>Run lifecycle</h3><button data-run-start="' + escapeHtml(track.id) + '">Start run</button>'
+        + '<h3>Run lifecycle</h3><div class="form-grid"><label>Run prompt <textarea id="run-start-prompt">Implement the selected track.</textarea></label><p><button data-run-start="' + escapeHtml(track.id) + '">Start run</button></p></div>'
         + artifactApprovalActions(artifactPayloads)
         + preview('Spec preview', payload.artifacts?.spec)
         + preview('Plan preview', payload.artifacts?.plan)
         + preview('Tasks preview', payload.artifacts?.tasks);
       detail.querySelector('[data-track-update]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
-        const statusInput = window.prompt('Track status for ' + track.id + ' (new, planned, ready, in_progress, blocked, review, done, failed)', track.status ?? 'new');
-        if (!statusInput) {
-          status.textContent = 'Track update cancelled for ' + track.id + '.';
-          return;
-        }
-        const specStatusInput = window.prompt('Spec status for ' + track.id + ' (draft, pending, approved, rejected)', track.specStatus ?? 'draft');
-        const planStatusInput = window.prompt('Plan status for ' + track.id + ' (draft, pending, approved, rejected)', track.planStatus ?? 'draft');
+        const statusInput = detail.querySelector('#track-workflow-status')?.value || 'new';
+        const specStatusInput = detail.querySelector('#track-workflow-spec-status')?.value || undefined;
+        const planStatusInput = detail.querySelector('#track-workflow-plan-status')?.value || undefined;
         await withAction(button, 'Updating track ' + track.id + '…', async () => {
           await patchJson('/tracks/' + encodeURIComponent(track.id), {
             status: statusInput,
-            specStatus: specStatusInput || undefined,
-            planStatus: planStatusInput || undefined,
+            specStatus: specStatusInput,
+            planStatus: planStatusInput,
           });
           await load();
           await loadTrackDetail(track.id);
@@ -321,9 +321,9 @@ export function renderOperatorUiClientScript(): string {
       });
       detail.querySelector('[data-run-start]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
-        const promptText = window.prompt('Prompt for the new run on ' + track.id, 'Implement the selected track.');
+        const promptText = detail.querySelector('#run-start-prompt')?.value.trim();
         if (!promptText) {
-          status.textContent = 'Run start cancelled for ' + track.id + '.';
+          status.textContent = 'Run start prompt is required for ' + track.id + '.';
           return;
         }
         await withAction(button, 'Starting run for ' + track.id + '…', async () => {
@@ -396,14 +396,14 @@ export function renderOperatorUiClientScript(): string {
           ['Started', run.startedAt],
           ['Finished', run.finishedAt],
         ])
-        + '<h3>Run lifecycle</h3><button data-run-resume="' + escapeHtml(run.id) + '">Resume run</button> <button data-run-cancel="' + escapeHtml(run.id) + '">Cancel run</button>'
+        + '<h3>Run lifecycle</h3><div class="form-grid"><label>Resume prompt <textarea id="run-resume-prompt">Continue with verification.</textarea></label><p><button data-run-resume="' + escapeHtml(run.id) + '">Resume run</button> <button data-run-cancel="' + escapeHtml(run.id) + '">Cancel run</button></p></div>'
         + cleanupSection
         + '<h3>Recent events</h3><p class="muted">Live updates use <code>GET /runs/:runId/events/stream</code> while this run is selected.</p><ul id="run-events">' + events.slice(-10).map((event) => '<li><span class="pill">' + escapeHtml(event.type) + '</span> ' + escapeHtml(event.summary) + '<br><span class="muted">' + escapeHtml(event.timestamp) + '</span></li>').join('') + '</ul>';
       detail.querySelector('[data-run-resume]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
-        const promptText = window.prompt('Resume prompt for ' + run.id, 'Continue with verification.');
+        const promptText = detail.querySelector('#run-resume-prompt')?.value.trim();
         if (!promptText) {
-          status.textContent = 'Run resume cancelled for ' + run.id + '.';
+          status.textContent = 'Run resume prompt is required for ' + run.id + '.';
           return;
         }
         await withAction(button, 'Resuming run ' + run.id + '…', async () => {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -104,10 +104,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI shell rendering composes separately testable style and client script helpers without adding a new frontend build pipeline
 - hosted UI top-level project and track actions use inline form controls while preserving the same HTTP API calls
 - hosted UI selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
+- hosted UI selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI run/action form polish**
-   - replace remaining selected-detail prompt dialogs for track workflow and run resume/start actions with clearer inline controls while continuing to reuse the same HTTP/SSE contracts.
+1. **Hosted operator UI destructive-action confirmation polish**
+   - replace remaining browser-native confirmation prompts for cancel/cleanup destructive actions with clearer in-page confirmation affordances while preserving explicit confirmation semantics.


### PR DESCRIPTION
## Summary
- replace selected-track workflow update prompts with inline status controls
- replace selected-track run-start prompt with an inline textarea
- replace selected-run resume prompt with an inline textarea
- preserve existing PATCH /tracks, POST /runs, and POST /runs/:runId/resume calls
- update hosted UI shell tests and roadmap docs

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (106 tests: 105 pass, 1 skipped)
- `pnpm build`

Closes #220
