### PR TITLE
test: cover hosted UI cleanup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -386,6 +386,30 @@ test("operator UI client harness submits selected-run detail actions", async () 
   });
 });
 
+test("operator UI client harness surfaces cleanup failure states", async () => {
+  const { createTrack, detail, elements, failPath, loadInitialState, requestCleanupPreview, startRun } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  await createTrack({ title: "Cleanup Failure Track" });
+  await startRun("Start run before cleanup failure checks.");
+
+  failPath("/runs/run-1/workspace-cleanup/preview", "cleanup preview refused");
+  const previewButton = detail.querySelector("[data-cleanup-preview]");
+  await requestCleanupPreview();
+
+  assert.equal(elements.get("#status")!.textContent, "Cleanup preview refreshed for run-1.");
+  assert.match(detail.innerHTML, /cleanup preview refused/);
+  assert.equal(previewButton.disabled, false);
+
+  failPath("/runs/run-1/workspace-cleanup/apply", "cleanup confirmation refused", "POST");
+  const requestButton = detail.querySelector("[data-cleanup-request]");
+  await requestButton.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "cleanup confirmation refused");
+  assert.equal(requestButton.disabled, false);
+});
+
 test("operator UI shell keeps hosted action and stream wiring", () => {
   const body = renderOperatorUiHtml();
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI cleanup failure harness**
-   - add no-dependency client coverage for workspace cleanup preview/apply refusals and user-visible status/detail behavior.
+1. **Hosted operator UI refresh failure harness**
+   - add no-dependency client coverage for top-level refresh/load failures and user-visible status errors.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for cleanup preview and confirmation failure states
- verify cleanup preview refusals render in the run detail pane
- verify cleanup confirmation failures surface API error text and re-enable the action button
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (115 tests: 114 pass, 1 skipped)
- `pnpm build`

Closes #252
