### PR TITLE
test: add hosted UI harness setup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
   - hosted UI client action harness exercises top-level project/track, selected-track, and selected-run click handlers without a browser dependency
-  - hosted UI fake DOM/fetch harness is isolated in a focused API test helper
+  - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects
 - `GET /projects`

--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -233,7 +233,37 @@ export function createHostedUiClientHarness() {
     EventSource: undefined,
   });
 
-  return { calls, elements, scope };
+  const detail = elements.get("#detail")!;
+
+  async function loadInitialState(): Promise<void> {
+    await flushClientPromises();
+  }
+
+  async function createTrack(input: { title: string; description?: string; priority?: string }): Promise<void> {
+    elements.get("#track-title")!.value = input.title;
+    elements.get("#track-description")!.value = input.description ?? "";
+    elements.get("#track-priority")!.value = input.priority ?? "medium";
+    await elements.get("#track-create")!.click();
+    await flushClientPromises();
+  }
+
+  async function startRun(prompt: string): Promise<void> {
+    detail.querySelector("#run-start-prompt").value = prompt;
+    await detail.querySelector("[data-run-start]").click();
+    await flushClientPromises();
+  }
+
+  async function requestCleanupPreview(): Promise<void> {
+    await detail.querySelector("[data-cleanup-preview]").click();
+    await flushClientPromises();
+  }
+
+  async function requestCleanupConfirmation(): Promise<void> {
+    await detail.querySelector("[data-cleanup-request]").click();
+    await flushClientPromises();
+  }
+
+  return { calls, detail, elements, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun };
 }
 
 export async function flushClientPromises(): Promise<void> {

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -88,8 +88,8 @@ test("operator UI client script stays on in-page controls instead of native dial
 });
 
 test("operator UI client harness submits top-level project and track actions", async () => {
-  const { calls, elements, scope } = createHostedUiClientHarness();
-  await flushClientPromises();
+  const { calls, createTrack, elements, loadInitialState, scope } = createHostedUiClientHarness();
+  await loadInitialState();
 
   elements.get("#project-name")!.value = "Project Two";
   elements.get("#project-repo-url")!.value = "https://example.com/two";
@@ -123,11 +123,7 @@ test("operator UI client harness submits top-level project and track actions", a
     defaultPlanningSystem: "speckit",
   });
 
-  elements.get("#track-title")!.value = "Track One";
-  elements.get("#track-description")!.value = "Implement track one";
-  elements.get("#track-priority")!.value = "high";
-  await elements.get("#track-create")!.click();
-  await flushClientPromises();
+  await createTrack({ title: "Track One", description: "Implement track one", priority: "high" });
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/tracks")?.body, {
     projectId: scope.value,
@@ -140,15 +136,10 @@ test("operator UI client harness submits top-level project and track actions", a
 });
 
 test("operator UI client harness submits selected-track detail actions", async () => {
-  const { calls, elements } = createHostedUiClientHarness();
-  const detail = elements.get("#detail")!;
-  await flushClientPromises();
+  const { calls, createTrack, detail, loadInitialState, startRun } = createHostedUiClientHarness();
+  await loadInitialState();
 
-  elements.get("#track-title")!.value = "Selected Track";
-  elements.get("#track-description")!.value = "Exercise selected-track controls";
-  elements.get("#track-priority")!.value = "medium";
-  await elements.get("#track-create")!.click();
-  await flushClientPromises();
+  await createTrack({ title: "Selected Track", description: "Exercise selected-track controls" });
 
   detail.querySelector("#track-workflow-status").value = "review";
   detail.querySelector("#track-workflow-spec-status").value = "approved";
@@ -196,9 +187,7 @@ test("operator UI client harness submits selected-track detail actions", async (
     createdBy: "user",
   });
 
-  detail.querySelector("#run-start-prompt").value = "Implement selected track now.";
-  await detail.querySelector("[data-run-start]").click();
-  await flushClientPromises();
+  await startRun("Implement selected track now.");
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs")?.body, {
     trackId: "track-1",
@@ -207,17 +196,11 @@ test("operator UI client harness submits selected-track detail actions", async (
 });
 
 test("operator UI client harness submits selected-run detail actions", async () => {
-  const { calls, elements } = createHostedUiClientHarness();
-  const detail = elements.get("#detail")!;
-  await flushClientPromises();
+  const { calls, createTrack, detail, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun } = createHostedUiClientHarness();
+  await loadInitialState();
 
-  elements.get("#track-title")!.value = "Run Harness Track";
-  elements.get("#track-description")!.value = "Create a run for selected-run controls";
-  await elements.get("#track-create")!.click();
-  await flushClientPromises();
-  detail.querySelector("#run-start-prompt").value = "Start run for harness.";
-  await detail.querySelector("[data-run-start]").click();
-  await flushClientPromises();
+  await createTrack({ title: "Run Harness Track", description: "Create a run for selected-run controls" });
+  await startRun("Start run for harness.");
 
   detail.querySelector("#run-resume-prompt").value = "Resume with verification.";
   await detail.querySelector("[data-run-resume]").click();
@@ -233,13 +216,11 @@ test("operator UI client harness submits selected-run detail actions", async () 
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs/run-1/cancel")?.body, {});
 
-  await detail.querySelector("[data-cleanup-preview]").click();
-  await flushClientPromises();
+  await requestCleanupPreview();
 
   assert.equal(calls.some((call) => call.method === "GET" && call.path === "/runs/run-1/workspace-cleanup/preview"), true);
 
-  await detail.querySelector("[data-cleanup-request]").click();
-  await flushClientPromises();
+  await requestCleanupConfirmation();
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs/run-1/workspace-cleanup/apply" && (call.body as { confirm?: string }).confirm === "")?.body, {
     confirm: "",

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -109,11 +109,11 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
 - hosted UI client action harness exercises top-level project/track, selected-track, and selected-run click handlers without a browser dependency
-- hosted UI fake DOM/fetch harness is isolated in a focused API test helper
+- hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI harness ergonomics**
-   - add small helper methods for common hosted UI setup flows (create track/run, load cleanup preview) so future action tests stay compact.
+1. **Hosted operator UI artifact approval action harness**
+   - extend the lightweight client action harness into artifact approval approve/reject controls while preserving in-page action handling.


### PR DESCRIPTION
## Summary
- add named hosted UI harness helpers for initial load, track creation, run start, and cleanup setup flows
- shorten hosted UI action tests while keeping assertions visible in `operator-ui.test.ts`
- update README and roadmap with the helper-method baseline and next suggested UI harness target

## Validation
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (110 tests: 109 pass, 1 skipped)
- `pnpm build`

Closes #238
