### PR TITLE
test: cover hosted UI form validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -184,6 +184,46 @@ test("operator UI client harness surfaces selected-detail load failures", async 
   assert.equal(detail.textContent, "run detail unavailable");
 });
 
+test("operator UI client harness blocks invalid form submissions", async () => {
+  const { calls, createTrack, detail, elements, loadInitialState } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  await elements.get("#project-create")!.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Project name is required.");
+  assert.equal(calls.some((call) => call.method === "POST" && call.path === "/projects"), false);
+
+  await elements.get("#track-create")!.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Track title is required.");
+  assert.equal(calls.some((call) => call.method === "POST" && call.path === "/tracks"), false);
+
+  await createTrack({ title: "Validation Track" });
+  const callsBeforeSelectedDetailValidation = calls.length;
+
+  await detail.querySelector("[data-planning-message-append]").click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Planning message body is required for track-1.");
+  assert.equal(calls.length, callsBeforeSelectedDetailValidation);
+
+  detail.querySelector("#run-start-prompt").value = "";
+  await detail.querySelector("[data-run-start]").click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Run start prompt is required for track-1.");
+  assert.equal(calls.some((call) => call.method === "POST" && call.path === "/runs"), false);
+
+  detail.querySelector("#artifact-proposal-content").value = "";
+  await detail.querySelector("[data-artifact-proposal]").click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Artifact proposal content is required for spec.");
+  assert.equal(calls.some((call) => call.method === "POST" && call.path === "/tracks/track-1/artifacts/spec"), false);
+});
+
 test("operator UI client harness submits selected-track detail actions", async () => {
   const { calls, createTrack, detail, loadInitialState, startRun } = createHostedUiClientHarness();
   await loadInitialState();

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI form validation harness**
-   - add no-dependency client coverage for required form fields and user-visible validation messages before HTTP requests are submitted.
+1. **Hosted operator UI action failure harness**
+   - add no-dependency client coverage for failed POST/PATCH actions and user-visible status errors while preserving button re-enable behavior.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for required-field validation guardrails
- verify invalid project/track creation does not submit HTTP POSTs
- verify representative selected-detail validation messages block planning, run, and artifact submissions
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (113 tests: 112 pass, 1 skipped)
- `pnpm build`

Closes #248
