### PR TITLE
test: extend hosted UI harness to selected-track actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track click handlers without a browser dependency
+  - hosted UI client action harness exercises top-level project/track and selected-track click handlers without a browser dependency
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -40,7 +40,6 @@ type HostedUiFetchCall = {
 class FakeElement {
   public value = "";
   public textContent = "";
-  public innerHTML = "";
   public className = "";
   public disabled = false;
   public hidden = false;
@@ -48,6 +47,17 @@ class FakeElement {
   public children: FakeElement[] = [];
   private readonly listeners = new Map<string, Array<(event: { currentTarget: FakeElement }) => unknown>>();
   private readonly descendants = new Map<string, FakeElement>();
+  private readonly attributes = new Map<string, string>();
+  private innerHtmlValue = "";
+
+  public get innerHTML(): string {
+    return this.innerHtmlValue;
+  }
+
+  public set innerHTML(value: string) {
+    this.innerHtmlValue = value;
+    this.descendants.clear();
+  }
 
   public addEventListener(type: string, listener: (event: { currentTarget: FakeElement }) => unknown): void {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
@@ -77,14 +87,36 @@ class FakeElement {
 
   public querySelector(selector: string): FakeElement {
     const existing = this.descendants.get(selector);
-    if (existing) return existing;
+    if (existing) {
+      this.syncAttributeFromInnerHtml(selector, existing);
+      return existing;
+    }
     const created = new FakeElement();
+    this.syncAttributeFromInnerHtml(selector, created);
     this.descendants.set(selector, created);
     return created;
   }
 
-  public querySelectorAll(): FakeElement[] {
+  public querySelectorAll(selector: string): FakeElement[] {
+    if (selector === "[data-artifact-proposal]") {
+      return [this.querySelector(selector)];
+    }
     return [];
+  }
+
+  public getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  public setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  private syncAttributeFromInnerHtml(selector: string, element: FakeElement): void {
+    const attributeName = selector.match(/^\[([^\]]+)\]$/)?.[1];
+    if (!attributeName) return;
+    const attributeValue = this.innerHTML.match(new RegExp(`${attributeName}="([^"]*)"`))?.[1] ?? "";
+    element.setAttribute(attributeName, attributeValue);
   }
 }
 
@@ -115,9 +147,12 @@ function createHostedUiClientHarness() {
 
   const projects = [{ id: "project-1", name: "Project One", repoUrl: "https://example.com/one", localRepoPath: "/repo/one", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" }];
   const tracks: Array<Record<string, unknown>> = [];
+  const runs: Array<Record<string, unknown>> = [];
   const calls: HostedUiFetchCall[] = [];
   let projectCounter = 2;
   let trackCounter = 1;
+  let runCounter = 1;
+  let planningSessionId: string | undefined;
 
   const document = {
     querySelector(selector: string) {
@@ -159,13 +194,41 @@ function createHostedUiClientHarness() {
     if (/^\/tracks\/[^/]+$/.test(path) && method === "GET") {
       const trackId = decodeURIComponent(path.slice("/tracks/".length));
       const track = tracks.find((candidate) => candidate.id === trackId) ?? { id: trackId, title: trackId, status: "new" };
-      return { ok: true, json: async () => ({ track, planningContext: {}, artifacts: {} }) };
+      return { ok: true, json: async () => ({ track, planningContext: { planningSessionId }, artifacts: {} }) };
+    }
+    if (/^\/tracks\/[^/]+$/.test(path) && method === "PATCH") {
+      const trackId = decodeURIComponent(path.slice("/tracks/".length));
+      const track = { id: trackId, ...(body as Record<string, unknown>) };
+      return { ok: true, json: async () => ({ track }) };
+    }
+    if (/^\/tracks\/[^/]+\/planning-sessions$/.test(path) && method === "POST") {
+      planningSessionId = "planning-1";
+      return { ok: true, json: async () => ({ planningSession: { id: planningSessionId, ...(body as Record<string, unknown>) } }) };
+    }
+    if (/^\/planning-sessions\/[^/]+\/messages$/.test(path) && method === "POST") {
+      return { ok: true, json: async () => ({ message: { id: "message-1", ...(body as Record<string, unknown>) } }) };
     }
     if (/^\/tracks\/[^/]+\/artifacts\/(spec|plan|tasks)$/.test(path) && method === "GET") {
       return { ok: true, json: async () => ({ approvalRequests: [] }) };
     }
+    if (/^\/tracks\/[^/]+\/artifacts\/(spec|plan|tasks)$/.test(path) && method === "POST") {
+      return { ok: true, json: async () => ({ revision: { id: "revision-1", ...(body as Record<string, unknown>) } }) };
+    }
     if (path === "/runs?page=1&pageSize=20" && method === "GET") {
-      return { ok: true, json: async () => ({ runs: [] }) };
+      return { ok: true, json: async () => ({ runs }) };
+    }
+    if (path === "/runs" && method === "POST") {
+      const run = { id: `run-${runCounter++}`, status: "running", ...(body as Record<string, unknown>) };
+      runs.push(run);
+      return { ok: true, json: async () => ({ run }) };
+    }
+    if (/^\/runs\/[^/]+$/.test(path) && method === "GET") {
+      const runId = decodeURIComponent(path.slice("/runs/".length));
+      const run = runs.find((candidate) => candidate.id === runId) ?? { id: runId, trackId: "track-1", status: "running" };
+      return { ok: true, json: async () => ({ run }) };
+    }
+    if (/^\/runs\/[^/]+\/events$/.test(path) && method === "GET") {
+      return { ok: true, json: async () => ({ events: [] }) };
     }
     throw new Error(`Unhandled fetch ${method} ${path}`);
   }
@@ -298,6 +361,73 @@ test("operator UI client harness submits top-level project and track actions", a
   });
   assert.equal(elements.get("#track-title")!.value, "");
   assert.equal(elements.get("#track-priority")!.value, "medium");
+});
+
+test("operator UI client harness submits selected-track detail actions", async () => {
+  const { calls, elements } = createHostedUiClientHarness();
+  const detail = elements.get("#detail")!;
+  await flushClientPromises();
+
+  elements.get("#track-title")!.value = "Selected Track";
+  elements.get("#track-description")!.value = "Exercise selected-track controls";
+  elements.get("#track-priority")!.value = "medium";
+  await elements.get("#track-create")!.click();
+  await flushClientPromises();
+
+  detail.querySelector("#track-workflow-status").value = "review";
+  detail.querySelector("#track-workflow-spec-status").value = "approved";
+  detail.querySelector("#track-workflow-plan-status").value = "pending";
+  await detail.querySelector("[data-track-update]").click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "PATCH" && call.path === "/tracks/track-1")?.body, {
+    status: "review",
+    specStatus: "approved",
+    planStatus: "pending",
+  });
+
+  detail.querySelector("#planning-session-status").value = "waiting_agent";
+  await detail.querySelector("[data-planning-session-create]").click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/tracks/track-1/planning-sessions")?.body, {
+    status: "waiting_agent",
+  });
+
+  detail.querySelector("#planning-message-author").value = "agent";
+  detail.querySelector("#planning-message-kind").value = "decision";
+  detail.querySelector("#planning-message-artifact").value = "spec";
+  detail.querySelector("#planning-message-body").value = "Proceed with the selected plan.";
+  await detail.querySelector("[data-planning-message-append]").click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/planning-sessions/planning-1/messages")?.body, {
+    authorType: "agent",
+    kind: "decision",
+    body: "Proceed with the selected plan.",
+    relatedArtifact: "spec",
+  });
+
+  detail.querySelector("#artifact-proposal-kind").value = "plan";
+  detail.querySelector("#artifact-proposal-summary").value = "Plan update";
+  detail.querySelector("#artifact-proposal-content").value = "Updated plan content";
+  await detail.querySelector("[data-artifact-proposal]").click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/tracks/track-1/artifacts/plan")?.body, {
+    content: "Updated plan content",
+    summary: "Plan update",
+    createdBy: "user",
+  });
+
+  detail.querySelector("#run-start-prompt").value = "Implement selected track now.";
+  await detail.querySelector("[data-run-start]").click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs")?.body, {
+    trackId: "track-1",
+    prompt: "Implement selected track now.",
+  });
 });
 
 test("operator UI shell keeps hosted action and stream wiring", () => {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,11 +108,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track click handlers without a browser dependency
+- hosted UI client action harness exercises top-level project/track and selected-track click handlers without a browser dependency
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI selected-detail action harness**
-   - extend the lightweight client action harness from top-level project/track actions into selected-track and selected-run controls.
+1. **Hosted operator UI selected-run action harness**
+   - extend the lightweight client action harness into selected-run resume/cancel and cleanup confirmation controls.


### PR DESCRIPTION
## Summary
- extend the no-dependency hosted UI client harness to selected-track detail actions
- exercise workflow update, planning session create, planning message append, artifact proposal, and run start handlers
- assert generated HTTP methods/paths/bodies for each selected-track action
- update README and roadmap with the selected-track harness baseline

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (109 tests: 108 pass, 1 skipped)
- `pnpm build`

Closes #232
