### PR TITLE
test: cover hosted UI artifact approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, selected-track, and selected-run click handlers without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, and selected-run click handlers without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -18,6 +18,7 @@ export class FakeElement {
   public children: FakeElement[] = [];
   private readonly listeners = new Map<string, Array<(event: { currentTarget: FakeElement }) => unknown>>();
   private readonly descendants = new Map<string, FakeElement>();
+  private readonly descendantLists = new Map<string, FakeElement[]>();
   private readonly attributes = new Map<string, string>();
   private innerHtmlValue = "";
 
@@ -28,6 +29,7 @@ export class FakeElement {
   public set innerHTML(value: string) {
     this.innerHtmlValue = value;
     this.descendants.clear();
+    this.descendantLists.clear();
   }
 
   public addEventListener(type: string, listener: (event: { currentTarget: FakeElement }) => unknown): void {
@@ -71,6 +73,19 @@ export class FakeElement {
   public querySelectorAll(selector: string): FakeElement[] {
     if (selector === "[data-artifact-proposal]") {
       return [this.querySelector(selector)];
+    }
+    if (selector === "[data-approval-id]") {
+      const existing = this.descendantLists.get(selector);
+      if (existing) return existing;
+
+      const buttons = Array.from(this.innerHTML.matchAll(/<button data-approval-id="([^"]*)" data-decision="([^"]*)">/g)).map((match) => {
+        const button = new FakeElement();
+        button.setAttribute("data-approval-id", match[1] ?? "");
+        button.setAttribute("data-decision", match[2] ?? "");
+        return button;
+      });
+      this.descendantLists.set(selector, buttons);
+      return buttons;
     }
     return [];
   }
@@ -117,6 +132,11 @@ export function createHostedUiClientHarness() {
   trackPriority.value = "medium";
 
   const projects = [{ id: "project-1", name: "Project One", repoUrl: "https://example.com/one", localRepoPath: "/repo/one", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" }];
+  const artifactApprovalRequests = {
+    spec: [{ id: "approval-spec-1", status: "pending" }],
+    plan: [{ id: "approval-plan-1", status: "pending" }],
+    tasks: [],
+  };
   const tracks: Array<Record<string, unknown>> = [];
   const runs: Array<Record<string, unknown>> = [];
   const calls: HostedUiFetchCall[] = [];
@@ -180,7 +200,8 @@ export function createHostedUiClientHarness() {
       return { ok: true, json: async () => ({ message: { id: "message-1", ...(body as Record<string, unknown>) } }) };
     }
     if (/^\/tracks\/[^/]+\/artifacts\/(spec|plan|tasks)$/.test(path) && method === "GET") {
-      return { ok: true, json: async () => ({ approvalRequests: [] }) };
+      const artifact = path.split("/").at(-1) as keyof typeof artifactApprovalRequests;
+      return { ok: true, json: async () => ({ approvalRequests: artifactApprovalRequests[artifact] }) };
     }
     if (/^\/tracks\/[^/]+\/artifacts\/(spec|plan|tasks)$/.test(path) && method === "POST") {
       return { ok: true, json: async () => ({ revision: { id: "revision-1", ...(body as Record<string, unknown>) } }) };
@@ -215,6 +236,9 @@ export function createHostedUiClientHarness() {
         return { ok: true, json: async () => ({ expectedConfirmation: "APPLY CLEANUP run-1" }) };
       }
       return { ok: true, json: async () => ({ cleanupResult: { status: "completed", failures: [] } }) };
+    }
+    if (/^\/approval-requests\/[^/]+\/(approve|reject)$/.test(path) && method === "POST") {
+      return { ok: true, json: async () => ({ approvalRequest: { id: path.split("/")[2], ...(body as Record<string, unknown>) } }) };
     }
     throw new Error(`Unhandled fetch ${method} ${path}`);
   }

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -187,6 +187,24 @@ test("operator UI client harness submits selected-track detail actions", async (
     createdBy: "user",
   });
 
+  const [approveButton] = detail.querySelectorAll("[data-approval-id]");
+  await approveButton.click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/approval-requests/approval-spec-1/approve")?.body, {
+    decidedBy: "user",
+    comment: "decided from hosted operator UI",
+  });
+
+  const [, , , rejectButton] = detail.querySelectorAll("[data-approval-id]");
+  await rejectButton.click();
+  await flushClientPromises();
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/approval-requests/approval-plan-1/reject")?.body, {
+    decidedBy: "user",
+    comment: "decided from hosted operator UI",
+  });
+
   await startRun("Implement selected track now.");
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs")?.body, {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, selected-track, and selected-run click handlers without a browser dependency
+- hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, and selected-run click handlers without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI artifact approval action harness**
-   - extend the lightweight client action harness into artifact approval approve/reject controls while preserving in-page action handling.
+1. **Hosted operator UI event stream lifecycle harness**
+   - add no-dependency coverage for EventSource lifecycle wiring (start/close/error handling) without introducing a browser runner.


### PR DESCRIPTION
## Summary
- seed pending artifact approval requests in the hosted UI client harness
- exercise approval approve/reject buttons through fake DOM click handlers and assert decision requests
- update README and roadmap with artifact approval harness coverage and the next recommended UI target

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (110 tests: 109 pass, 1 skipped)
- `pnpm build`

Closes #240
