### PR TITLE
docs: update architecture overview in Korean

### DIFF
--- a/docs/architecture/mvp-architecture.md
+++ b/docs/architecture/mvp-architecture.md
@@ -1,160 +1,600 @@
-# SpecRail MVP Architecture
+# SpecRail MVP 아키텍처
 
-## Goal
+이 문서는 현재 구현된 SpecRail MVP의 실행 가능한 아키텍처를 기준으로 정리한다. 과거 설계 의도가 아니라, 현재 코드가 제공하는 서비스 경계, 데이터 흐름, 저장소 구조, 클라이언트 표면을 설명한다.
 
-Build a practical v1 service that combines:
-- durable planning artifacts
-- file-backed project, track, planning, run, channel, and attachment state
-- local executor paths for Codex and Claude Code
-- machine-readable interfaces for HTTP/SSE, ACP, terminal, and thin chat clients
+## 목표
 
-The current MVP supports these caller flows:
-1. create a track and materialize `spec.md`, `plan.md`, and `tasks.md`
-2. inspect, list, sort, and update track workflow state
-3. create planning sessions, append planning messages, propose artifact revisions, and approve/reject revisions
-4. start Codex-backed or Claude Code-backed runs in isolated workspace directories
-5. persist normalized execution events, summaries, provider metadata, and linked planning context
-6. resume or cancel existing runs
-7. read run events through JSON history or SSE streams
-8. bind external channels, register attachment references, and project runs through terminal, Telegram, and ACP edge adapters
+SpecRail은 코딩 에이전트 작업을 `spec -> plan -> tasks -> run -> inspect/resume/cancel` 흐름으로 관리하는 파일 기반 오케스트레이션 서비스다.
 
-## Current system slices
+현재 MVP의 핵심 목표는 다음과 같다.
 
-### 1. Control plane
+- 프로젝트와 트랙 단위로 작업 맥락을 분리한다.
+- `spec.md`, `plan.md`, `tasks.md`를 지속 가능한 산출물로 관리한다.
+- 계획 세션, 산출물 제안, 승인/거절 흐름을 기록한다.
+- Codex와 Claude Code 실행을 동일한 실행 이벤트 모델로 정규화한다.
+- HTTP/JSON, SSE, Hosted Operator UI, Terminal, Telegram, ACP edge adapter가 같은 코어 서비스와 파일 상태를 바라보게 한다.
+- 런 이벤트, 실행 메타데이터, 세션 메타데이터를 재시작/복구 가능한 형태로 저장한다.
 
-Owns product, planning, workflow, and artifact state.
+## 전체 시스템 구조
 
-Currently implemented:
-- default project bootstrap
-- track creation, inspection, listing, sorting, and workflow/approval status updates
-- generated per-track `spec.md`, `plan.md`, `tasks.md`, and reserved runtime artifact `events.jsonl` placeholders
-- planning sessions and planning messages
-- artifact revision proposal and approval request workflows
-- approved artifact materialization back into the artifact tree
-- file-backed repositories for projects, tracks, planning sessions, artifact revisions, approval requests, channel bindings, attachment references, and executions
-- JSONL-backed execution and planning-message stores
+```mermaid
+flowchart LR
+  subgraph Clients["클라이언트 / Edge 표면"]
+    Operator["Hosted Operator UI\nGET /operator"]
+    Terminal["Terminal client"]
+    Telegram["Telegram adapter"]
+    ACP["ACP stdio adapter"]
+    HTTP["HTTP JSON/SSE clients"]
+  end
 
-Primary artifacts:
-- Markdown: `spec.md`, `plan.md`, `tasks.md`, index/workflow/track summaries
-- JSON: project, track, planning, approval, channel, attachment, and execution metadata
-- JSONL: authoritative run events, planning messages, and session-local adapter events
+  subgraph API["apps/api"]
+    Router["HTTP 라우터\n검증 / 에러 매핑 / SSE"]
+    UiRenderer["operator-ui.ts\n단일 HTML 셸 렌더링"]
+  end
 
-Event-history ownership:
-- `state/events/<runId>.jsonl` is the canonical run-event log used by HTTP history, SSE replay, run summaries, and lifecycle reconciliation.
-- `sessions/<sessionRef>.events.jsonl` is provider-adapter telemetry for debugging and replaying executor output; normalized domain events are copied into `state/events/<runId>.jsonl`.
-- `artifacts/tracks/<trackId>/events.jsonl` is a reserved runtime artifact placeholder in the current MVP. It is not read by the API and must not be treated as the source of truth.
-- the repo-visible artifact tree intentionally contains only `spec.md`, `plan.md`, `tasks.md`, and `sync.json` for each track; run history should be exposed through API/SSE until a future export contract is designed.
+  subgraph Core["packages/core"]
+    Service["SpecRailService"]
+    Domain["도메인 타입 / 상태 전이"]
+    Repos["파일 기반 Repository"]
+    EventStore["JSONL EventStore"]
+  end
 
-### 2. Execution plane
+  subgraph Adapters["packages/adapters"]
+    Codex["Codex executor"]
+    Claude["Claude Code executor"]
+    GitHub["GitHub integration boundary"]
+    OpenSpec["OpenSpec integration boundary"]
+  end
 
-Owns runtime orchestration.
+  subgraph Config["packages/config"]
+    Paths["경로 / 설정 로딩"]
+    Artifacts["산출물 materialization"]
+  end
 
-Currently implemented:
-- workspace directory allocation per run
-- backend selection between `codex` and `claude_code`
-- persisted execution backend/profile normalization
-- local Codex spawn/resume/cancel lifecycle
-- local Claude Code process-backed execution with stream-event promotion
-- persisted session metadata, provider metadata, and last-message files
-- normalized lifecycle, stream, approval, message, tool, result, and summary events where supported by the backend
-- run summary derivation from persisted events
-- terminal-state reconciliation back into track status (`completed -> review`, `failed -> failed`, `cancelled -> blocked`)
-- planning-context capture for runs, including stale-context rejection when newer planning revisions are pending approval
-- executor callback delivery for runtime approval decisions through Codex and Claude Code resume/no-retry fallbacks
+  subgraph Storage["SPECRAIL_DATA_DIR"]
+    State["state/*.json"]
+    Events["state/events/*.jsonl"]
+    ArtifactTree["artifacts/tracks/*/*.md"]
+    Sessions["sessions/*"]
+    Workspaces["workspaces/<runId>/"]
+  end
 
-Currently not implemented:
-- worktree/git orchestration beyond metadata/workspace path allocation
-- provider-native permission continuation beyond normal resume fallback behavior
-- scheduler/queue management
+  Operator --> Router
+  Terminal --> Router
+  Telegram --> Router
+  ACP --> Router
+  HTTP --> Router
+  Router --> UiRenderer
+  Router --> Service
+  Service --> Domain
+  Service --> Repos
+  Service --> EventStore
+  Service --> Codex
+  Service --> Claude
+  Service --> GitHub
+  Service --> OpenSpec
+  Service --> Paths
+  Service --> Artifacts
+  Repos --> State
+  EventStore --> Events
+  Artifacts --> ArtifactTree
+  Codex --> Sessions
+  Claude --> Sessions
+  Service --> Workspaces
+```
 
-### 3. Interface plane
+## 계층별 책임
 
-Owns how external callers interact with the service.
+### 1. Control Plane
 
-Currently implemented:
-- Node HTTP API
-- JSON responses
-- SSE event stream
-- request validation and structured API errors
-- terminal client surfaces for track/run inspection, planning, execution controls, backend/profile selection, run filters, and live event following
-- ACP stdio edge adapter that maps ACP sessions onto SpecRail runs while keeping HTTP/SSE as the system of record
-- thin Telegram adapter that binds chats to tracks, registers attachment references, and relays run events
-- GitHub/OpenSpec integration surfaces for import/export and run-summary publication
+제품/작업/계획/산출물 상태를 소유한다.
 
-Deferred:
-- web UI
-- production auth/authz and multi-user access control
-- GitHub app/webhook automation
+구현된 기능:
+
+- 기본 프로젝트 bootstrap
+- 프로젝트 생성, 조회, 수정
+- 트랙 생성, 조회, 목록, 정렬, 필터링
+- 트랙 workflow 상태와 `specStatus`, `planStatus` 업데이트
+- 트랙별 `spec.md`, `plan.md`, `tasks.md` 생성 및 승인된 revision materialization
+- 계획 세션 생성과 계획 메시지 JSONL 저장
+- `spec`, `plan`, `tasks` 산출물 revision 제안
+- 산출물 approval request 생성, 승인, 거절
+- 채널 바인딩과 첨부파일 reference 등록
+- 실행 기록과 이벤트 로그를 통한 run summary 재계산
+
+주요 파일:
+
+- Markdown: `spec.md`, `plan.md`, `tasks.md`, 프로젝트 인덱스/워크플로우/트랙 요약
+- JSON: project, track, planning session, artifact revision, approval request, channel binding, attachment, execution metadata
+- JSONL: run events, planning messages, provider adapter events
+
+### 2. Execution Plane
+
+에이전트 실행 생명주기와 provider adapter 연동을 소유한다.
+
+구현된 기능:
+
+- run별 workspace 경로 할당
+- `codex`, `claude_code` backend 선택
+- backend/profile/sessionRef/provider metadata 영속화
+- Codex spawn/resume/cancel 생명주기
+- Claude Code process-backed 실행과 stream event 정규화
+- run start/resume/cancel 이벤트 저장
+- provider stdout/stderr, assistant message, tool call/result, approval-like signal을 공통 이벤트 모델로 승격
+- planning context capture와 stale planning context run 거절
+- runtime approval decision을 domain event로 기록하고 executor callback으로 전달
+- terminal 결과 기반 track 상태 reconciliation
+- workspace cleanup preview/apply 안전 흐름
+
+아직 MVP 범위 밖:
+
+- scheduler/queue 관리
+- production-grade provider-native permission continuation
+- 완전한 git branch/worktree orchestration 자동화
+
+### 3. Interface Plane
+
+외부 호출자가 SpecRail을 사용하는 표면을 소유한다.
+
+구현된 표면:
+
+- HTTP JSON API
+- `GET /runs/:runId/events/stream` SSE
+- `GET /operator` Hosted Operator UI
+- Terminal client
+- Telegram thin adapter
+- ACP JSON-RPC stdio edge adapter
+- GitHub/OpenSpec import/export 및 run-summary publication 경계
+
+아직 MVP 범위 밖:
+
+- production auth/authz
+- multi-user access control
+- hosted GitHub app/webhook 자동화
 - database-backed persistence
 
-## Concrete module ownership
+## 현재 앱/패키지 소유권
+
+```mermaid
+flowchart TB
+  Root["specrail monorepo"]
+
+  Root --> Apps["apps/"]
+  Apps --> Api["api\nHTTP/SSE/Hosted UI/CLI admin wrappers"]
+  Apps --> Acp["acp-server\nACP stdio edge adapter"]
+  Apps --> TerminalApp["terminal\n터미널 UI 클라이언트"]
+  Apps --> TelegramApp["telegram\nTelegram webhook/thin client"]
+
+  Root --> Packages["packages/"]
+  Packages --> CorePkg["core\n도메인 / 서비스 / 파일 repository / event store"]
+  Packages --> AdaptersPkg["adapters\nCodex / Claude Code / integration provider 경계"]
+  Packages --> ConfigPkg["config\n설정 / 경로 / 산출물 materialization"]
+
+  Root --> Docs["docs/\n운영/아키텍처/클라이언트 문서"]
+  Root --> Template[".specrail-template/\n프로젝트 산출물 seed"]
+  Root --> Scripts["scripts/\n검증/유지보수 스크립트"]
+```
 
 ### `packages/core`
 
-Owns:
-- domain types and enums
-- artifact document rendering
+- 도메인 타입과 enum
+- artifact 문서 렌더링
 - file-backed repositories
-- event store and planning-message store contracts plus JSONL implementations
-- `SpecRailService` orchestration logic for tracks, planning, approvals, runs, channel bindings, and attachment references
+- execution event store와 planning-message store 계약 및 JSONL 구현
+- `SpecRailService` orchestration
+- track, planning, artifact approval, run, channel binding, attachment reference 유스케이스
 
 ### `packages/adapters`
 
-Owns:
-- executor adapter contracts
+- executor adapter 계약
 - Codex adapter
 - Claude Code adapter
-- provider command/session metadata persistence shapes
-- provider stream normalization into the shared execution event schema
-- OpenSpec and GitHub integration provider boundaries
+- provider command/session metadata shape
+- provider stream event -> 공통 execution event 변환
+- OpenSpec/GitHub integration provider 경계
 
 ### `packages/config`
 
-Owns:
-- config loading
-- path conventions for artifacts/state/workspaces
-- track artifact materialization helpers
+- 설정 로딩
+- artifact/state/workspace 경로 규칙
+- track artifact materialization helper
 - terminal client config loading
 
 ### `apps/api`
 
-Owns:
 - HTTP routing
 - request validation
-- JSON and SSE response handling
-- service composition with file-backed dependencies and configured executors
-- CLI/admin wrappers around HTTP, OpenSpec, and GitHub-oriented workflows
+- structured API error mapping
+- JSON/SSE response handling
+- file-backed dependency composition
+- configured executor wiring
+- Hosted Operator UI HTML serving
+- workspace cleanup preview/apply HTTP boundary
+- CLI/admin wrappers around HTTP, OpenSpec, GitHub-oriented workflows
 
 ### `apps/acp-server`
 
-Owns:
 - ACP JSON-RPC stdio edge adapter
 - ACP session state under `state/acp-sessions/`
-- mapping ACP `session/new`, `session/prompt`, `session/cancel`, `session/load`, and `session/list` onto SpecRail service calls
-- ACP-facing projections for execution events and permission requests
+- ACP `session/new`, `session/prompt`, `session/cancel`, `session/load`, `session/list`를 SpecRail service call로 매핑
+- execution event와 permission request를 ACP-facing projection으로 변환
 
 ### `apps/terminal`
 
-Owns:
-- terminal client state and rendering
-- track/run list and detail views
-- planning and approval workspace views
-- execution start/resume/cancel controls
-- live SSE follow mode and event filters
+- terminal client 상태와 렌더링
+- track/run 목록과 상세 뷰
+- planning/approval workspace 뷰
+- backend/profile 선택
+- run start/resume/cancel 제어
+- live SSE follow mode와 event filter
+- workspace cleanup preview/apply 제어
 
 ### `apps/telegram`
 
-Owns:
-- Telegram webhook handling
-- thin-channel binding to SpecRail tracks/planning sessions
-- attachment reference registration
-- run event relay back to Telegram chats
+- Telegram webhook 처리
+- chat/thread/user context와 SpecRail track/planning session 바인딩
+- attachment reference 등록
+- run event relay
 
-## API coverage in the MVP
+## 주요 데이터 모델
 
-Implemented routes:
+```mermaid
+classDiagram
+  class Project {
+    id
+    name
+    repoUrl
+    localRepoPath
+    defaultWorkflowPolicy
+    defaultPlanningSystem
+    createdAt
+    updatedAt
+  }
 
-### Tracks and planning
+  class Track {
+    id
+    projectId
+    title
+    description
+    status
+    specStatus
+    planStatus
+    priority
+    planningSystem
+    createdAt
+    updatedAt
+  }
+
+  class PlanningSession {
+    id
+    trackId
+    status
+    latestRevisionId
+    createdAt
+    updatedAt
+  }
+
+  class ArtifactRevision {
+    id
+    trackId
+    artifact
+    version
+    content
+    summary
+    approvalRequestId
+    approvedAt
+    createdAt
+  }
+
+  class ApprovalRequest {
+    id
+    trackId
+    artifact
+    revisionId
+    status
+    requestedBy
+    requestedAt
+    decidedAt
+    decidedBy
+  }
+
+  class Execution {
+    id
+    trackId
+    backend
+    profile
+    workspacePath
+    branchName
+    sessionRef
+    command
+    summary
+    planningSessionId
+    status
+    createdAt
+    startedAt
+    finishedAt
+  }
+
+  class ExecutionEvent {
+    id
+    executionId
+    type
+    subtype
+    timestamp
+    source
+    summary
+    payload
+  }
+
+  class ChannelBinding {
+    id
+    projectId
+    channelType
+    externalChatId
+    externalThreadId
+    externalUserId
+    trackId
+    planningSessionId
+  }
+
+  class AttachmentReference {
+    id
+    sourceType
+    externalFileId
+    fileName
+    mimeType
+    localPath
+    trackId
+    planningSessionId
+  }
+
+  Project "1" --> "many" Track
+  Track "1" --> "many" PlanningSession
+  Track "1" --> "many" ArtifactRevision
+  ArtifactRevision "1" --> "0..1" ApprovalRequest
+  Track "1" --> "many" Execution
+  Execution "1" --> "many" ExecutionEvent
+  Project "1" --> "many" ChannelBinding
+  Track "0..1" --> "many" AttachmentReference
+  PlanningSession "0..1" --> "many" AttachmentReference
+```
+
+## Persistence layout
+
+런타임 상태는 `SPECRAIL_DATA_DIR` 아래에 파일로 저장한다.
+
+```mermaid
+flowchart TB
+  DataDir["SPECRAIL_DATA_DIR"]
+  DataDir --> Artifacts["artifacts/"]
+  DataDir --> State["state/"]
+  DataDir --> Sessions["sessions/"]
+  DataDir --> Workspaces["workspaces/"]
+
+  Artifacts --> ProjectDocs["index.md\nworkflow.md\ntracks.md"]
+  Artifacts --> TrackArtifacts["tracks/<trackId>/\nspec.md / plan.md / tasks.md / sync.json"]
+  TrackArtifacts --> ReservedEvents["events.jsonl\n예약 placeholder - API source of truth 아님"]
+
+  State --> Projects["projects/<projectId>.json"]
+  State --> Tracks["tracks/<trackId>.json"]
+  State --> PlanningSessions["planning-sessions/<id>.json"]
+  State --> PlanningMessages["planning-messages/<id>.jsonl"]
+  State --> ArtifactRevisions["artifact-revisions/<trackId>/<artifact>/<revisionId>.json"]
+  State --> ApprovalRequests["approval-requests/<id>.json"]
+  State --> ChannelBindings["channel-bindings/<id>.json"]
+  State --> Attachments["attachments/<id>.json"]
+  State --> Executions["executions/<runId>.json"]
+  State --> Events["events/<runId>.jsonl\ncanonical run event log"]
+  State --> AcpSessions["acp-sessions/<id>.json"]
+
+  Sessions --> ProviderSession["<sessionRef>.json"]
+  Sessions --> ProviderEvents["<sessionRef>.events.jsonl"]
+  Sessions --> LastMessage["<sessionRef>.last-message.txt"]
+  Workspaces --> RunWorkspace["<runId>/"]
+```
+
+### 이벤트 로그 소유권
+
+- `state/events/<runId>.jsonl`이 canonical run event log다.
+- HTTP event history, SSE replay, run summary, lifecycle reconciliation은 모두 canonical log를 사용한다.
+- `sessions/<sessionRef>.events.jsonl`은 provider adapter 디버깅/재생용 telemetry다.
+- `artifacts/tracks/<trackId>/events.jsonl`은 현재 MVP에서 예약 placeholder이며 API가 읽지 않는다.
+- repo-visible track artifact는 `spec.md`, `plan.md`, `tasks.md`, `sync.json` 중심으로 유지한다.
+
+## 주요 요청 흐름
+
+### 트랙 생성과 산출물 materialization
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant A as apps/api
+  participant S as SpecRailService
+  participant R as File repositories
+  participant W as Artifact writer
+
+  C->>A: POST /tracks
+  A->>A: request body 검증
+  A->>S: createTrack(projectId?, title, description, priority?)
+  S->>R: 기본 project 보장 / track metadata 저장
+  S->>W: spec.md, plan.md, tasks.md, sync.json 생성
+  S-->>A: track + artifact refs
+  A-->>C: 201 JSON
+```
+
+### 계획 revision 제안과 승인
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant A as apps/api
+  participant S as SpecRailService
+  participant R as File repositories
+  participant W as Artifact writer
+
+  C->>A: POST /tracks/:trackId/artifacts/:artifact
+  A->>S: proposeArtifactRevision(...)
+  S->>R: ArtifactRevision 저장
+  S->>R: ApprovalRequest 생성
+  S-->>A: revision + approvalRequest
+  A-->>C: 201 JSON
+
+  C->>A: POST /approval-requests/:id/approve
+  A->>S: approveArtifactRevision(...)
+  S->>R: approval 결정 저장
+  S->>W: 승인된 content를 artifact file에 반영
+  S-->>A: approved revision
+  A-->>C: 200 JSON
+```
+
+### Run 시작, 이벤트 저장, SSE
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant A as apps/api
+  participant S as SpecRailService
+  participant E as Executor Adapter
+  participant L as state/events JSONL
+  participant SSE as SSE Client
+
+  C->>A: POST /runs
+  A->>S: startRun(trackId, prompt, backend, profile, planningSessionId?)
+  S->>S: planning context freshness 검증
+  S->>S: workspacePath / branchName 할당
+  S->>E: start(command, workspacePath, session metadata)
+  E-->>S: normalized execution events
+  S->>L: append events
+  S-->>A: execution snapshot + summary
+  A-->>C: 201 JSON
+
+  SSE->>A: GET /runs/:runId/events/stream
+  A->>L: 기존 이벤트 replay
+  L-->>A: JSONL lines
+  A-->>SSE: SSE event stream
+  E-->>S: 추가 stream events
+  S->>L: append events
+  A-->>SSE: appended events
+```
+
+### Run lifecycle 응답 경계 계약
+
+`resume`/`cancel` 응답은 해당 service call에서 adapter가 반환한 이벤트를 canonical log에 저장하고, 그 로그로 run snapshot을 재계산한 뒤 반환하는 시점의 스냅샷이다. 이후 provider telemetry나 adapter fidelity 개선으로 이벤트가 더 붙을 수 있으므로, 응답 시점의 정확한 event count를 API 계약으로 보지 않는다.
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant A as apps/api
+  participant S as SpecRailService
+  participant E as Executor Adapter
+  participant L as state/events JSONL
+
+  C->>A: POST /runs/:runId/resume 또는 cancel
+  A->>S: lifecycle command 전달
+  S->>E: adapter resume/cancel 호출
+  E-->>S: 이번 호출에서 생성된 normalized events
+  S->>L: events append
+  S->>S: canonical log 기반 snapshot 재계산
+  S-->>A: run summary 포함 응답
+  A-->>C: 200 JSON
+  Note over E,L: 이후 adapter/provider 이벤트가 추가될 수 있음
+```
+
+`POST /runs/:runId/resume`의 동기 보장:
+
+- persisted run이 있고 backend/profile 요청이 유효하면 `200`을 반환한다.
+- `run.id`는 유지된다.
+- `run.status`는 resume 이벤트 반영 후 재계산된 값이며 일반적으로 `running`이다.
+- `run.command.prompt`는 최신 resume prompt를 저장한다.
+- adapter가 resumable session reference를 제공하면 `run.command.resumeSessionRef`가 존재한다.
+- `run.summary.eventCount`는 이전 이벤트 수와 이번 호출에서 append된 resume 이벤트를 반영한 하한 이상이다.
+- `run.summary.lastEventSummary`는 응답 직전에 저장된 최신 이벤트를 기준으로 한다.
+
+`POST /runs/:runId/cancel`의 동기 보장:
+
+- persisted run이 있고 cancel 처리가 끝나면 `200`을 반환한다.
+- `run.status`는 `cancelled`다.
+- `run.finishedAt`이 설정된다.
+- cancellation 이벤트는 응답 전에 저장된다.
+- 같은 호출에서 더 늦게 저장된 이벤트가 없다면 `run.summary.lastEventSummary`는 최신 cancellation 이벤트를 가리킨다.
+
+명시적 non-guarantee:
+
+- resume/cancel 응답 경계에서의 정확한 `run.summary.eventCount` 값
+- 현재 adapter 호출이 append한 이벤트 외 provider-specific 이벤트 순서
+- 비동기 provider telemetry, file watcher, 미래 adapter fidelity 개선으로 인한 후속 이벤트 부재
+
+따라서 테스트와 클라이언트는 exact event count snapshot 대신 lifecycle 의미, 이벤트 존재 여부, event count 하한/단조 증가, 현재 summary 일관성을 검증해야 한다.
+
+### Runtime approval 처리
+
+```mermaid
+sequenceDiagram
+  participant Edge as ACP/Terminal/HTTP Client
+  participant A as apps/api
+  participant S as SpecRailService
+  participant L as state/events JSONL
+  participant E as Executor Adapter
+
+  Edge->>A: POST /runs/:runId/approval-requests/:requestId/approve|reject
+  A->>S: resolveRuntimeApprovalRequest(...)
+  S->>L: approval_resolved event append
+  S->>S: execution snapshot 재계산
+  S->>E: resolveRuntimeApproval(event, snapshot)
+  alt adapter handled
+    E-->>S: handled
+  else unsupported/fallback
+    E-->>S: unsupported
+    S->>L: summary fallback event append
+  end
+  S-->>A: updated execution snapshot
+  A-->>Edge: 200 JSON
+```
+
+### Workspace cleanup 안전 흐름
+
+```mermaid
+sequenceDiagram
+  participant O as Operator
+  participant A as apps/api
+  participant S as SpecRailService
+  participant W as WorkspaceManager
+  participant L as state/events JSONL
+
+  O->>A: GET /runs/:runId/workspace-cleanup/preview
+  A->>S: previewWorkspaceCleanup(runId)
+  S->>W: ownership/path/branch 검증 + dry-run plan
+  W-->>S: cleanupPlan(dryRun=true)
+  S-->>A: cleanupPlan + expectedConfirmation
+  A-->>O: 200 JSON
+
+  O->>A: POST /runs/:runId/workspace-cleanup/apply
+  A->>A: confirm 문자열 검증
+  A->>S: applyWorkspaceCleanup(runId)
+  S->>W: persisted workspacePath 내부에서만 cleanup 실행
+  W-->>S: cleanupResult
+  S->>L: summary event append
+  S-->>A: cleanupResult
+  A-->>O: 200 JSON
+```
+
+## HTTP API 범위
+
+### Hosted Operator UI
+
+- `GET /operator`
+
+단일 HTML 셸로 프로젝트/트랙/계획/산출물/승인/run/cleanup 흐름을 제어한다. 브라우저 native `prompt`/`confirm` 대신 inline form과 in-page confirmation을 사용한다. 주요 action area는 안정적인 `data-control-group` selector로 테스트된다.
+
+### Projects
+
+- `GET /projects`
+- `POST /projects`
+- `GET /projects/:projectId`
+- `PATCH /projects/:projectId`
+
+### Tracks, artifacts, planning
+
 - `POST /tracks`
 - `GET /tracks`
 - `GET /tracks/:trackId`
@@ -169,345 +609,38 @@ Implemented routes:
 - `POST /approval-requests/:approvalRequestId/approve`
 - `POST /approval-requests/:approvalRequestId/reject`
 
-### Runs and events
+### Runs, events, cleanup, runtime approvals
+
 - `POST /runs`
 - `GET /runs`
 - `GET /runs/:runId`
 - `POST /runs/:runId/resume`
 - `POST /runs/:runId/cancel`
+- `GET /runs/:runId/workspace-cleanup/preview`
+- `POST /runs/:runId/workspace-cleanup/apply`
 - `POST /runs/:runId/approval-requests/:requestId/approve`
 - `POST /runs/:runId/approval-requests/:requestId/reject`
 - `GET /runs/:runId/events`
 - `GET /runs/:runId/events/stream`
 
-### Channel and attachment references
+### Channel bindings and attachments
+
 - `POST /channel-bindings`
 - `GET /channel-bindings`
 - `POST /attachments`
 - `GET /attachments`
 
-Not implemented yet:
-- project CRUD endpoints beyond default project bootstrap
-- direct artifact edit/update endpoints outside the proposal/approval flow
-- webhook callback endpoints for GitHub or other hosted integrations
+### 에러 계약
 
-## Data model snapshot
+- `400`: malformed JSON
+- `404`: project/track/run 등 대상 없음
+- `422`: validation failure, invalid pagination/sort params 포함
+- `500`: unexpected server error
 
-### Project
-- `id`
-- `name`
-- `repoUrl`
-- `localRepoPath`
-- `defaultWorkflowPolicy`
-- `defaultPlanningSystem`
-- `createdAt`
-- `updatedAt`
+## Event normalization
 
-### Track
-- `id`
-- `projectId`
-- `title`
-- `description`
-- `status`
-- `specStatus`
-- `planStatus`
-- `priority`
-- `planningSystem`
-- `createdAt`
-- `updatedAt`
+공통 이벤트 타입은 작고 안정적인 집합으로 유지한다.
 
-### PlanningSession
-- `id`
-- `trackId`
-- `status`
-- `latestRevisionId`
-- `createdAt`
-- `updatedAt`
-
-### ArtifactRevision
-- `id`
-- `trackId`
-- `artifact`
-- `version`
-- `content`
-- `summary`
-- `createdBy`
-- `approvalRequestId`
-- `approvedAt`
-- `createdAt`
-
-### ApprovalRequest
-- `id`
-- `trackId`
-- `artifact`
-- `revisionId`
-- `status`
-- `requestedBy`
-- `requestedAt`
-- `decidedAt`
-- `decidedBy`
-- `decisionComment`
-
-### ChannelBinding
-- `id`
-- `projectId`
-- `channelType`
-- `externalChatId`
-- `externalThreadId`
-- `externalUserId`
-- `trackId`
-- `planningSessionId`
-- `createdAt`
-- `updatedAt`
-
-### AttachmentReference
-- `id`
-- `sourceType`
-- `externalFileId`
-- `fileName`
-- `mimeType`
-- `localPath`
-- `trackId`
-- `planningSessionId`
-- `uploadedAt`
-
-### Execution
-- `id`
-- `trackId`
-- `backend`
-- `profile`
-- `workspacePath`
-- `branchName`
-- `sessionRef`
-- `command`
-- `summary`
-- `planningSessionId`
-- approved planning revision ids (`specRevisionId`, `planRevisionId`, `tasksRevisionId`)
-- planning context freshness metadata
-- provider metadata fields surfaced through backend-specific event/session metadata
-- `status`
-- `createdAt`
-- `startedAt`
-- `finishedAt`
-
-### Event
-- `id`
-- `executionId`
-- `type`
-- `subtype`
-- `timestamp`
-- `source`
-- `summary`
-- `payload`
-
-## Persistence layout
-
-The runtime uses file-backed persistence under the configured data directory.
-
-### Artifact tree
-
-```text
-artifacts/
-  index.md
-  workflow.md
-  tracks.md
-  tracks/
-    <trackId>/
-      track.json
-      spec.md
-      plan.md
-      tasks.md
-      events.jsonl
-```
-
-### State tree
-
-```text
-state/
-  projects/
-    <projectId>.json
-  tracks/
-    <trackId>.json
-  planning-sessions/
-    <planningSessionId>.json
-  planning-messages/
-    <planningSessionId>.jsonl
-  artifact-revisions/
-    <trackId>/
-      <artifact>/
-        <revisionId>.json
-  approval-requests/
-    <approvalRequestId>.json
-  channel-bindings/
-    <bindingId>.json
-  attachments/
-    <attachmentId>.json
-  executions/
-    <runId>.json
-  events/
-    <runId>.jsonl
-  acp-sessions/
-    <acpSessionId>.json
-```
-
-### Session tree
-
-```text
-sessions/
-  <sessionRef>.json
-  <sessionRef>.events.jsonl
-  <sessionRef>.last-message.txt
-```
-
-### Workspace tree
-
-```text
-workspaces/
-  <runId>/
-```
-
-### Execution workspace and branch contract
-
-The current MVP always allocates a per-run workspace path before starting an executor:
-
-```text
-workspacePath = workspaces/<runId>/
-branchName = specrail/<runId>
-```
-
-The workspace path is persisted on the execution record and passed to the selected executor as its working directory. The branch name is currently metadata only; future git orchestration should make it real without changing the execution record shape.
-
-Workspace modes:
-
-- `directory`: create `workspaces/<runId>/` as an empty/plain directory. This is the current behavior and remains the safe fallback.
-- `git_worktree`: create a git worktree rooted at `workspaces/<runId>/` with branch `specrail/<runId>` when the project has a local git repository and worktree creation is enabled.
-
-Branch and worktree ownership rules:
-
-- SpecRail owns branches matching `specrail/<runId>` that it creates.
-- SpecRail must not delete or mutate unrelated branches/worktrees.
-- If `specrail/<runId>` already exists, startup should fail with a validation error rather than silently reusing it.
-- If worktree creation fails, the run should not start unless the caller/config explicitly allows falling back to `directory` mode.
-- `workspacePath`, `branchName`, backend, profile, and session refs are the durable recovery handles.
-
-Cleanup expectations:
-
-- `completed`: eligible for cleanup only after review/merge/export tooling no longer needs the workspace.
-- `failed`: not eligible by default; keep the workspace for debugging unless an operator explicitly requests cleanup.
-- `cancelled`: not eligible by default; keep the workspace for inspection unless an operator explicitly requests cleanup.
-- active states such as `running` and `waiting_approval`: never eligible for cleanup.
-- interrupted process: recover from persisted execution metadata and event history; do not assume the worktree can be deleted automatically.
-
-Cleanup safety contract:
-
-1. Cleanup must have a dry-run/preview path that reports the exact workspace path, branch name, workspace mode, and git commands/filesystem operations that would be used.
-2. Destructive cleanup must require an explicit non-dry-run request and must only target persisted `workspacePath` values under the configured `workspaceRoot`.
-3. Branch cleanup must only target persisted `branchName` values matching `specrail/<runId>` for the same execution id.
-4. `directory` mode cleanup may remove `workspaces/<runId>/` only after the path ownership check passes.
-5. `git_worktree` mode cleanup should run worktree removal before branch deletion, for example `git worktree remove <workspacePath>` followed by `git branch -D specrail/<runId>` only when the branch is still owned and local.
-6. Cleanup should append a normalized `summary` event with dry-run versus applied outcome, attempted operations, and any verification notes.
-7. Partial failures must preserve the execution record and append a failure summary event; they must not retry destructive operations automatically.
-
-The first implementation slice provides a workspace manager abstraction with:
-
-- `DirectoryExecutionWorkspaceManager` for the default plain directory behavior.
-- `GitWorktreeExecutionWorkspaceManager` for explicit `git worktree add -b specrail/<runId> workspaces/<runId>` allocation when a local repository path is provided.
-- `GitCommandRunner` injection so tests and future operators can validate command planning without invoking git directly.
-
-Actual branch deletion/cleanup remains a separate explicit operation.
-
-## Request flow
-
-### Create track
-1. caller submits title/description/priority
-2. service ensures a default project exists
-3. service creates a track record
-4. service writes `track.json`, `spec.md`, `plan.md`, `tasks.md`, and a reserved runtime artifact `events.jsonl` placeholder
-5. caller can fetch the track plus artifact contents and inferred planning context
-
-### Update track workflow state
-1. caller patches any of `status`, `specStatus`, `planStatus`
-2. service validates enum values
-3. track metadata is updated in file-backed state
-
-### Propose and approve artifact revisions
-1. caller posts artifact content for `spec`, `plan`, or `tasks`
-2. service stores a versioned `ArtifactRevision` and creates an `ApprovalRequest`
-3. approve/reject endpoints resolve the request
-4. approved revisions are materialized into the track artifact files
-
-### Start run
-1. caller submits `trackId`, prompt, optional backend/profile, and optional planning session
-2. service rejects stale planning context when newer revisions are pending approval
-3. service allocates `workspaces/<runId>/`
-4. selected executor builds and spawns the provider command
-5. execution metadata, planning-context refs, provider/session metadata, and initial normalized events are persisted
-
-### Resume run
-1. caller submits a follow-up prompt
-2. service loads execution + persisted session reference
-3. optional backend must match the persisted run backend
-4. adapter resumes the provider session
-5. resume-related events returned by the adapter are appended before the response snapshot is returned
-6. run summary/status are recomputed from the persisted canonical event log
-
-### Cancel run
-1. caller requests cancellation
-2. adapter best-effort terminates the persisted process/session
-3. cancellation events returned by the adapter are appended before the response snapshot is returned
-4. execution status becomes `cancelled` and the linked track reconciles to `blocked`
-5. run summary/status are recomputed from the persisted canonical event log
-
-### Run lifecycle response-boundary contract
-
-Run lifecycle responses are snapshots after the service has persisted the events produced by that specific service call. They are not a promise that no additional adapter events can appear later.
-
-Synchronous guarantees for `POST /runs/:runId/resume`:
-
-- response status is `200` when the persisted run exists and the backend/profile request is valid
-- `run.id` is unchanged
-- `run.status` reflects the recomputed snapshot after resume events, normally `running`
-- `run.command.prompt` stores the latest resume prompt
-- `run.command.resumeSessionRef` is present when the adapter provided a resumable session reference
-- `run.summary.eventCount` is at least the previously persisted event count plus the resume events appended by this call
-- `run.summary.lastEventSummary` reflects the latest event that was persisted before the response was serialized
-
-Synchronous guarantees for `POST /runs/:runId/cancel`:
-
-- response status is `200` when the persisted run exists and cancellation handling completes
-- `run.status` is `cancelled`
-- `run.finishedAt` is set
-- a cancellation event is persisted before the response snapshot is returned
-- `run.summary.lastEventSummary` reflects the latest persisted cancellation event when no later same-call event supersedes it
-
-Non-guarantees:
-
-- exact `run.summary.eventCount` values at resume/cancel response boundaries
-- provider-specific event ordering beyond events appended by the current adapter call
-- absence of later events from asynchronous provider telemetry, file watchers, or future adapter fidelity improvements
-
-Tests and clients should assert semantic lifecycle facts, event presence, monotonic event-count lower bounds, and current summary coherence instead of exact event-count snapshots.
-
-### Stream run events
-1. caller opens SSE stream for a run
-2. API replays existing persisted events from `state/events/<runId>.jsonl` first
-3. file watcher plus polling fallback tails appended JSONL lines from the same canonical state log
-4. keep-alive comments preserve long-lived connection health
-
-### Bind channel and register attachments
-1. channel frontend creates or refreshes a channel binding for a chat/thread/user context
-2. channel frontend registers attachment references with external ids and optional local metadata
-3. later calls resolve the external channel back to the linked track/planning context and list associated attachments
-
-### ACP session prompt
-1. ACP client creates a session with SpecRail metadata, including `trackId`
-2. first prompt starts a SpecRail run and links it to the ACP session
-3. later prompts resume the linked run
-4. run events are projected into ACP session updates while retaining the original event payload in `_meta.specrail.executionEvent`
-
-## Event normalization constraints
-
-The shared event model stays intentionally small:
 - `message`
 - `tool_call`
 - `tool_result`
@@ -519,67 +652,39 @@ The shared event model stays intentionally small:
 - `test_result`
 - `summary`
 
-Current Codex coverage:
-- spawn -> `shell_command`
-- run started/resumed/cancelled/completed/failed -> `task_status_changed`
-- stdout/stderr capture -> `message`
+Backend별 현황:
 
-Current Claude Code coverage:
-- initialization and result envelopes -> `summary` subtypes
-- assistant text -> `message` subtypes
-- tool use and tool result stream events -> `tool_call` / `tool_result`
-- permission denials and approval-like runtime signals -> `approval_requested`
-- provider metadata such as model, transcript/log path, and working directory is attached through shared metadata/payload shapes
+- Codex: spawn/resume/cancel lifecycle, stdout/stderr, started/completed/failed/cancelled 상태 이벤트
+- Claude Code: initialization/result envelope, assistant text, tool use/result, permission denial/approval-like signal, provider metadata
+- ACP edge: task status update projection, `session/request_permission`, `_meta.specrail.permissionResolution` round trip
 
-Current ACP edge coverage:
-- `task_status_changed` updates ACP session status metadata
-- `approval_requested` can be projected as ACP `session/request_permission`
-- client `_meta.specrail.permissionResolution` is resolved through `SpecRailService.resolveRuntimeApprovalRequest(...)` and then resumes the run
+## Execution workspace와 branch 계약
 
-### Runtime approval callback contract
-
-Runtime approval resolution has two separate responsibilities:
-
-1. persist the domain decision in SpecRail
-2. deliver that decision to the active executor when the backend implements `resolveRuntimeApproval(...)`
-
-The implemented domain decision path is canonical:
+현재 MVP는 run 시작 전에 항상 workspace path를 할당한다.
 
 ```text
-POST /runs/:runId/approval-requests/:requestId/approve|reject
-  -> SpecRailService.resolveRuntimeApprovalRequest(...)
-  -> append approval_resolved to state/events/<runId>.jsonl
-  -> reconcile the run snapshot from persisted execution events
+workspacePath = workspaces/<runId>/
+branchName = specrail/<runId>
 ```
 
-Executors treat the persisted `approval_resolved` event as the durable source of truth. The optional executor callback receives the resolved event plus the current execution snapshot, not a provider-specific API shape. The stable fields are:
+- `workspacePath`는 execution record에 저장되고 executor working directory로 전달된다.
+- `branchName`은 현재 metadata 중심이며, git orchestration 확장 시 동일한 execution shape를 유지한다.
+- `directory` mode는 기본 safe fallback이다.
+- `git_worktree` mode는 local git repo와 명시적 설정이 있을 때 `git worktree add -b specrail/<runId> ...` 형태로 확장된다.
+- cleanup은 persisted `workspacePath`가 configured `workspaceRoot` 아래인지 확인한 뒤에만 실행한다.
+- active 상태(`running`, `waiting_approval`)는 cleanup 대상이 아니다.
+- cleanup 실패는 execution record를 훼손하지 않고 summary event로 남긴다.
 
-- `executionId`
-- `payload.requestId`
-- `payload.requestEventId`
-- `payload.outcome` (`approved` or `rejected`)
-- `payload.decidedBy` (`user`, `agent`, or `system`)
-- `payload.comment`
-- `payload.toolName`
-- `payload.toolUseId`
+## 현재 알려진 한계
 
-Expected callback behavior:
+- production 인증/인가가 없다.
+- database persistence가 없다.
+- scheduler/queue가 없다.
+- GitHub app/webhook 자동화는 아직 hosted integration 경계 수준이다.
+- provider-native permission continuation은 backend별 fallback이 남아 있다.
+- rich artifact editing API는 proposal/approval 흐름 밖에서는 아직 제한적이다.
+- git branch/worktree orchestration은 metadata와 manager abstraction 중심이며 자동화 범위가 제한적이다.
 
-- `approved`: continue the blocked operation when the provider exposes a permission-continuation primitive; otherwise resume the run with a clear event explaining the fallback path.
-- `rejected`: do not retry the blocked operation; mark or keep the run cancelled unless a backend can represent a narrower blocked-step state.
-- unsupported callbacks append a `summary` event so the gap is visible in run history and edge adapters can use their fallback resume path.
-- handled callbacks let edge adapters skip duplicate resume/continuation behavior.
-- callback failure after the domain event is recorded appends an additional `summary` event rather than mutating the approval decision.
+## 문서 갱신 규칙
 
-Provider-specific metadata can remain under event `payload` / `_meta`, but the callback boundary should not require callers to know Codex, Claude Code, or ACP transport details. That keeps the core event contract stable while adapter fidelity improves incrementally.
-
-## Out of scope for the current MVP
-
-- database layer
-- production auth system
-- production deployment manifests
-- provider-native permission continuation primitives beyond current resume fallback behavior
-- rich artifact editing/versioning API outside the current proposal/approval flow
-- multi-project tenant management beyond default project bootstrap
-- hosted GitHub app/webhook automation
-- web UI
+API route, event payload, persistence layout, adapter behavior, operator workflow가 바뀌면 이 문서를 같은 변경 단위에서 갱신한다. 새 durable reference가 생기면 `docs/README.md`도 함께 갱신한다.

--- a/docs/architecture/repository-structure.md
+++ b/docs/architecture/repository-structure.md
@@ -1,74 +1,206 @@
 # Repository Structure Rationale
 
-## Top level
+이 문서는 현재 SpecRail monorepo 구조와 각 디렉터리의 책임을 설명한다. 기준은 현재 구현된 MVP이며, 초기 scaffold 의도와 달라진 부분은 현재 코드에 맞춰 정리한다.
 
-### `apps/`
-Application entrypoints.
+## 최상위 구조
 
-Current app:
-- `api/` for the Node HTTP service boundary
+```mermaid
+flowchart TB
+  Repo["specrail/"]
 
-What it currently contains:
-- route handlers for tracks and runs
-- SSE streaming implementation
-- dependency wiring for file-backed repositories, artifact writers, and the Codex adapter
+  Repo --> Apps["apps/\n실행 가능한 앱/클라이언트 entrypoint"]
+  Apps --> Api["api/\nHTTP API, SSE, Hosted Operator UI"]
+  Apps --> Acp["acp-server/\nACP JSON-RPC stdio edge adapter"]
+  Apps --> Terminal["terminal/\n터미널 클라이언트"]
+  Apps --> Telegram["telegram/\nTelegram thin adapter"]
 
-### `packages/`
-Reusable internal libraries.
+  Repo --> Packages["packages/\n재사용 가능한 내부 라이브러리"]
+  Packages --> Core["core/\n도메인, 서비스, repository, event store"]
+  Packages --> Adapters["adapters/\nCodex/Claude Code executor와 integration boundary"]
+  Packages --> Config["config/\n설정, 경로, 산출물 materialization"]
 
-Current packages:
-- `core` — domain model, artifact renderers, file repositories, event store, service orchestration
-- `adapters` — executor contracts plus the Codex MVP adapter
-- `config` — config loading, artifact path helpers, and artifact materialization
+  Repo --> Docs["docs/\n아키텍처, 운영, 클라이언트 문서"]
+  Repo --> Template[".specrail-template/\n프로젝트 산출물 seed template"]
+  Repo --> Scripts["scripts/\n검증/유지보수 스크립트"]
+  Repo --> Tools["tools/\n로컬 helper entrypoint"]
+```
 
-### `docs/`
-Product and architecture documentation.
+## `apps/`
 
-Current docs here should describe the executable MVP, not just the original scaffold intent.
+실제 실행 표면을 둔다. 앱은 외부 transport, 사용자 인터페이스, edge protocol을 맡고, 핵심 상태 전이는 `packages/core`의 `SpecRailService`에 위임한다.
 
-### `.specrail-template/`
-Seed markdown templates for project-level artifact files such as:
+### `apps/api/`
+
+책임:
+
+- Node HTTP service boundary
+- JSON route handling
+- SSE event stream
+- request validation과 structured error response
+- file-backed dependency wiring
+- Codex/Claude Code executor composition
+- `GET /operator` Hosted Operator UI serving
+- workspace cleanup preview/apply HTTP boundary
+- OpenSpec/GitHub-oriented admin wrapper
+
+### `apps/acp-server/`
+
+책임:
+
+- ACP JSON-RPC stdio edge adapter
+- ACP session state 저장
+- ACP `session/new`, `session/prompt`, `session/cancel`, `session/load`, `session/list`를 SpecRail track/run 흐름으로 매핑
+- execution event와 permission request를 ACP client가 이해하는 projection으로 변환
+
+### `apps/terminal/`
+
+책임:
+
+- terminal UI state와 rendering
+- track/run list/detail view
+- planning/approval workspace view
+- backend/profile 선택
+- run start/resume/cancel 제어
+- live event follow mode
+- workspace cleanup preview/apply 조작
+
+### `apps/telegram/`
+
+책임:
+
+- Telegram webhook handling
+- chat/thread/user context를 SpecRail project/track/planning session에 바인딩
+- attachment reference 등록
+- run event relay
+
+## `packages/`
+
+앱 사이에서 공유하는 내부 라이브러리다. transport나 UI의 세부사항보다 도메인 규칙, 저장소 계약, provider adapter 계약을 우선한다.
+
+```mermaid
+flowchart LR
+  App["apps/*"] --> Core["packages/core"]
+  App --> Config["packages/config"]
+  Core --> Config
+  Core --> Adapters["packages/adapters"]
+  Adapters --> Provider["Codex / Claude Code / GitHub / OpenSpec"]
+  Core --> State["file-backed state + JSONL events"]
+```
+
+### `packages/core/`
+
+책임:
+
+- Project, Track, PlanningSession, ArtifactRevision, ApprovalRequest, Execution, ExecutionEvent 도메인 타입
+- artifact renderer
+- file-backed repositories
+- JSONL event store와 planning message store
+- `SpecRailService` 유스케이스 orchestration
+- workflow/planning/artifact approval/run/channel/attachment 상태 전이
+
+### `packages/adapters/`
+
+책임:
+
+- executor adapter interface
+- Codex provider adapter
+- Claude Code provider adapter
+- provider command/session metadata shape
+- provider stream event normalization
+- GitHub/OpenSpec integration boundary
+
+### `packages/config/`
+
+책임:
+
+- config loading
+- `SPECRAIL_DATA_DIR` 기준 artifact/state/session/workspace 경로 규칙
+- `.specrail-template` 기반 artifact materialization
+- terminal client config loading
+
+## `docs/`
+
+제품과 구현을 연결하는 durable reference를 둔다.
+
+- `docs/architecture/mvp-architecture.md`: 현재 MVP 시스템 구조, 데이터 흐름, persistence layout, API 범위
+- `docs/architecture/mvp-roadmap.md`: 현재 baseline에서 다음 검증/개선 작업 후보
+- `docs/domain-entities.md`: 주요 도메인 entity 설명
+- `docs/interfaces-and-adapters.md`: adapter boundary와 외부 표면 연결 방식
+- client/operation 문서: terminal, ACP, Claude Code, Telegram 등
+
+문서는 실행 가능한 코드와 함께 갱신되어야 한다. API route, event payload, persistence layout, adapter behavior, operator workflow가 바뀌면 관련 문서를 같은 PR/commit에서 업데이트한다.
+
+## `.specrail-template/`
+
+프로젝트 수준 artifact seed template을 둔다.
+
 - `index.md`
 - `workflow.md`
 - `tracks.md`
 
-Track-specific files are then materialized by code in `packages/config`.
+트랙별 `spec.md`, `plan.md`, `tasks.md`는 `packages/config`의 materialization helper가 생성한다.
 
-### `scripts/`
-Bootstrap and maintenance scripts that are not part of the runtime service.
+## `scripts/`와 `tools/`
 
-### `tools/`
-Small local tools or helper entrypoints.
+런타임 서비스가 아닌 검증/유지보수/helper entrypoint를 둔다.
 
-## Why not a single-package repo?
+예시:
 
-A single package would still be possible, but the current implementation already has stable seams:
-- API transport and streaming behavior in `apps/api`
-- workflow/domain logic in `packages/core`
-- executor-specific process/session behavior in `packages/adapters`
-- path/config/artifact conventions in `packages/config`
+- markdown link 검사
+- repository maintenance script
+- 로컬 분석/운영 helper
 
-That separation is now justified by real code, not just anticipated growth.
+## 왜 단일 패키지가 아닌가?
 
-## Why not a heavy Nx/Turborepo setup yet?
+현재 구현은 이미 다음 경계가 실제 코드로 존재한다.
 
-Still premature.
+```mermaid
+flowchart TB
+  Transport["Transport/UI concerns\nHTTP, SSE, Terminal, Telegram, ACP"] --> Service["Domain service boundary\nSpecRailService"]
+  Service --> Persistence["Persistence contracts\nRepositories + JSONL stores"]
+  Service --> Executors["Executor contracts\nCodex / Claude Code"]
+  Service --> Artifacts["Artifact conventions\nspec/plan/tasks materialization"]
+```
 
-The repo currently only needs:
-- pnpm workspaces
-- TypeScript package builds/checks
-- lightweight package boundaries
+단일 패키지도 가능하지만, 현재는 다음 이유로 분리가 더 유지보수하기 좋다.
 
-This keeps the MVP easy to inspect while leaving room for stronger build orchestration later if package count or CI complexity grows.
+- API/클라이언트 transport 변경이 도메인 상태 전이를 흔들지 않는다.
+- executor provider 교체나 확장이 HTTP route를 직접 오염시키지 않는다.
+- file-backed persistence를 나중에 database-backed persistence로 바꿀 때 repository 계약을 기준으로 이동할 수 있다.
+- Hosted UI, Terminal, Telegram, ACP가 같은 core service를 공유한다.
 
-## Current structure snapshot
+## 왜 무거운 Nx/Turborepo를 아직 쓰지 않는가?
+
+아직은 과하다.
+
+현재 필요한 것은 다음 정도다.
+
+- pnpm workspace
+- TypeScript package build/check
+- package-level 테스트
+- 가벼운 internal boundary
+
+패키지 수나 CI 복잡도가 커지면 build orchestration 도입을 다시 검토할 수 있다. 지금은 inspectability와 빠른 변경을 우선한다.
+
+## 현재 구조 snapshot
 
 ```text
 specrail/
   apps/
+    acp-server/
+      src/
+        index.ts
+        server.ts
     api/
       src/
         __tests__/
+        index.ts
+        operator-ui.ts
+    telegram/
+      src/
+        index.ts
+    terminal/
+      src/
         index.ts
   packages/
     adapters/
@@ -76,6 +208,7 @@ specrail/
         __tests__/
         interfaces/
         providers/
+        index.ts
     config/
       src/
         __tests__/
@@ -83,10 +216,14 @@ specrail/
         index.ts
     core/
       src/
+        __tests__/
         domain/
         services/
+        errors.ts
         index.ts
   docs/
     architecture/
   .specrail-template/
+  scripts/
+  tools/
 ```


### PR DESCRIPTION
Closes #266.\n\n## Summary\n- rewrite MVP architecture and repository structure docs in Korean\n- add Mermaid diagrams for system structure, package ownership, data model, persistence layout, and request flows\n- preserve the run lifecycle response-boundary contract from #263 in the Korean architecture overview\n\n## Validation\n- pnpm check:links