### PR TITLE
test: cover hosted UI detail failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -176,6 +176,7 @@ export function createHostedUiClientHarness() {
   const runs: Array<Record<string, unknown>> = [];
   const calls: HostedUiFetchCall[] = [];
   const eventSources: FakeEventSource[] = [];
+  const failedPaths = new Map<string, string>();
   let projectCounter = 3;
   let trackCounter = 1;
   let runCounter = 1;
@@ -196,6 +197,11 @@ export function createHostedUiClientHarness() {
     const method = init?.method ?? "GET";
     const body = init?.body === undefined ? undefined : JSON.parse(init.body);
     calls.push({ path, method, body });
+
+    const failureMessage = failedPaths.get(`${method} ${path}`) ?? failedPaths.get(path);
+    if (failureMessage !== undefined) {
+      return { ok: false, text: async () => failureMessage, json: async () => ({ message: failureMessage }) };
+    }
 
     if (path === "/projects" && method === "GET") {
       return { ok: true, json: async () => ({ projects }) };
@@ -308,6 +314,10 @@ export function createHostedUiClientHarness() {
     await flushClientPromises();
   }
 
+  function failPath(path: string, message: string, method = "GET"): void {
+    failedPaths.set(`${method} ${path}`, message);
+  }
+
   async function createTrack(input: { title: string; description?: string; priority?: string }): Promise<void> {
     elements.get("#track-title")!.value = input.title;
     elements.get("#track-description")!.value = input.description ?? "";
@@ -338,7 +348,7 @@ export function createHostedUiClientHarness() {
     await flushClientPromises();
   }
 
-  return { calls, detail, elements, eventSources, scope, createTrack, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, selectProject, startRun };
+  return { calls, detail, elements, eventSources, scope, createTrack, failPath, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, selectProject, startRun };
 }
 
 export async function flushClientPromises(): Promise<void> {

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -163,6 +163,27 @@ test("operator UI client harness filters tracks by project scope", async () => {
   assert.equal(elements.get("#status")?.textContent, "Loaded 2 projects, 2 tracks, and 0 runs.");
 });
 
+test("operator UI client harness surfaces selected-detail load failures", async () => {
+  const { detail, elements, createTrack, failPath, loadInitialState, startRun } = createHostedUiClientHarness();
+  await loadInitialState();
+  await createTrack({ title: "Failure Detail Track" });
+
+  failPath("/tracks/track-1", "track detail unavailable");
+  await elements.get("#tracks")!.children[0]!.click();
+  await flushClientPromises();
+
+  assert.equal(detail.className, "muted");
+  assert.equal(detail.textContent, "track detail unavailable");
+
+  failPath("/runs/run-1", "run detail unavailable");
+  await startRun("Start run before failure check");
+  await elements.get("#runs")!.children[0]!.click();
+  await flushClientPromises();
+
+  assert.equal(detail.className, "muted");
+  assert.equal(detail.textContent, "run detail unavailable");
+});
+
 test("operator UI client harness submits selected-track detail actions", async () => {
   const { calls, createTrack, detail, loadInitialState, startRun } = createHostedUiClientHarness();
   await loadInitialState();

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI selected-detail failure harness**
-   - add no-dependency client coverage for failed selected-track/run detail loads and user-visible detail error messages.
+1. **Hosted operator UI form validation harness**
+   - add no-dependency client coverage for required form fields and user-visible validation messages before HTTP requests are submitted.


### PR DESCRIPTION
## Summary
- add controlled fetch failure injection to the hosted UI fake harness
- verify selected track and selected run detail load failures render muted detail-pane error messages
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (112 tests: 111 pass, 1 skipped)
- `pnpm build`

Closes #246
