### PR TITLE
test: group hosted UI shell coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
   - selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
-  - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs
+  - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -24,6 +24,12 @@ import {
   renderOperatorUiStyleCss,
 } from "../operator-ui.js";
 
+function assertContainsAll(body: string, patterns: RegExp[]): void {
+  for (const pattern of patterns) {
+    assert.match(body, pattern);
+  }
+}
+
 test("operator UI helpers escape metadata and previews", () => {
   assert.equal(operatorUiEscapeHtml(`<script>alert("x")</script>`), "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
   assert.equal(operatorUiMetadataHtml([["Run", "run-1"], ["Missing", undefined]]), "<dl><dt>Run</dt><dd>run-1</dd><dt>Missing</dt><dd>unknown</dd></dl>");
@@ -83,50 +89,18 @@ test("operator UI client script stays on in-page controls instead of native dial
 test("operator UI shell keeps hosted action and stream wiring", () => {
   const body = renderOperatorUiHtml();
 
-  assert.match(body, /SpecRail Operator/);
-  assert.match(body, /<style>\n/);
-  assert.match(body, /<script type="module">\n/);
-  assert.match(body, /id="project-create"/);
-  assert.match(body, /id="project-update"/);
-  assert.match(body, /id="track-create"/);
-  assert.match(body, /id="project-name"/);
-  assert.match(body, /id="project-repo-url"/);
-  assert.match(body, /id="track-title"/);
-  assert.match(body, /id="track-priority"/);
-  assert.match(body, /data-track-update/);
-  assert.match(body, /id="track-workflow-status"/);
-  assert.match(body, /id="track-workflow-spec-status"/);
-  assert.match(body, /data-planning-session-create/);
-  assert.match(body, /id="planning-session-status"/);
-  assert.match(body, /data-planning-message-append/);
-  assert.match(body, /id="planning-message-body"/);
-  assert.match(body, /id="planning-message-author"/);
-  assert.match(body, /method: 'PATCH'/);
-  assert.match(body, /defaultWorkflowPolicy/);
-  assert.match(body, /defaultPlanningSystem/);
-  assert.match(body, /optionalNullableInputValue/);
-  assert.match(body, /data-approval-id/);
-  assert.match(body, /data-artifact-proposal/);
-  assert.match(body, /id="artifact-proposal-kind"/);
-  assert.match(body, /id="artifact-proposal-content"/);
-  assert.match(body, /Propose artifact/);
-  assert.match(body, /createdBy: 'user'/);
-  assert.match(body, /data-run-start/);
-  assert.match(body, /id="run-start-prompt"/);
-  assert.match(body, /data-run-resume/);
-  assert.match(body, /id="run-resume-prompt"/);
-  assert.match(body, /id="run-cancel-confirmation"/);
-  assert.match(body, /data-run-cancel/);
-  assert.match(body, /workspace-cleanup\/preview/);
-  assert.match(body, /data-cleanup-request/);
-  assert.match(body, /id="cleanup-confirmation"/);
-  assert.match(body, /workspace-cleanup\/apply/);
-  assert.match(body, /new EventSource/);
-  assert.match(body, /\.artifact-preview/);
-  assert.match(body, /events\/stream/);
-  assert.match(body, /async function withAction/);
-  assert.match(body, /function errorMessage/);
-  assert.match(body, /button.disabled = true/);
-  assert.match(body, /button.isConnected/);
-  assert.match(body, /Refresh failed:/);
+  const controlGroups = {
+    shell: [/SpecRail Operator/, /<style>\n/, /<script type="module">\n/, /\.artifact-preview/],
+    project: [/id="project-create"/, /id="project-update"/, /id="project-name"/, /id="project-repo-url"/, /method: 'PATCH'/, /defaultWorkflowPolicy/, /defaultPlanningSystem/, /optionalNullableInputValue/],
+    track: [/id="track-create"/, /id="track-title"/, /id="track-priority"/, /data-track-update/, /id="track-workflow-status"/, /id="track-workflow-spec-status"/],
+    planning: [/data-planning-session-create/, /id="planning-session-status"/, /data-planning-message-append/, /id="planning-message-body"/, /id="planning-message-author"/],
+    artifacts: [/data-approval-id/, /data-artifact-proposal/, /id="artifact-proposal-kind"/, /id="artifact-proposal-content"/, /Propose artifact/, /createdBy: 'user'/],
+    runs: [/data-run-start/, /id="run-start-prompt"/, /data-run-resume/, /id="run-resume-prompt"/, /id="run-cancel-confirmation"/, /data-run-cancel/],
+    cleanup: [/workspace-cleanup\/preview/, /data-cleanup-request/, /id="cleanup-confirmation"/, /workspace-cleanup\/apply/, /Refresh failed:/],
+    streamsAndActions: [/new EventSource/, /events\/stream/, /async function withAction/, /function errorMessage/, /button.disabled = true/, /button.isConnected/],
+  };
+
+  for (const patterns of Object.values(controlGroups)) {
+    assertContainsAll(body, patterns);
+  }
 });

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -106,7 +106,7 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI selected-track planning and artifact proposal actions use inline controls for session/message/proposal fields
 - hosted UI selected-detail workflow and run lifecycle actions use inline controls for status and prompt fields
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
-- hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs without adding a frontend build pipeline
+- hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 


### PR DESCRIPTION
## Summary
- group hosted operator UI shell assertions by action area
- keep native dialog regression coverage intact
- update README and roadmap to describe grouped shell coverage as the lightweight baseline for deeper UI tests

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (107 tests: 106 pass, 1 skipped)
- `pnpm build`

Closes #226
