### PR TITLE
feat: add GitHub org and team authorization

### DIFF
--- a/apps/github/src/__tests__/github-app.test.ts
+++ b/apps/github/src/__tests__/github-app.test.ts
@@ -7,9 +7,11 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import {
+  authorizeGitHubActor,
   buildGitHubSignature256,
   createGitHubAppInstallationTokenProvider,
   createGitHubAppJwt,
+  createGitHubRestAuthorizationClient,
   createGitHubRestIssueCommentClient,
   createGitHubWebhookHttpServer,
   JsonFileGitHubRelayJobQueue,
@@ -288,6 +290,7 @@ async function withGitHubWebhookServer(
   specRail: GitHubSpecRailPort,
   fn: (baseUrl: string) => Promise<void>,
   configOverrides: Partial<ReturnType<typeof loadGitHubAppConfig>> = {},
+  authorization?: { isOrganizationMember(input: { organization: string; username: string }): Promise<boolean>; isTeamMember(input: { organization: string; teamSlug: string; username: string }): Promise<boolean> },
 ): Promise<void> {
   const server = createGitHubWebhookHttpServer({
     config: {
@@ -300,9 +303,12 @@ async function withGitHubWebhookServer(
       followTerminalEvents: false,
       repositoryProjects: {},
       allowedActors: [],
+      allowedOrganizations: [],
+      allowedTeams: [],
       ...configOverrides,
     },
     specRail,
+    authorization,
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -515,6 +521,8 @@ test("startGitHubWebhookApp starts the webhook server with injected config and p
       followTerminalEvents: false,
       repositoryProjects: {},
       allowedActors: [],
+      allowedOrganizations: [],
+      allowedTeams: [],
     },
     specRail: port,
   });
@@ -719,6 +727,8 @@ test("GitHub webhook HTTP app schedules terminal relay without waiting for termi
       followTerminalEvents: true,
       repositoryProjects: {},
       allowedActors: [],
+      allowedOrganizations: [],
+      allowedTeams: [],
     },
     specRail: port,
     github: {
@@ -773,6 +783,8 @@ test("GitHub webhook HTTP app surfaces terminal relay enqueue failures", async (
       followTerminalEvents: true,
       repositoryProjects: {},
       allowedActors: [],
+      allowedOrganizations: [],
+      allowedTeams: [],
     },
     specRail: port,
     github: {
@@ -1047,6 +1059,8 @@ test("GitHub webhook HTTP app enqueues durable terminal relay jobs", async () =>
       followTerminalEvents: true,
       repositoryProjects: {},
       allowedActors: [],
+      allowedOrganizations: [],
+      allowedTeams: [],
     },
     specRail: port,
     github: {
@@ -1070,4 +1084,94 @@ test("GitHub webhook HTTP app enqueues durable terminal relay jobs", async () =>
     server.close();
     await once(server, "close");
   }
+});
+
+test("authorizeGitHubActor supports organization and team membership", async () => {
+  const checks: string[] = [];
+  const authorization = {
+    async isOrganizationMember(input: { organization: string; username: string }) {
+      checks.push(`org:${input.organization}:${input.username}`);
+      return input.organization === "yoophi-a";
+    },
+    async isTeamMember(input: { organization: string; teamSlug: string; username: string }) {
+      checks.push(`team:${input.organization}/${input.teamSlug}:${input.username}`);
+      return input.organization === "other" && input.teamSlug === "maintainers";
+    },
+  };
+
+  assert.equal(
+    await authorizeGitHubActor({ config: { allowedActors: [], allowedOrganizations: ["yoophi-a"], allowedTeams: [] }, senderLogin: "octocat", authorization }),
+    true,
+  );
+  assert.equal(
+    await authorizeGitHubActor({ config: { allowedActors: [], allowedOrganizations: ["missing"], allowedTeams: ["other/maintainers"] }, senderLogin: "hubot", authorization }),
+    true,
+  );
+  assert.equal(
+    await authorizeGitHubActor({ config: { allowedActors: [], allowedOrganizations: ["missing"], allowedTeams: ["other/reviewers"] }, senderLogin: "mallory", authorization }),
+    false,
+  );
+  assert.deepEqual(checks, ["org:yoophi-a:octocat", "org:missing:hubot", "team:other/maintainers:hubot", "org:missing:mallory", "team:other/reviewers:mallory"]);
+});
+
+test("createGitHubRestAuthorizationClient checks org and team membership", async () => {
+  const requests: Array<{ url?: string; authorization?: string }> = [];
+  await withJsonServer((request, response) => {
+    requests.push({ url: request.url, authorization: request.headers.authorization });
+    response.statusCode = request.url?.includes("/teams/maintainers/") ? 404 : 204;
+    response.end();
+  }, async (baseUrl) => {
+    const client = createGitHubRestAuthorizationClient({ token: "github-token", apiBaseUrl: baseUrl });
+    assert.equal(await client.isOrganizationMember({ organization: "yoophi-a", username: "octocat" }), true);
+    assert.equal(await client.isTeamMember({ organization: "yoophi-a", teamSlug: "maintainers", username: "octocat" }), false);
+  });
+
+  assert.deepEqual(requests, [
+    { url: "/orgs/yoophi-a/members/octocat", authorization: "Bearer github-token" },
+    { url: "/orgs/yoophi-a/teams/maintainers/memberships/octocat", authorization: "Bearer github-token" },
+  ]);
+});
+
+test("GitHub webhook HTTP app accepts org-authorized actors and rejects authorization failures before runs", async () => {
+  const accepted = createSpecRailPort();
+  await withGitHubWebhookServer(
+    accepted.port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run org"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+      assert.equal(((await response.json()) as { accepted: boolean }).accepted, true);
+    },
+    { allowedOrganizations: ["yoophi-a"] },
+    {
+      async isOrganizationMember() {
+        return true;
+      },
+      async isTeamMember() {
+        return false;
+      },
+    },
+  );
+  assert.notDeepEqual(accepted.calls, []);
+
+  const rejected = createSpecRailPort();
+  await withGitHubWebhookServer(
+    rejected.port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run rejected"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 502);
+      assert.deepEqual(await response.json(), { error: "github_authorization_failed", message: "membership check failed" });
+    },
+    { allowedOrganizations: ["yoophi-a"] },
+    {
+      async isOrganizationMember() {
+        throw new Error("membership check failed");
+      },
+      async isTeamMember() {
+        return false;
+      },
+    },
+  );
+  assert.deepEqual(rejected.calls, []);
 });

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -26,6 +26,8 @@ export interface GitHubAppConfig {
   githubRelayQueuePath?: string;
   repositoryProjects: Record<string, string>;
   allowedActors: string[];
+  allowedOrganizations: string[];
+  allowedTeams: string[];
 }
 
 export interface GitHubIssueCommentCommandEvent {
@@ -113,6 +115,11 @@ export interface GitHubIssueCommentPort {
   createIssueComment(input: { repositoryFullName: string; issueNumber: number; body: string }): Promise<{ id?: string | number; url?: string }>;
 }
 
+export interface GitHubAuthorizationPort {
+  isOrganizationMember(input: { organization: string; username: string }): Promise<boolean>;
+  isTeamMember(input: { organization: string; teamSlug: string; username: string }): Promise<boolean>;
+}
+
 export interface GitHubTokenProvider {
   getToken(): Promise<string>;
 }
@@ -125,6 +132,7 @@ export interface GitHubWebhookAppDeps {
   config: GitHubAppConfig;
   specRail: GitHubSpecRailPort;
   github?: GitHubIssueCommentPort;
+  authorization?: GitHubAuthorizationPort;
   scheduler?: GitHubBackgroundTaskScheduler;
   relayQueue?: GitHubRelayJobQueue;
 }
@@ -224,6 +232,44 @@ export function isGitHubActorAuthorized(config: Pick<GitHubAppConfig, "allowedAc
   return config.allowedActors.includes(senderLogin) || config.allowedActors.includes(`@${senderLogin}`);
 }
 
+function parseAllowedTeam(value: string): { organization: string; teamSlug: string } {
+  const [organization, teamSlug] = value.split("/").map((part) => part.trim());
+  if (!organization || !teamSlug) {
+    throw new Error(`invalid GITHUB_ALLOWED_TEAMS entry: ${value}`);
+  }
+  return { organization, teamSlug };
+}
+
+export async function authorizeGitHubActor(input: {
+  config: Pick<GitHubAppConfig, "allowedActors" | "allowedOrganizations" | "allowedTeams">;
+  senderLogin?: string;
+  authorization?: GitHubAuthorizationPort;
+}): Promise<boolean> {
+  const hasActorPolicy = input.config.allowedActors.length > 0;
+  const hasMembershipPolicy = input.config.allowedOrganizations.length > 0 || input.config.allowedTeams.length > 0;
+  if (!hasActorPolicy && !hasMembershipPolicy) {
+    return true;
+  }
+  if (hasActorPolicy && isGitHubActorAuthorized({ allowedActors: input.config.allowedActors }, input.senderLogin)) {
+    return true;
+  }
+  if (!hasMembershipPolicy || !input.senderLogin || !input.authorization) {
+    return false;
+  }
+
+  for (const organization of input.config.allowedOrganizations) {
+    if (await input.authorization.isOrganizationMember({ organization, username: input.senderLogin })) {
+      return true;
+    }
+  }
+  for (const team of input.config.allowedTeams) {
+    if (await input.authorization.isTeamMember({ ...parseAllowedTeam(team), username: input.senderLogin })) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function loadGitHubAppConfig(env: NodeJS.ProcessEnv = process.env): GitHubAppConfig {
   return {
     apiBaseUrl: env.SPECRAIL_API_BASE_URL ?? "http://127.0.0.1:4000",
@@ -240,6 +286,8 @@ export function loadGitHubAppConfig(env: NodeJS.ProcessEnv = process.env): GitHu
     githubRelayQueuePath: env.GITHUB_RELAY_QUEUE_PATH,
     repositoryProjects: parseRepositoryProjectMap(env.SPECRAIL_GITHUB_REPOSITORY_PROJECTS),
     allowedActors: parseCsvList(env.GITHUB_ALLOWED_ACTORS),
+    allowedOrganizations: parseCsvList(env.GITHUB_ALLOWED_ORGS),
+    allowedTeams: parseCsvList(env.GITHUB_ALLOWED_TEAMS),
   };
 }
 
@@ -355,6 +403,44 @@ export function createGitHubRestIssueCommentClient(input: { token?: string; toke
         headers: { authorization: `Bearer ${token}` },
         body: JSON.stringify({ body: commentInput.body }),
       }, input.fetchFn);
+    },
+  };
+}
+
+export function createGitHubRestAuthorizationClient(input: { token?: string; tokenProvider?: GitHubTokenProvider; apiBaseUrl?: string; fetchFn?: FetchLike }): GitHubAuthorizationPort {
+  const apiBaseUrl = input.apiBaseUrl ?? "https://api.github.com";
+  const tokenProvider = input.tokenProvider ?? (input.token ? createStaticGitHubTokenProvider(input.token) : undefined);
+  if (!tokenProvider) {
+    throw new Error("GitHub authorization client requires a token or token provider");
+  }
+  const provider = tokenProvider;
+  async function request(pathname: string): Promise<boolean> {
+    const token = await provider.getToken();
+    const response = await (input.fetchFn ?? fetch)(new URL(pathname, apiBaseUrl), {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (response.status === 204) {
+      return true;
+    }
+    if (response.status === 404) {
+      return false;
+    }
+    const responseText = await response.text();
+    const bodySuffix = responseText ? `: ${responseText}` : "";
+    throw new Error(`GitHub API GET ${pathname} failed with ${response.status}${bodySuffix}`);
+  }
+  return {
+    isOrganizationMember(input) {
+      return request(`/orgs/${encodeGitHubPathSegment(input.organization)}/members/${encodeGitHubPathSegment(input.username)}`);
+    },
+    isTeamMember(input) {
+      return request(
+        `/orgs/${encodeGitHubPathSegment(input.organization)}/teams/${encodeGitHubPathSegment(input.teamSlug)}/memberships/${encodeGitHubPathSegment(input.username)}`,
+      );
     },
   };
 }
@@ -478,8 +564,9 @@ export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRai
   const specRail = input.specRail ?? createSpecRailHttpClient(config.apiBaseUrl);
   const tokenProvider = createGitHubTokenProviderFromConfig(config);
   const github = input.github ?? (tokenProvider ? createGitHubRestIssueCommentClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined);
+  const authorization = tokenProvider ? createGitHubRestAuthorizationClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined;
   const relayQueue = config.githubRelayQueuePath ? new JsonFileGitHubRelayJobQueue(config.githubRelayQueuePath) : undefined;
-  const server = createGitHubWebhookHttpServer({ config, specRail, github, scheduler: defaultGitHubBackgroundTaskScheduler, relayQueue });
+  const server = createGitHubWebhookHttpServer({ config, specRail, github, authorization, scheduler: defaultGitHubBackgroundTaskScheduler, relayQueue });
   if (relayQueue && github) {
     const interval = setInterval(() => {
       processGitHubRelayQueue({ queue: relayQueue, specRail, github }).catch((error: unknown) => {
@@ -916,7 +1003,14 @@ export async function handleGitHubWebhookHttpRequest(
       sendJson(response, 202, { accepted: false, reason: "unsupported_repository" });
       return;
     }
-    if (!isGitHubActorAuthorized(deps.config, command.senderLogin)) {
+    let authorized: boolean;
+    try {
+      authorized = await authorizeGitHubActor({ config: deps.config, senderLogin: command.senderLogin, authorization: deps.authorization });
+    } catch (error) {
+      sendJson(response, 502, { error: "github_authorization_failed", message: error instanceof Error ? error.message : String(error) });
+      return;
+    }
+    if (!authorized) {
       sendJson(response, 202, { accepted: false, reason: "unauthorized_actor" });
       return;
     }

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -41,7 +41,9 @@ The runnable app entrypoint reads these environment variables:
 | `SPECRAIL_GITHUB_PROJECT_ID` | `SPECRAIL_PROJECT_ID` or `project-default` | Default project id used when creating tracks from GitHub issues/PRs. |
 | `SPECRAIL_PROJECT_ID` | `project-default` | Fallback project id when `SPECRAIL_GITHUB_PROJECT_ID` is not set. |
 | `SPECRAIL_GITHUB_REPOSITORY_PROJECTS` | unset | Optional comma-separated repository allowlist and project map, for example `yoophi-a/specrail=project-specrail,other/repo=project-other`. When set, unmapped repositories are ignored. |
-| `GITHUB_ALLOWED_ACTORS` | unset | Optional comma-separated sender login allowlist, for example `octocat,@hubot`. When set, other senders are ignored. |
+| `GITHUB_ALLOWED_ACTORS` | unset | Optional comma-separated sender login allowlist, for example `octocat,@hubot`. When set with no org/team policy, other senders are ignored. |
+| `GITHUB_ALLOWED_ORGS` | unset | Optional comma-separated GitHub organization membership allowlist for `/specrail` command senders. Requires a GitHub token provider. |
+| `GITHUB_ALLOWED_TEAMS` | unset | Optional comma-separated team allowlist in `org/team-slug` form. Requires a GitHub token provider. |
 | `GITHUB_WEBHOOK_SECRET` | empty string | Secret used to validate `X-Hub-Signature-256`. Set this in real deployments. |
 | `GITHUB_APP_PORT` | `4200` | HTTP port for the GitHub webhook server. |
 | `GITHUB_WEBHOOK_PATH` | `/github/webhook` | HTTP path that receives GitHub webhooks. |
@@ -90,12 +92,12 @@ The webhook endpoint returns JSON responses:
 - REST issue-comment posting supports static tokens and GitHub App installation-token refresh. Private keys must be supplied securely by deployment secret management.
 - Durable terminal relay is JSON-file based when `GITHUB_RELAY_QUEUE_PATH` is set. Failed relay attempts are retained with `lastError`, attempt count, and retry timing; deployments should place this path on persistent storage.
 - Terminal outcome comment relay is available when `GITHUB_FOLLOW_TERMINAL_EVENTS=true`; the webhook response only waits for scheduling/enqueue, not for the run to reach a terminal state.
-- Repository/project allowlists and sender-login actor authorization are supported; team-based authorization is not implemented yet.
+- Repository/project allowlists plus sender-login, organization, and team-based authorization are supported.
 - Non-terminal progress is intentionally not posted to GitHub; use the operator UI, terminal, Telegram, or SSE surfaces for detailed progress.
 - GitHub is not a canonical artifact or run-history store. Completed-run reports remain derived read-only exports at `GET /runs/:runId/report.md`.
 
 ## Recommended follow-ups
 
-1. Add GitHub team/org-based authorization for `/specrail` commands.
-2. Add richer terminal outcome links once hosted operator run URLs are finalized.
-3. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
+1. Add richer terminal outcome links once hosted operator run URLs are finalized.
+2. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
+3. Add admin-facing diagnostics for denied GitHub `/specrail` commands.


### PR DESCRIPTION
## Summary
- add GitHub org/team membership authorization for /specrail command senders
- preserve existing GITHUB_ALLOWED_ACTORS behavior while allowing actor/org/team policies to combine
- add a GitHub REST authorization client boundary and webhook tests for org/team success and authorization API failures
- document GITHUB_ALLOWED_ORGS and GITHUB_ALLOWED_TEAMS

Closes #315

## Verification
- pnpm check
- pnpm test
- pnpm build