### PR TITLE
feat: add completed run report endpoint

### DIFF
--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -566,6 +566,59 @@ test("API supports creating tracks, planning sessions, messages, starting runs, 
   });
 });
 
+
+test("API serves completed run Markdown reports without mutating artifacts or events", async () => {
+  await withServer(async (baseUrl, paths) => {
+    const trackResponse = await fetch(`${baseUrl}/tracks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Report export",
+        description: "Render a completed-run report.",
+      }),
+    });
+    const trackPayload = (await trackResponse.json()) as { track: { id: string } };
+
+    const createRunResponse = await fetch(`${baseUrl}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        trackId: trackPayload.track.id,
+        prompt: "Generate the report",
+      }),
+    });
+    const runPayload = (await createRunResponse.json()) as { run: { id: string } };
+
+    const eventsBeforeResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/events`);
+    const eventsBefore = await eventsBeforeResponse.text();
+    const specPath = path.join(paths.repoArtifactDir, "tracks", trackPayload.track.id, "spec.md");
+    const specBefore = await readFile(specPath, "utf8");
+
+    const reportResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/report.md`);
+    assert.equal(reportResponse.status, 200);
+    assert.match(reportResponse.headers.get("content-type") ?? "", /text\/markdown; charset=utf-8/);
+    assert.match(reportResponse.headers.get("content-disposition") ?? "", new RegExp(`specrail-run-${runPayload.run.id}-report\\.md`));
+
+    const report = await reportResponse.text();
+    assert.match(report, new RegExp(`# Run Report — ${runPayload.run.id}`));
+    assert.match(report, /## Summary/);
+    assert.match(report, /- Track: Report export/);
+    assert.match(report, /## Timeline/);
+    assert.match(report, /Run started/);
+    assert.match(report, new RegExp("Generated from `state/events/" + runPayload.run.id + "\\.jsonl`"));
+    assert.match(report, /does not mutate `spec.md`, `plan.md`, or `tasks.md`/);
+
+    const eventsAfterResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/events`);
+    const eventsAfter = await eventsAfterResponse.text();
+    const specAfter = await readFile(specPath, "utf8");
+    assert.equal(eventsAfter, eventsBefore);
+    assert.equal(specAfter, specBefore);
+
+    const missingResponse = await fetch(`${baseUrl}/runs/missing-run/report.md`);
+    await assertJsonResponseStatus(missingResponse, 404);
+  });
+});
+
 test("API supports streaming run events over SSE", async () => {
   await withServer(async (baseUrl) => {
     const trackResponse = await fetch(`${baseUrl}/tracks`, {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,7 @@ import {
   createExecutionWorkspaceManager,
   ExecutionWorkspaceCleanupApplier,
   planExecutionWorkspaceCleanup,
+  renderCompletedRunReport,
   type ExecutionWorkspaceMode,
   type ApplyExecutionWorkspaceCleanupResult,
   type ExecutionEvent,
@@ -376,6 +377,14 @@ function sendJson(response: ServerResponse, statusCode: number, body: unknown): 
 
 function sendHtml(response: ServerResponse, statusCode: number, body: string): void {
   response.writeHead(statusCode, { "content-type": "text/html; charset=utf-8" });
+  response.end(body);
+}
+
+function sendMarkdown(response: ServerResponse, statusCode: number, body: string, filename: string): void {
+  response.writeHead(statusCode, {
+    "content-type": "text/markdown; charset=utf-8",
+    "content-disposition": `inline; filename="${filename}"`,
+  });
   response.end(body);
 }
 
@@ -1455,6 +1464,28 @@ export function createSpecRailHttpServer(deps: ApiDeps): http.Server {
         }
 
         await streamRunEvents(response, deps.service, deps.eventLogDir, run.id);
+        return;
+      }
+
+      if (method === "GET" && segments.length === 3 && segments[0] === "runs" && segments[2] === "report.md") {
+        const run = await deps.service.getRun(segments[1] ?? "");
+
+        if (!run) {
+          sendError(response, 404, "not_found", "run not found");
+          return;
+        }
+
+        const track = await deps.service.getTrack(run.trackId);
+
+        if (!track) {
+          sendError(response, 404, "not_found", "track not found");
+          return;
+        }
+
+        const project = await deps.service.getProject(track.projectId);
+        const events = await deps.service.listRunEvents(run.id);
+        const report = renderCompletedRunReport({ run, track, project, events, generatedAt: new Date().toISOString() });
+        sendMarkdown(response, 200, report, `specrail-run-${run.id}-report.md`);
         return;
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,3 +7,4 @@ export * from "./services/execution-workspace-manager.js";
 export * from "./services/file-repositories.js";
 export * from "./services/ports.js";
 export * from "./services/specrail-service.js";
+export * from "./services/completed-run-report.js";

--- a/packages/core/src/services/__tests__/completed-run-report.test.ts
+++ b/packages/core/src/services/__tests__/completed-run-report.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderCompletedRunReport } from "../completed-run-report.js";
+import type { Execution, ExecutionEvent, Project, Track } from "../../domain/types.js";
+
+test("renderCompletedRunReport renders metadata, escaped timeline, highlights, and source footer", () => {
+  const project: Project = {
+    id: "project-a",
+    name: "SpecRail",
+    createdAt: "2026-05-04T00:00:00.000Z",
+    updatedAt: "2026-05-04T00:00:00.000Z",
+  };
+  const track: Track = {
+    id: "track-a",
+    projectId: project.id,
+    title: "Report | export",
+    description: "Render reports",
+    status: "review",
+    specStatus: "approved",
+    planStatus: "approved",
+    priority: "medium",
+    createdAt: "2026-05-04T00:00:00.000Z",
+    updatedAt: "2026-05-04T00:00:00.000Z",
+  };
+  const run: Execution = {
+    id: "run-a",
+    trackId: track.id,
+    backend: "codex",
+    profile: "default",
+    workspacePath: "/tmp/run-a",
+    branchName: "specrail/run-a",
+    sessionRef: "session-a",
+    command: { command: "codex", args: ["exec"], cwd: "/tmp/run-a", prompt: "Ship | verify\nthen report" },
+    summary: { eventCount: 2, lastEventSummary: "Tests passed", lastEventAt: "2026-05-04T00:02:00.000Z" },
+    status: "completed",
+    createdAt: "2026-05-04T00:00:00.000Z",
+    startedAt: "2026-05-04T00:01:00.000Z",
+    finishedAt: "2026-05-04T00:03:00.000Z",
+    planningSessionId: "planning-a",
+    specRevisionId: "spec-r1",
+  };
+  const events: ExecutionEvent[] = [
+    {
+      id: "event-2",
+      executionId: run.id,
+      type: "test_result",
+      timestamp: "2026-05-04T00:02:00.000Z",
+      source: "vitest|node",
+      summary: "Tests passed\n118 ok",
+    },
+    {
+      id: "event-1",
+      executionId: run.id,
+      type: "task_status_changed",
+      timestamp: "2026-05-04T00:01:00.000Z",
+      source: "codex",
+      summary: "Run started",
+    },
+  ];
+
+  const report = renderCompletedRunReport({ project, track, run, events, generatedAt: "2026-05-04T00:04:00.000Z" });
+
+  assert.match(report, /^# Run Report — run-a/);
+  assert.match(report, /- Project: SpecRail \(project-a\)/);
+  assert.match(report, /- Track: Report \| export \(track-a\)/);
+  assert.match(report, /Ship \| verify\nthen report/);
+  assert.match(report, /- Planning session: planning-a/);
+  assert.match(report, /- Spec revision: spec-r1/);
+  assert.match(report, /\| 2026-05-04T00:01:00.000Z \| task_status_changed \| codex \| Run started \|/);
+  assert.match(report, /\| 2026-05-04T00:02:00.000Z \| test_result \| vitest\\\|node \| Tests passed<br>118 ok \|/);
+  assert.match(report, /- 2026-05-04T00:02:00.000Z — test_result — Tests passed/);
+  assert.match(report, /Generated from `state\/events\/run-a\.jsonl` at 2026-05-04T00:04:00.000Z\./);
+  assert.match(report, /does not mutate `spec.md`, `plan.md`, or `tasks.md`/);
+});

--- a/packages/core/src/services/completed-run-report.ts
+++ b/packages/core/src/services/completed-run-report.ts
@@ -1,0 +1,83 @@
+import type { Execution, ExecutionEvent, Project, Track } from "../domain/types.js";
+
+export interface CompletedRunReportInput {
+  run: Execution;
+  track: Track;
+  project?: Project | null;
+  events: ExecutionEvent[];
+  generatedAt: string;
+}
+
+export function renderCompletedRunReport(input: CompletedRunReportInput): string {
+  const { run, track, project, generatedAt } = input;
+  const events = [...input.events].sort((left, right) => left.timestamp.localeCompare(right.timestamp));
+  const highlights = events.filter((event) =>
+    ["approval_requested", "approval_resolved", "tool_call", "tool_result", "test_result", "task_status_changed", "summary"].includes(event.type),
+  );
+
+  const lines: string[] = [];
+
+  lines.push(`# Run Report — ${run.id}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push(`- Project: ${project ? `${project.name} (${project.id})` : `unknown (${track.projectId})`}`);
+  lines.push(`- Track: ${track.title} (${track.id})`);
+  lines.push(`- Status: ${run.status}`);
+  lines.push(`- Backend/Profile: ${run.backend} / ${run.profile}`);
+  lines.push(`- Started: ${run.startedAt ?? "not started"}`);
+  lines.push(`- Finished: ${run.finishedAt ?? "not finished"}`);
+  lines.push(`- Event count: ${run.summary?.eventCount ?? events.length}`);
+  lines.push(`- Last event: ${run.summary?.lastEventSummary ?? "none"}${run.summary?.lastEventAt ? ` (${run.summary.lastEventAt})` : ""}`);
+  lines.push("");
+  lines.push("## Prompt");
+  lines.push("");
+  lines.push(run.command?.prompt?.trim() ? run.command.prompt : "No prompt recorded.");
+  lines.push("");
+  lines.push("## Planning Context");
+  lines.push(`- Planning session: ${run.planningSessionId ?? "none"}`);
+  lines.push(`- Spec revision: ${run.specRevisionId ?? "none"}`);
+  lines.push(`- Plan revision: ${run.planRevisionId ?? "none"}`);
+  lines.push(`- Tasks revision: ${run.tasksRevisionId ?? "none"}`);
+  lines.push("");
+  lines.push("## Timeline");
+  lines.push("");
+  lines.push("| Time | Type | Source | Summary |");
+  lines.push("| ---- | ---- | ------ | ------- |");
+
+  if (events.length === 0) {
+    lines.push("| none | none | none | No events recorded. |");
+  } else {
+    for (const event of events) {
+      lines.push(`| ${escapeMarkdownTableCell(event.timestamp)} | ${escapeMarkdownTableCell(event.type)} | ${escapeMarkdownTableCell(event.source)} | ${escapeMarkdownTableCell(event.summary)} |`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## Highlights");
+  lines.push("");
+
+  if (highlights.length === 0) {
+    lines.push("- No highlight events recorded.");
+  } else {
+    for (const event of highlights) {
+      lines.push(`- ${event.timestamp} — ${event.type} — ${event.summary}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## Source of Truth");
+  lines.push("");
+  lines.push(`Generated from \`state/events/${run.id}.jsonl\` at ${generatedAt}.`);
+  lines.push("This report is a derived snapshot and does not replace canonical run history.");
+  lines.push("It does not mutate `spec.md`, `plan.md`, or `tasks.md`.");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function escapeMarkdownTableCell(value: unknown): string {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, "<br>");
+}


### PR DESCRIPTION
Closes #275.

## Summary
- add a shared completed-run Markdown report renderer
- add read-only `GET /runs/:runId/report.md`
- include run/project/track metadata, prompt, planning context, timeline, highlights, and source-of-truth footer
- verify endpoint does not mutate run events or track planning artifacts

## Validation
- pnpm --filter @specrail/core check
- pnpm --filter @specrail/api check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit packages/core/src/services/__tests__/completed-run-report.test.ts apps/api/src/__tests__/api.test.ts
- pnpm check
- pnpm test
- pnpm build
