### PR TITLE
feat: add in-page destructive confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - top-level project and track actions use inline form controls while preserving the same HTTP API calls
   - selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
   - selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
+  - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -214,11 +214,14 @@ test("API serves the hosted operator UI shell", async () => {
     assert.match(body, /data-run-resume/);
     assert.match(body, /run-resume-prompt/);
     assert.match(body, /data-run-cancel/);
+    assert.match(body, /run-cancel-confirmation/);
     assert.match(body, /Recent events/);
     assert.match(body, /EventSource/);
     assert.match(body, /events\/stream/);
     assert.match(body, /Live event stream disconnected/);
     assert.match(body, /Workspace cleanup/);
+    assert.match(body, /data-cleanup-request/);
+    assert.match(body, /cleanup-confirmation/);
     assert.match(body, /data-cleanup-apply/);
     assert.match(body, /loadTrackDetail/);
     assert.match(body, /loadRunDetail/);

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -98,8 +98,11 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
   assert.match(body, /id="run-start-prompt"/);
   assert.match(body, /data-run-resume/);
   assert.match(body, /id="run-resume-prompt"/);
+  assert.match(body, /id="run-cancel-confirmation"/);
   assert.match(body, /data-run-cancel/);
   assert.match(body, /workspace-cleanup\/preview/);
+  assert.match(body, /data-cleanup-request/);
+  assert.match(body, /id="cleanup-confirmation"/);
   assert.match(body, /workspace-cleanup\/apply/);
   assert.match(body, /new EventSource/);
   assert.match(body, /\.artifact-preview/);

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -380,7 +380,7 @@ export function renderOperatorUiClientScript(): string {
           ['Eligible', cleanupPlan.eligible ? 'yes' : 'no'],
           ['Operations', (cleanupPlan.operations ?? []).length],
           ['Refusal reasons', (cleanupPlan.refusalReasons ?? []).join('; ') || 'none'],
-        ]) + '<button data-cleanup-preview="' + escapeHtml(run.id) + '">Refresh cleanup preview</button> <button data-cleanup-apply="' + escapeHtml(run.id) + '"' + (cleanupPlan.eligible ? '' : ' disabled') + '>Apply with server confirmation</button>'
+        ]) + '<button data-cleanup-preview="' + escapeHtml(run.id) + '">Refresh cleanup preview</button> <button data-cleanup-request="' + escapeHtml(run.id) + '"' + (cleanupPlan.eligible ? '' : ' disabled') + '>Request cleanup confirmation</button><div id="cleanup-confirm-panel" hidden><p class="muted">Server confirmation phrase: <code id="cleanup-expected-confirmation"></code></p><label>Confirmation <input id="cleanup-confirmation" autocomplete="off" placeholder="Paste server confirmation phrase" /></label><p><button data-cleanup-apply="' + escapeHtml(run.id) + '">Apply cleanup</button></p></div>'
         : '<h3>Workspace cleanup</h3><button data-cleanup-preview="' + escapeHtml(run.id) + '">Load cleanup preview</button>';
       detail.className = 'detail-grid';
       detail.innerHTML = '<h3>Run ' + escapeHtml(run.id) + '</h3>'
@@ -396,7 +396,7 @@ export function renderOperatorUiClientScript(): string {
           ['Started', run.startedAt],
           ['Finished', run.finishedAt],
         ])
-        + '<h3>Run lifecycle</h3><div class="form-grid"><label>Resume prompt <textarea id="run-resume-prompt">Continue with verification.</textarea></label><p><button data-run-resume="' + escapeHtml(run.id) + '">Resume run</button> <button data-run-cancel="' + escapeHtml(run.id) + '">Cancel run</button></p></div>'
+        + '<h3>Run lifecycle</h3><div class="form-grid"><label>Resume prompt <textarea id="run-resume-prompt">Continue with verification.</textarea></label><label>Cancel confirmation <input id="run-cancel-confirmation" autocomplete="off" placeholder="Type cancel to confirm" /></label><p><button data-run-resume="' + escapeHtml(run.id) + '">Resume run</button> <button data-run-cancel="' + escapeHtml(run.id) + '">Cancel run</button></p></div>'
         + cleanupSection
         + '<h3>Recent events</h3><p class="muted">Live updates use <code>GET /runs/:runId/events/stream</code> while this run is selected.</p><ul id="run-events">' + events.slice(-10).map((event) => '<li><span class="pill">' + escapeHtml(event.type) + '</span> ' + escapeHtml(event.summary) + '<br><span class="muted">' + escapeHtml(event.timestamp) + '</span></li>').join('') + '</ul>';
       detail.querySelector('[data-run-resume]')?.addEventListener('click', async (event) => {
@@ -414,9 +414,9 @@ export function renderOperatorUiClientScript(): string {
       });
       detail.querySelector('[data-run-cancel]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
-        const accepted = window.confirm('Cancel run ' + run.id + '?');
-        if (!accepted) {
-          status.textContent = 'Run cancel skipped for ' + run.id + '.';
+        const confirmation = detail.querySelector('#run-cancel-confirmation')?.value.trim().toLowerCase();
+        if (confirmation !== 'cancel') {
+          status.textContent = 'Type cancel before cancelling run ' + run.id + '.';
           return;
         }
         await withAction(button, 'Cancelling run ' + run.id + '…', async () => {
@@ -432,17 +432,25 @@ export function renderOperatorUiClientScript(): string {
         }, 'Cleanup preview refreshed for ' + run.id + '.');
       });
       startRunEventStream(run.id);
-      detail.querySelector('[data-cleanup-apply]')?.addEventListener('click', async (event) => {
+      detail.querySelector('[data-cleanup-request]')?.addEventListener('click', async (event) => {
         const button = event.currentTarget;
         await withAction(button, 'Requesting cleanup confirmation for ' + run.id + '…', async () => {
           const confirmationPayload = await postJson('/runs/' + encodeURIComponent(run.id) + '/workspace-cleanup/apply', { confirm: '' });
           const expectedConfirmation = confirmationPayload.expectedConfirmation;
-          const accepted = window.confirm('Apply workspace cleanup for ' + run.id + '?\n\nServer confirmation phrase:\n' + expectedConfirmation);
-          if (!accepted) {
-            status.textContent = 'Workspace cleanup apply cancelled for ' + run.id + '.';
-            return;
-          }
-          const applyPayload = await postJson('/runs/' + encodeURIComponent(run.id) + '/workspace-cleanup/apply', { confirm: expectedConfirmation });
+          detail.querySelector('#cleanup-expected-confirmation').textContent = expectedConfirmation;
+          detail.querySelector('#cleanup-confirmation').value = '';
+          detail.querySelector('#cleanup-confirm-panel').hidden = false;
+        }, 'Cleanup confirmation phrase loaded for ' + run.id + '.');
+      });
+      detail.querySelector('[data-cleanup-apply]')?.addEventListener('click', async (event) => {
+        const button = event.currentTarget;
+        const confirmation = detail.querySelector('#cleanup-confirmation')?.value.trim();
+        if (!confirmation) {
+          status.textContent = 'Cleanup confirmation phrase is required for ' + run.id + '.';
+          return;
+        }
+        await withAction(button, 'Applying cleanup for ' + run.id + '…', async () => {
+          const applyPayload = await postJson('/runs/' + encodeURIComponent(run.id) + '/workspace-cleanup/apply', { confirm: confirmation });
           const resultText = 'Workspace cleanup ' + applyPayload.cleanupResult.status + ' for ' + run.id + '.';
           status.textContent = resultText;
           try {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -105,10 +105,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI top-level project and track actions use inline form controls while preserving the same HTTP API calls
 - hosted UI selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
 - hosted UI selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
+- hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI destructive-action confirmation polish**
-   - replace remaining browser-native confirmation prompts for cancel/cleanup destructive actions with clearer in-page confirmation affordances while preserving explicit confirmation semantics.
+1. **Hosted operator UI stateful interaction tests**
+   - add browser-level tests or DOM-level harness coverage for the hosted operator UI action flows that are currently covered primarily through served shell/script assertions.


### PR DESCRIPTION
## Summary
- replace run cancel browser confirm with an in-page confirmation input
- split cleanup apply into in-page request/apply controls that show the server confirmation phrase
- preserve server-side cleanup confirmation semantics and refresh-failure result visibility
- update hosted UI shell tests and roadmap docs

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (106 tests: 105 pass, 1 skipped)
- `pnpm build`

Closes #222
