### PR TITLE
test: add hosted UI client action harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
+  - hosted UI client action harness exercises top-level project/track click handlers without a browser dependency
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import vm from "node:vm";
 
 import {
   operatorUiApprovalDecisionPath,
@@ -28,6 +29,167 @@ function assertContainsAll(body: string, patterns: RegExp[]): void {
   for (const pattern of patterns) {
     assert.match(body, pattern);
   }
+}
+
+type HostedUiFetchCall = {
+  path: string;
+  method: string;
+  body: unknown;
+};
+
+class FakeElement {
+  public value = "";
+  public textContent = "";
+  public innerHTML = "";
+  public className = "";
+  public disabled = false;
+  public hidden = false;
+  public isConnected = true;
+  public children: FakeElement[] = [];
+  private readonly listeners = new Map<string, Array<(event: { currentTarget: FakeElement }) => unknown>>();
+  private readonly descendants = new Map<string, FakeElement>();
+
+  public addEventListener(type: string, listener: (event: { currentTarget: FakeElement }) => unknown): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  public async click(): Promise<void> {
+    for (const listener of this.listeners.get("click") ?? []) {
+      await listener({ currentTarget: this });
+    }
+  }
+
+  public replaceChildren(...children: FakeElement[]): void {
+    this.children = children;
+  }
+
+  public append(child: FakeElement): void {
+    this.children.push(child);
+  }
+
+  public get firstElementChild(): FakeElement | undefined {
+    return this.children[0];
+  }
+
+  public remove(): void {
+    this.isConnected = false;
+  }
+
+  public querySelector(selector: string): FakeElement {
+    const existing = this.descendants.get(selector);
+    if (existing) return existing;
+    const created = new FakeElement();
+    this.descendants.set(selector, created);
+    return created;
+  }
+
+  public querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+function createHostedUiClientHarness() {
+  const selectors = [
+    "#project-scope",
+    "#status",
+    "#tracks",
+    "#runs",
+    "#detail",
+    "#refresh",
+    "#project-create",
+    "#project-update",
+    "#track-create",
+    "#project-name",
+    "#project-repo-url",
+    "#project-local-repo-path",
+    "#project-workflow-policy",
+    "#project-planning-system",
+    "#track-title",
+    "#track-description",
+    "#track-priority",
+  ];
+  const elements = new Map(selectors.map((selector) => [selector, new FakeElement()]));
+  const scope = elements.get("#project-scope")!;
+  const trackPriority = elements.get("#track-priority")!;
+  trackPriority.value = "medium";
+
+  const projects = [{ id: "project-1", name: "Project One", repoUrl: "https://example.com/one", localRepoPath: "/repo/one", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" }];
+  const tracks: Array<Record<string, unknown>> = [];
+  const calls: HostedUiFetchCall[] = [];
+  let projectCounter = 2;
+  let trackCounter = 1;
+
+  const document = {
+    querySelector(selector: string) {
+      const element = elements.get(selector);
+      if (!element) throw new Error(`Missing fake element for ${selector}`);
+      return element;
+    },
+    createElement() {
+      return new FakeElement();
+    },
+  };
+
+  async function fetch(path: string, init?: { method?: string; body?: string }) {
+    const method = init?.method ?? "GET";
+    const body = init?.body === undefined ? undefined : JSON.parse(init.body);
+    calls.push({ path, method, body });
+
+    if (path === "/projects" && method === "GET") {
+      return { ok: true, json: async () => ({ projects }) };
+    }
+    if (path === "/projects" && method === "POST") {
+      const project = { id: `project-${projectCounter++}`, ...(body as Record<string, unknown>) };
+      projects.push(project as typeof projects[number]);
+      return { ok: true, json: async () => ({ project }) };
+    }
+    if (path.startsWith("/projects/") && method === "PATCH") {
+      const projectId = decodeURIComponent(path.slice("/projects/".length));
+      const project = { id: projectId, ...(body as Record<string, unknown>) };
+      return { ok: true, json: async () => ({ project }) };
+    }
+    if (path.startsWith("/tracks?page=1&pageSize=20") && method === "GET") {
+      return { ok: true, json: async () => ({ tracks }) };
+    }
+    if (path === "/tracks" && method === "POST") {
+      const track = { id: `track-${trackCounter++}`, status: "new", ...(body as Record<string, unknown>) };
+      tracks.push(track);
+      return { ok: true, json: async () => ({ track }) };
+    }
+    if (/^\/tracks\/[^/]+$/.test(path) && method === "GET") {
+      const trackId = decodeURIComponent(path.slice("/tracks/".length));
+      const track = tracks.find((candidate) => candidate.id === trackId) ?? { id: trackId, title: trackId, status: "new" };
+      return { ok: true, json: async () => ({ track, planningContext: {}, artifacts: {} }) };
+    }
+    if (/^\/tracks\/[^/]+\/artifacts\/(spec|plan|tasks)$/.test(path) && method === "GET") {
+      return { ok: true, json: async () => ({ approvalRequests: [] }) };
+    }
+    if (path === "/runs?page=1&pageSize=20" && method === "GET") {
+      return { ok: true, json: async () => ({ runs: [] }) };
+    }
+    throw new Error(`Unhandled fetch ${method} ${path}`);
+  }
+
+  vm.runInNewContext(renderOperatorUiClientScript(), {
+    document,
+    fetch,
+    Option: class FakeOption {
+      public textContent: string;
+      public value: string;
+      public constructor(label: string, value: string) {
+        this.textContent = label;
+        this.value = value;
+      }
+    },
+    EventSource: undefined,
+  });
+
+  return { calls, elements, scope };
+}
+
+async function flushClientPromises(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
 }
 
 test("operator UI helpers escape metadata and previews", () => {
@@ -84,6 +246,58 @@ test("operator UI client script stays on in-page controls instead of native dial
   assert.match(body, /id="run-resume-prompt"/);
   assert.match(body, /id="run-cancel-confirmation"/);
   assert.match(body, /id="cleanup-confirmation"/);
+});
+
+test("operator UI client harness submits top-level project and track actions", async () => {
+  const { calls, elements, scope } = createHostedUiClientHarness();
+  await flushClientPromises();
+
+  elements.get("#project-name")!.value = "Project Two";
+  elements.get("#project-repo-url")!.value = "https://example.com/two";
+  elements.get("#project-local-repo-path")!.value = "/repo/two";
+  elements.get("#project-workflow-policy")!.value = "strict";
+  elements.get("#project-planning-system")!.value = "native";
+  await elements.get("#project-create")!.click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/projects")?.body, {
+    name: "Project Two",
+    repoUrl: "https://example.com/two",
+    localRepoPath: "/repo/two",
+    defaultWorkflowPolicy: "strict",
+    defaultPlanningSystem: "native",
+  });
+
+  elements.get("#project-name")!.value = "Project Two Updated";
+  elements.get("#project-repo-url")!.value = "";
+  elements.get("#project-local-repo-path")!.value = "/repo/two-updated";
+  elements.get("#project-workflow-policy")!.value = "";
+  elements.get("#project-planning-system")!.value = "speckit";
+  await elements.get("#project-update")!.click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "PATCH" && call.path === "/projects/project-2")?.body, {
+    name: "Project Two Updated",
+    repoUrl: null,
+    localRepoPath: "/repo/two-updated",
+    defaultWorkflowPolicy: null,
+    defaultPlanningSystem: "speckit",
+  });
+
+  elements.get("#track-title")!.value = "Track One";
+  elements.get("#track-description")!.value = "Implement track one";
+  elements.get("#track-priority")!.value = "high";
+  await elements.get("#track-create")!.click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/tracks")?.body, {
+    projectId: scope.value,
+    title: "Track One",
+    description: "Implement track one",
+    priority: "high",
+  });
+  assert.equal(elements.get("#track-title")!.value, "");
+  assert.equal(elements.get("#track-priority")!.value, "medium");
 });
 
 test("operator UI shell keeps hosted action and stream wiring", () => {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,10 +108,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
+- hosted UI client action harness exercises top-level project/track click handlers without a browser dependency
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI stateful interaction tests**
-   - add browser-level tests or a DOM-level harness for actual click/submit behavior now that lightweight native-dialog regression coverage exists.
+1. **Hosted operator UI selected-detail action harness**
+   - extend the lightweight client action harness from top-level project/track actions into selected-track and selected-run controls.


### PR DESCRIPTION
## Summary
- add a no-dependency fake DOM/fetch harness for `renderOperatorUiClientScript()`
- exercise project create, project update, and track create click handlers
- assert generated HTTP methods/paths/bodies plus track form reset behavior
- update README and roadmap to mark the top-level client action harness baseline

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (108 tests: 107 pass, 1 skipped)
- `pnpm build`

Closes #230
