### PR TITLE
test: cover hosted UI refresh failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -163,6 +163,18 @@ test("operator UI client harness filters tracks by project scope", async () => {
   assert.equal(elements.get("#status")?.textContent, "Loaded 2 projects, 2 tracks, and 0 runs.");
 });
 
+test("operator UI client harness surfaces top-level refresh failures", async () => {
+  const { elements, failPath, loadInitialState } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  failPath("/runs?page=1&pageSize=20", "run list unavailable");
+  await elements.get("#refresh")!.click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "run list unavailable");
+  assert.equal(elements.get("#refresh")!.disabled, false);
+});
+
 test("operator UI client harness surfaces selected-detail load failures", async () => {
   const { detail, elements, createTrack, failPath, loadInitialState, startRun } = createHostedUiClientHarness();
   await loadInitialState();

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -585,8 +585,10 @@ export function renderOperatorUiClientScript(): string {
       populateProjectForm(scope.value);
       load().catch((error) => { status.textContent = errorMessage(error); });
     });
-    refresh.addEventListener('click', load);
-    load().catch((error) => { status.textContent = error instanceof Error ? error.message : String(error); });
+    refresh.addEventListener('click', () => {
+      load().catch((error) => { status.textContent = errorMessage(error); });
+    });
+    load().catch((error) => { status.textContent = errorMessage(error); });
 `;
 }
 

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI refresh failure harness**
-   - add no-dependency client coverage for top-level refresh/load failures and user-visible status errors.
+1. **Hosted operator UI cleanup confirmation validation harness**
+   - add no-dependency client coverage for missing cleanup confirmation text before apply requests are submitted.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for top-level refresh/list failures
- route manual refresh click errors into the status area instead of letting the rejected promise escape
- verify the refresh button is re-enabled after a failed run-list load
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (116 tests: 115 pass, 1 skipped)
- `pnpm build`

Closes #254
