### PR TITLE
test: cover hosted UI event streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, and selected-run click handlers without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -106,6 +106,32 @@ export class FakeElement {
   }
 }
 
+export class FakeEventSource {
+  public onerror: (() => void) | undefined;
+  public closed = false;
+  private readonly listeners = new Map<string, Array<(message: { data: string }) => void>>();
+
+  public constructor(public readonly url: string) {}
+
+  public addEventListener(type: string, listener: (message: { data: string }) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  public emit(type: string, data: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ data: JSON.stringify(data) });
+    }
+  }
+
+  public fail(): void {
+    this.onerror?.();
+  }
+
+  public close(): void {
+    this.closed = true;
+  }
+}
+
 export function createHostedUiClientHarness() {
   const selectors = [
     "#project-scope",
@@ -140,6 +166,7 @@ export function createHostedUiClientHarness() {
   const tracks: Array<Record<string, unknown>> = [];
   const runs: Array<Record<string, unknown>> = [];
   const calls: HostedUiFetchCall[] = [];
+  const eventSources: FakeEventSource[] = [];
   let projectCounter = 2;
   let trackCounter = 1;
   let runCounter = 1;
@@ -243,6 +270,13 @@ export function createHostedUiClientHarness() {
     throw new Error(`Unhandled fetch ${method} ${path}`);
   }
 
+  const EventSource = class extends FakeEventSource {
+    public constructor(url: string) {
+      super(url);
+      eventSources.push(this);
+    }
+  };
+
   vm.runInNewContext(renderOperatorUiClientScript(), {
     document,
     fetch,
@@ -254,7 +288,7 @@ export function createHostedUiClientHarness() {
         this.value = value;
       }
     },
-    EventSource: undefined,
+    EventSource,
   });
 
   const detail = elements.get("#detail")!;
@@ -287,7 +321,7 @@ export function createHostedUiClientHarness() {
     await flushClientPromises();
   }
 
-  return { calls, detail, elements, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun };
+  return { calls, detail, elements, eventSources, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun };
 }
 
 export async function flushClientPromises(): Promise<void> {

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -214,15 +214,25 @@ test("operator UI client harness submits selected-track detail actions", async (
 });
 
 test("operator UI client harness submits selected-run detail actions", async () => {
-  const { calls, createTrack, detail, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun } = createHostedUiClientHarness();
+  const { calls, createTrack, detail, elements, eventSources, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun } = createHostedUiClientHarness();
   await loadInitialState();
 
   await createTrack({ title: "Run Harness Track", description: "Create a run for selected-run controls" });
   await startRun("Start run for harness.");
 
+  assert.equal(eventSources.at(-1)?.url, "/runs/run-1/events/stream");
+
+  eventSources.at(-1)?.emit("execution-event", { type: "log", summary: "streamed event", timestamp: "2026-01-01T00:00:00.000Z" });
+
+  assert.equal(detail.querySelector("#run-events").children.length, 1);
+  assert.equal(elements.get("#status")?.textContent, "Live event received for run-1.");
+
   detail.querySelector("#run-resume-prompt").value = "Resume with verification.";
   await detail.querySelector("[data-run-resume]").click();
   await flushClientPromises();
+
+  assert.equal(eventSources[0]?.closed, true);
+  assert.equal(eventSources.at(-1)?.url, "/runs/run-1/events/stream");
 
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs/run-1/resume")?.body, {
     prompt: "Resume with verification.",
@@ -232,7 +242,15 @@ test("operator UI client harness submits selected-run detail actions", async () 
   await detail.querySelector("[data-run-cancel]").click();
   await flushClientPromises();
 
+  assert.equal(eventSources.at(-2)?.closed, true);
+  assert.equal(eventSources.at(-1)?.url, "/runs/run-1/events/stream");
+
   assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/runs/run-1/cancel")?.body, {});
+
+  eventSources.at(-1)?.fail();
+
+  assert.equal(eventSources.at(-1)?.closed, true);
+  assert.equal(elements.get("#status")?.textContent, "Live event stream disconnected for run-1; recent events remain visible.");
 
   await requestCleanupPreview();
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, and selected-run click handlers without a browser dependency
+- hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI event stream lifecycle harness**
-   - add no-dependency coverage for EventSource lifecycle wiring (start/close/error handling) without introducing a browser runner.
+1. **Hosted operator UI project-scope selection harness**
+   - add no-dependency client coverage for switching project scope and preserving the existing `/tracks?projectId=...` HTTP contract.


### PR DESCRIPTION
## Summary
- add a lightweight fake EventSource to the hosted UI client harness
- verify selected-run detail opens the event stream, appends live messages, closes old streams on refresh, and reports disconnects
- update README and roadmap baseline with event stream lifecycle harness coverage

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (110 tests: 109 pass, 1 skipped)
- `pnpm build`

Closes #242
