### PR TITLE
test: guard hosted UI native dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
   - selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
+  - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -63,6 +63,23 @@ test("operator UI renderer exposes style and client script helpers", () => {
   assert.match(script, /workspace-cleanup\/apply/);
 });
 
+test("operator UI client script stays on in-page controls instead of native dialogs", () => {
+  const script = renderOperatorUiClientScript();
+  const body = renderOperatorUiHtml();
+
+  assert.doesNotMatch(script, /window\.prompt/);
+  assert.doesNotMatch(script, /window\.confirm/);
+  assert.match(body, /id="project-name"/);
+  assert.match(body, /id="track-title"/);
+  assert.match(body, /id="planning-message-body"/);
+  assert.match(body, /id="artifact-proposal-content"/);
+  assert.match(body, /id="track-workflow-status"/);
+  assert.match(body, /id="run-start-prompt"/);
+  assert.match(body, /id="run-resume-prompt"/);
+  assert.match(body, /id="run-cancel-confirmation"/);
+  assert.match(body, /id="cleanup-confirmation"/);
+});
+
 test("operator UI shell keeps hosted action and stream wiring", () => {
   const body = renderOperatorUiHtml();
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -106,10 +106,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
 - hosted UI selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
+- hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs without adding a frontend build pipeline
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
 1. **Hosted operator UI stateful interaction tests**
-   - add browser-level tests or DOM-level harness coverage for the hosted operator UI action flows that are currently covered primarily through served shell/script assertions.
+   - add browser-level tests or a DOM-level harness for actual click/submit behavior now that lightweight native-dialog regression coverage exists.


### PR DESCRIPTION
## Summary
- add regression coverage that hosted UI client script does not reintroduce `window.prompt` or `window.confirm`
- assert the major in-page replacement controls remain rendered
- update README and roadmap with the lightweight dialog regression coverage

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (107 tests: 106 pass, 1 skipped)
- `pnpm build`

Closes #224
