### PR TITLE
test: cover hosted UI project scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -42,6 +42,12 @@ export class FakeElement {
     }
   }
 
+  public async change(): Promise<void> {
+    for (const listener of this.listeners.get("change") ?? []) {
+      await listener({ currentTarget: this });
+    }
+  }
+
   public replaceChildren(...children: FakeElement[]): void {
     this.children = children;
   }
@@ -157,7 +163,10 @@ export function createHostedUiClientHarness() {
   const trackPriority = elements.get("#track-priority")!;
   trackPriority.value = "medium";
 
-  const projects = [{ id: "project-1", name: "Project One", repoUrl: "https://example.com/one", localRepoPath: "/repo/one", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" }];
+  const projects = [
+    { id: "project-1", name: "Project One", repoUrl: "https://example.com/one", localRepoPath: "/repo/one", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" },
+    { id: "project-2", name: "Project Two", repoUrl: "https://example.com/two", localRepoPath: "/repo/two", defaultWorkflowPolicy: "standard", defaultPlanningSystem: "native" },
+  ];
   const artifactApprovalRequests = {
     spec: [{ id: "approval-spec-1", status: "pending" }],
     plan: [{ id: "approval-plan-1", status: "pending" }],
@@ -167,7 +176,7 @@ export function createHostedUiClientHarness() {
   const runs: Array<Record<string, unknown>> = [];
   const calls: HostedUiFetchCall[] = [];
   const eventSources: FakeEventSource[] = [];
-  let projectCounter = 2;
+  let projectCounter = 3;
   let trackCounter = 1;
   let runCounter = 1;
   let planningSessionId: string | undefined;
@@ -202,7 +211,9 @@ export function createHostedUiClientHarness() {
       return { ok: true, json: async () => ({ project }) };
     }
     if (path.startsWith("/tracks?page=1&pageSize=20") && method === "GET") {
-      return { ok: true, json: async () => ({ tracks }) };
+      const projectId = new URLSearchParams(path.slice(path.indexOf("?") + 1)).get("projectId");
+      const filteredTracks = projectId === null ? tracks : tracks.filter((track) => track.projectId === projectId);
+      return { ok: true, json: async () => ({ tracks: filteredTracks }) };
     }
     if (path === "/tracks" && method === "POST") {
       const track = { id: `track-${trackCounter++}`, status: "new", ...(body as Record<string, unknown>) };
@@ -311,6 +322,12 @@ export function createHostedUiClientHarness() {
     await flushClientPromises();
   }
 
+  async function selectProject(projectId: string): Promise<void> {
+    scope.value = projectId;
+    await scope.change();
+    await flushClientPromises();
+  }
+
   async function requestCleanupPreview(): Promise<void> {
     await detail.querySelector("[data-cleanup-preview]").click();
     await flushClientPromises();
@@ -321,7 +338,7 @@ export function createHostedUiClientHarness() {
     await flushClientPromises();
   }
 
-  return { calls, detail, elements, eventSources, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun };
+  return { calls, detail, elements, eventSources, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, selectProject, startRun };
 }
 
 export async function flushClientPromises(): Promise<void> {

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -115,7 +115,7 @@ test("operator UI client harness submits top-level project and track actions", a
   await elements.get("#project-update")!.click();
   await flushClientPromises();
 
-  assert.deepEqual(calls.find((call) => call.method === "PATCH" && call.path === "/projects/project-2")?.body, {
+  assert.deepEqual(calls.find((call) => call.method === "PATCH" && call.path === "/projects/project-3")?.body, {
     name: "Project Two Updated",
     repoUrl: null,
     localRepoPath: "/repo/two-updated",
@@ -133,6 +133,34 @@ test("operator UI client harness submits top-level project and track actions", a
   });
   assert.equal(elements.get("#track-title")!.value, "");
   assert.equal(elements.get("#track-priority")!.value, "medium");
+});
+
+test("operator UI client harness filters tracks by project scope", async () => {
+  const { calls, createTrack, elements, loadInitialState, selectProject } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  await selectProject("project-1");
+  await createTrack({ title: "Project One Track" });
+
+  assert.deepEqual(calls.find((call) => call.method === "POST" && call.path === "/tracks")?.body, {
+    projectId: "project-1",
+    title: "Project One Track",
+    description: "",
+    priority: "medium",
+  });
+
+  await selectProject("project-2");
+  await createTrack({ title: "Project Two Track" });
+
+  const scopedTrackLoads = calls.filter((call) => call.method === "GET" && call.path.startsWith("/tracks?page=1&pageSize=20"));
+  assert.ok(scopedTrackLoads.some((call) => call.path === "/tracks?page=1&pageSize=20&projectId=project-1"));
+  assert.ok(scopedTrackLoads.some((call) => call.path === "/tracks?page=1&pageSize=20&projectId=project-2"));
+  assert.equal(elements.get("#tracks")?.children.length, 1);
+
+  await selectProject("");
+
+  assert.equal(calls.at(-2)?.path, "/tracks?page=1&pageSize=20");
+  assert.equal(elements.get("#status")?.textContent, "Loaded 2 projects, 2 tracks, and 0 runs.");
 });
 
 test("operator UI client harness submits selected-track detail actions", async () => {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI project-scope selection harness**
-   - add no-dependency client coverage for switching project scope and preserving the existing `/tracks?projectId=...` HTTP contract.
+1. **Hosted operator UI selected-detail failure harness**
+   - add no-dependency client coverage for failed selected-track/run detail loads and user-visible detail error messages.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for project-scope selection
- seed multiple projects in the fake harness and filter track listing responses by `projectId`
- verify scope changes preserve the existing `/tracks?projectId=...` HTTP contract and unscoped reset behavior
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (111 tests: 110 pass, 1 skipped)
- `pnpm build`

Closes #244
