### PR TITLE
test: cover cleanup confirmation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Current endpoints in `apps/api/src/index.ts`:
   - destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
   - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area
   - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-  - hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+  - hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, cleanup confirmation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
   - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 
 ### Projects

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -398,6 +398,25 @@ test("operator UI client harness submits selected-run detail actions", async () 
   });
 });
 
+test("operator UI client harness blocks blank cleanup confirmation", async () => {
+  const { calls, createTrack, detail, elements, loadInitialState, requestCleanupConfirmation, requestCleanupPreview, startRun } = createHostedUiClientHarness();
+  await loadInitialState();
+
+  await createTrack({ title: "Cleanup Validation Track" });
+  await startRun("Start run before cleanup validation.");
+  await requestCleanupPreview();
+  await requestCleanupConfirmation();
+
+  const cleanupApplyCallsBeforeValidation = calls.filter((call) => call.method === "POST" && call.path === "/runs/run-1/workspace-cleanup/apply");
+
+  detail.querySelector("#cleanup-confirmation").value = "   ";
+  await detail.querySelector("[data-cleanup-apply]").click();
+  await flushClientPromises();
+
+  assert.equal(elements.get("#status")!.textContent, "Cleanup confirmation phrase is required for run-1.");
+  assert.deepEqual(calls.filter((call) => call.method === "POST" && call.path === "/runs/run-1/workspace-cleanup/apply"), cleanupApplyCallsBeforeValidation);
+});
+
 test("operator UI client harness surfaces cleanup failure states", async () => {
   const { createTrack, detail, elements, failPath, loadInitialState, requestCleanupPreview, startRun } = createHostedUiClientHarness();
   await loadInitialState();

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -108,12 +108,12 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 - hosted UI destructive run cancel and workspace cleanup apply flows use in-page confirmation controls
 - hosted UI tests guard against reintroducing browser-native prompt/confirm dialogs and group shell coverage by action area without adding a frontend build pipeline
 - hosted UI markup exposes stable `data-control-group` selectors for major action areas
-- hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
+- hosted UI client action harness exercises top-level project/track, project-scope filtering, refresh failure states, form validation guardrails, cleanup confirmation guardrails, action failure states, cleanup failure states, selected-detail failure states, selected-track, artifact approval, selected-run click handlers, and live event stream lifecycle without a browser dependency
 - hosted UI fake DOM/fetch harness is isolated in a focused API test helper with named setup-flow methods
 - keep HTTP/SSE as the system of record for new clients
 - reuse existing approval, event, and listing APIs rather than inventing parallel workflows
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI cleanup confirmation validation harness**
-   - add no-dependency client coverage for missing cleanup confirmation text before apply requests are submitted.
+1. **Hosted operator UI run lifecycle validation harness**
+   - add no-dependency client coverage for blank resume prompts and invalid cancel confirmation before run lifecycle requests are submitted.


### PR DESCRIPTION
## Summary
- add hosted UI client harness coverage for blank cleanup confirmation validation
- verify blank cleanup apply shows the user-visible guardrail message
- verify invalid cleanup apply attempts do not submit another apply request
- update README and roadmap baseline/next recommendation

## Validation
- `pnpm --filter @specrail/api check`
- `pnpm test -- apps/api/src/__tests__/operator-ui.test.ts`
- `pnpm check:links`
- `pnpm check`
- `pnpm test` (117 tests: 116 pass, 1 skipped)
- `pnpm build`

Closes #256
