### PR TITLE
test: cover hosted UI action failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -224,6 +224,30 @@ test("operator UI client harness blocks invalid form submissions", async () => {
   assert.equal(calls.some((call) => call.method === "POST" && call.path === "/tracks/track-1/artifacts/spec"), false);
 });
 
+test("operator UI client harness surfaces failed mutating actions", async () => {
+  const { createTrack, detail, elements, failPath, loadInitialState, selectProject } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  await selectProject("project-1");
+  elements.get("#project-name")!.value = "Project One Update";
+  failPath("/projects/project-1", "project update refused", "PATCH");
+  await elements.get("#project-update")!.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "project update refused");
+  assert.equal(elements.get("#project-update")!.disabled, false);
+
+  await createTrack({ title: "Action Failure Track" });
+  detail.querySelector("#track-workflow-status").value = "review";
+  failPath("/tracks/track-1", "track update refused", "PATCH");
+  const trackUpdateButton = detail.querySelector("[data-track-update]");
+  await trackUpdateButton.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "track update refused");
+  assert.equal(trackUpdateButton.disabled, false);
+});
+
 test("operator UI client harness submits selected-track detail actions", async () => {
   const { calls, createTrack, detail, loadInitialState, startRun } = createHostedUiClientHarness();
   await loadInitialState();

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI action failure harness**
-   - add no-dependency client coverage for failed POST/PATCH actions and user-visible status errors while preserving button re-enable behavior.
+1. **Hosted operator UI cleanup failure harness**
+   - add no-dependency client coverage for workspace cleanup preview/apply refusals and user-visible status/detail behavior.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for failed mutating actions
- verify failed project update and track update actions surface API error text in the status area
- verify failed-action buttons are re-enabled after errors
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (114 tests: 113 pass, 1 skipped)
- `pnpm build`

Closes #250
