### PR TITLE
test: stabilize API run lifecycle event count

### DIFF
--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -659,7 +659,7 @@ test("API supports resuming and cancelling a run", async () => {
     assert.equal(resumedPayload.run.status, "running");
     assert.equal(resumedPayload.run.command?.prompt, "Continue with verification");
     assert.ok(resumedPayload.run.command?.resumeSessionRef);
-    assert.equal(resumedPayload.run.summary?.eventCount, 3);
+    assert.ok((resumedPayload.run.summary?.eventCount ?? 0) >= 3);
     assert.match(resumedPayload.run.summary?.lastEventSummary ?? "", /Resumed Codex session/);
 
     const cancelResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/cancel`, {

--- a/docs/architecture/mvp-roadmap.md
+++ b/docs/architecture/mvp-roadmap.md
@@ -115,5 +115,5 @@ This roadmap reflects the implemented MVP baseline and the next practical gaps t
 
 ## Suggested issue framing from the current baseline
 
-1. **Hosted operator UI artifact proposal validation harness**
-   - add no-dependency client coverage for blank artifact proposal content before proposal requests are submitted.
+1. **API run lifecycle event summary contract cleanup**
+   - document or refine which execution events are guaranteed at resume/cancel response boundaries versus eventually appended by adapters.


### PR DESCRIPTION
Closes #261.\n\n## Summary\n- relax resume response event-count assertion to avoid exact timing dependence\n- keep resume semantics checks for running status, prompt, resume session reference, and resume summary\n- refresh roadmap next issue framing toward run lifecycle event summary contract cleanup\n\n## Validation\n- pnpm --filter @specrail/api check\n- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/api/src/__tests__/*.test.ts\n- pnpm check:links\n- pnpm check\n- pnpm test\n- pnpm build