### PR TITLE
feat: add GitHub operator run links

### DIFF
--- a/apps/api/src/__tests__/operator-ui-harness.ts
+++ b/apps/api/src/__tests__/operator-ui-harness.ts
@@ -138,7 +138,7 @@ export class FakeEventSource {
   }
 }
 
-export function createHostedUiClientHarness() {
+export function createHostedUiClientHarness(input: { search?: string } = {}) {
   const selectors = [
     "#project-scope",
     "#status",
@@ -306,6 +306,8 @@ export function createHostedUiClientHarness() {
       }
     },
     EventSource,
+    URLSearchParams,
+    window: { location: { search: input.search ?? "" } },
   });
 
   const detail = elements.get("#detail")!;

--- a/apps/api/src/__tests__/operator-ui.test.ts
+++ b/apps/api/src/__tests__/operator-ui.test.ts
@@ -483,3 +483,13 @@ test("operator UI shell keeps hosted action and stream wiring", () => {
     assertContainsAll(body, patterns);
   }
 });
+
+test("operator UI client opens run detail from runId query parameter", async () => {
+  const { calls, detail, loadInitialState } = createHostedUiClientHarness({ search: "?runId=run%2Flinked" });
+  await loadInitialState();
+  await flushClientPromises();
+
+  assert.ok(calls.some((call) => call.path === "/runs/run%2Flinked" && call.method === "GET"));
+  assert.ok(calls.some((call) => call.path === "/runs/run%2Flinked/events" && call.method === "GET"));
+  assert.match(detail.innerHTML, /Run run\/linked/);
+});

--- a/apps/api/src/operator-ui.ts
+++ b/apps/api/src/operator-ui.ts
@@ -131,6 +131,7 @@ export function renderOperatorUiClientScript(): string {
     const trackPriority = document.querySelector('#track-priority');
     let activeEventStream = null;
     let projectsById = new Map();
+    const initialRunId = new URLSearchParams(window.location.search).get('runId');
 
     async function api(path, init) {
       const response = await fetch(path, { headers: { accept: 'application/json', 'content-type': 'application/json' }, ...init });
@@ -593,7 +594,9 @@ export function renderOperatorUiClientScript(): string {
     refresh.addEventListener('click', () => {
       load().catch((error) => { status.textContent = errorMessage(error); });
     });
-    load().catch((error) => { status.textContent = errorMessage(error); });
+    load()
+      .then(() => { if (initialRunId) return loadRunDetail(initialRunId); return undefined; })
+      .catch((error) => { status.textContent = errorMessage(error); });
 `;
 }
 

--- a/apps/github/src/__tests__/github-app.test.ts
+++ b/apps/github/src/__tests__/github-app.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { test } from "node:test";
 import {
   authorizeGitHubActor,
+  buildGitHubOperatorRunUrl,
   buildGitHubSignature256,
   createGitHubAppInstallationTokenProvider,
   createGitHubAppJwt,
@@ -227,8 +228,9 @@ test("formatGitHubTerminalOutcomeComment formats terminal outcomes with optional
       runId: "run-1",
       status: "completed",
       reportUrl: "https://specrail.example.test/runs/run-1/report.md",
+      operatorUrl: "https://specrail.example.test/operator?runId=run-1",
     }),
-    "SpecRail run run-1 completed.\nReport: https://specrail.example.test/runs/run-1/report.md",
+    "SpecRail run run-1 completed.\nReport: https://specrail.example.test/runs/run-1/report.md\nOperator: https://specrail.example.test/operator?runId=run-1",
   );
   assert.equal(
     formatGitHubTerminalOutcomeComment({ repositoryFullName: "yoophi-a/specrail", issueNumber: 123, runId: "run-2", status: "failed" }),
@@ -242,6 +244,10 @@ test("formatGitHubTerminalOutcomeComment formats terminal outcomes with optional
     formatGitHubTerminalOutcomeComment({ repositoryFullName: "yoophi-a/specrail", issueNumber: 123, runId: "run-4", status: "running" }),
     undefined,
   );
+});
+
+test("buildGitHubOperatorRunUrl creates encoded hosted run detail links", () => {
+  assert.equal(buildGitHubOperatorRunUrl("https://specrail.example.test", "run/opaque value"), "https://specrail.example.test/operator?runId=run%2Fopaque+value");
 });
 
 test("postGitHubTerminalOutcomeComment posts terminal comments and ignores progress statuses", async () => {
@@ -831,10 +837,12 @@ test("loadGitHubAppConfig parses repository project mappings and actor allowlist
     GITHUB_WEBHOOK_SECRET: "secret",
     SPECRAIL_GITHUB_REPOSITORY_PROJECTS: "yoophi-a/specrail=project-specrail, other/repo = project-other",
     GITHUB_ALLOWED_ACTORS: "octocat,@hubot",
+    SPECRAIL_OPERATOR_BASE_URL: "https://specrail.example.test",
   });
 
   assert.deepEqual(config.repositoryProjects, { "yoophi-a/specrail": "project-specrail", "other/repo": "project-other" });
   assert.deepEqual(config.allowedActors, ["octocat", "@hubot"]);
+  assert.equal(config.operatorBaseUrl, "https://specrail.example.test");
   assert.equal(resolveGitHubProjectId(config, "yoophi-a/specrail"), "project-specrail");
   assert.equal(resolveGitHubProjectId(config, "missing/repo"), undefined);
   assert.equal(isGitHubActorAuthorized(config, "octocat"), true);

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -13,6 +13,7 @@ export interface GitHubRunCommand {
 
 export interface GitHubAppConfig {
   apiBaseUrl: string;
+  operatorBaseUrl?: string;
   port: number;
   webhookPath: string;
   webhookSecret: string;
@@ -107,6 +108,7 @@ export interface GitHubRunCommandOutcome {
   planningSessionId?: string;
   runId: string;
   reportUrl?: string;
+  operatorUrl?: string;
 }
 
 export type GitHubRunOutcomeStatus = "queued" | "running" | "waiting_approval" | "completed" | "failed" | "cancelled";
@@ -143,6 +145,7 @@ export interface GitHubTerminalRelayJob {
   issueNumber: number;
   runId: string;
   reportUrl?: string;
+  operatorUrl?: string;
   status: "pending" | "running" | "completed" | "failed";
   attempts: number;
   createdAt: string;
@@ -152,7 +155,7 @@ export interface GitHubTerminalRelayJob {
 }
 
 export interface GitHubRelayJobQueue {
-  enqueue(input: { repositoryFullName: string; issueNumber: number; runId: string; reportUrl?: string }): Promise<GitHubTerminalRelayJob>;
+  enqueue(input: { repositoryFullName: string; issueNumber: number; runId: string; reportUrl?: string; operatorUrl?: string }): Promise<GitHubTerminalRelayJob>;
   claimNext(now?: Date): Promise<GitHubTerminalRelayJob | undefined>;
   complete(jobId: string, now?: Date): Promise<void>;
   fail(jobId: string, error: unknown, now?: Date): Promise<void>;
@@ -165,6 +168,7 @@ export interface GitHubTerminalOutcomeCommentInput {
   runId: string;
   status: GitHubRunOutcomeStatus;
   reportUrl?: string;
+  operatorUrl?: string;
 }
 
 export type GitHubTerminalOutcomeCommentResult =
@@ -273,6 +277,7 @@ export async function authorizeGitHubActor(input: {
 export function loadGitHubAppConfig(env: NodeJS.ProcessEnv = process.env): GitHubAppConfig {
   return {
     apiBaseUrl: env.SPECRAIL_API_BASE_URL ?? "http://127.0.0.1:4000",
+    operatorBaseUrl: env.SPECRAIL_OPERATOR_BASE_URL,
     port: Number(env.GITHUB_APP_PORT ?? 4200),
     webhookPath: env.GITHUB_WEBHOOK_PATH ?? "/github/webhook",
     webhookSecret: env.GITHUB_WEBHOOK_SECRET ?? "",
@@ -636,6 +641,12 @@ export function buildGitHubRunReportUrl(apiBaseUrl: string, runId: string): stri
   return new URL(`/runs/${encodeURIComponent(runId)}/report.md`, apiBaseUrl).toString();
 }
 
+export function buildGitHubOperatorRunUrl(operatorBaseUrl: string, runId: string): string {
+  const url = new URL("/operator", operatorBaseUrl);
+  url.searchParams.set("runId", runId);
+  return url.toString();
+}
+
 function isTerminalGitHubRunStatus(status: GitHubRunOutcomeStatus): status is "completed" | "failed" | "cancelled" {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
@@ -669,6 +680,9 @@ export function formatGitHubTerminalOutcomeComment(input: GitHubTerminalOutcomeC
   if (input.reportUrl) {
     lines.push(`Report: ${input.reportUrl}`);
   }
+  if (input.operatorUrl) {
+    lines.push(`Operator: ${input.operatorUrl}`);
+  }
   return lines.join("\n");
 }
 
@@ -699,6 +713,7 @@ export function scheduleGitHubRunTerminalOutcomeRelay(input: {
   issueNumber: number;
   runId: string;
   reportUrl?: string;
+  operatorUrl?: string;
   onError?: (error: unknown) => void;
 }): GitHubRunEventRelayScheduleResult {
   if (!input.enabled) {
@@ -717,6 +732,7 @@ export function scheduleGitHubRunTerminalOutcomeRelay(input: {
         issueNumber: input.issueNumber,
         runId: input.runId,
         reportUrl: input.reportUrl,
+        operatorUrl: input.operatorUrl,
       });
     } catch (error) {
       input.onError?.(error);
@@ -736,6 +752,7 @@ export async function relayGitHubRunTerminalOutcome(input: {
   issueNumber: number;
   runId: string;
   reportUrl?: string;
+  operatorUrl?: string;
 }): Promise<GitHubRunEventRelayResult> {
   if (!input.specRail.streamRunEvents) {
     return { posted: false, reason: "stream_not_available" };
@@ -755,6 +772,7 @@ export async function relayGitHubRunTerminalOutcome(input: {
         runId: input.runId,
         status,
         reportUrl: input.reportUrl,
+        operatorUrl: input.operatorUrl,
       },
     });
 
@@ -774,7 +792,7 @@ function createRelayJobId(input: { repositoryFullName: string; issueNumber: numb
 export class JsonFileGitHubRelayJobQueue implements GitHubRelayJobQueue {
   constructor(private readonly filePath: string) {}
 
-  async enqueue(input: { repositoryFullName: string; issueNumber: number; runId: string; reportUrl?: string }): Promise<GitHubTerminalRelayJob> {
+  async enqueue(input: { repositoryFullName: string; issueNumber: number; runId: string; reportUrl?: string; operatorUrl?: string }): Promise<GitHubTerminalRelayJob> {
     const now = new Date();
     const jobs = await this.readJobs();
     const job: GitHubTerminalRelayJob = {
@@ -782,7 +800,8 @@ export class JsonFileGitHubRelayJobQueue implements GitHubRelayJobQueue {
       repositoryFullName: input.repositoryFullName,
       issueNumber: input.issueNumber,
       runId: input.runId,
-      reportUrl: input.reportUrl,
+      ...(input.reportUrl ? { reportUrl: input.reportUrl } : {}),
+      ...(input.operatorUrl ? { operatorUrl: input.operatorUrl } : {}),
       status: "pending",
       attempts: 0,
       createdAt: now.toISOString(),
@@ -873,6 +892,7 @@ export async function processGitHubRelayQueue(input: {
       issueNumber: job.issueNumber,
       runId: job.runId,
       reportUrl: job.reportUrl,
+      operatorUrl: job.operatorUrl,
     });
     await input.queue.complete(job.id, input.now);
     return { processed: true, jobId: job.id, result };
@@ -1022,6 +1042,7 @@ export async function handleGitHubWebhookHttpRequest(
       apiBaseUrl: deps.config.apiBaseUrl,
     });
     let relay: GitHubRunEventRelayScheduleResult | undefined;
+    const operatorUrl = deps.config.operatorBaseUrl ? buildGitHubOperatorRunUrl(deps.config.operatorBaseUrl, outcome.runId) : undefined;
     try {
       if (deps.config.followTerminalEvents && deps.github && deps.relayQueue) {
         await deps.relayQueue.enqueue({
@@ -1029,6 +1050,7 @@ export async function handleGitHubWebhookHttpRequest(
           issueNumber: command.issueNumber,
           runId: outcome.runId,
           reportUrl: outcome.reportUrl,
+          operatorUrl,
         });
         relay = { scheduled: true };
       } else {
@@ -1041,6 +1063,7 @@ export async function handleGitHubWebhookHttpRequest(
           issueNumber: command.issueNumber,
           runId: outcome.runId,
           reportUrl: outcome.reportUrl,
+          operatorUrl,
           onError: (error) => console.error("GitHub terminal outcome relay failed", error),
         });
       }

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -38,6 +38,7 @@ The runnable app entrypoint reads these environment variables:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SPECRAIL_API_BASE_URL` | `http://127.0.0.1:4000` | Base URL for the SpecRail API. Also used to derive `/runs/:runId/report.md` links. |
+| `SPECRAIL_OPERATOR_BASE_URL` | unset | Optional hosted operator UI base URL. When set, terminal outcome comments include `/operator?runId=...` links. |
 | `SPECRAIL_GITHUB_PROJECT_ID` | `SPECRAIL_PROJECT_ID` or `project-default` | Default project id used when creating tracks from GitHub issues/PRs. |
 | `SPECRAIL_PROJECT_ID` | `project-default` | Fallback project id when `SPECRAIL_GITHUB_PROJECT_ID` is not set. |
 | `SPECRAIL_GITHUB_REPOSITORY_PROJECTS` | unset | Optional comma-separated repository allowlist and project map, for example `yoophi-a/specrail=project-specrail,other/repo=project-other`. When set, unmapped repositories are ignored. |
@@ -92,12 +93,13 @@ The webhook endpoint returns JSON responses:
 - REST issue-comment posting supports static tokens and GitHub App installation-token refresh. Private keys must be supplied securely by deployment secret management.
 - Durable terminal relay is JSON-file based when `GITHUB_RELAY_QUEUE_PATH` is set. Failed relay attempts are retained with `lastError`, attempt count, and retry timing; deployments should place this path on persistent storage.
 - Terminal outcome comment relay is available when `GITHUB_FOLLOW_TERMINAL_EVENTS=true`; the webhook response only waits for scheduling/enqueue, not for the run to reach a terminal state.
+- Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state.
 - Repository/project allowlists plus sender-login, organization, and team-based authorization are supported.
 - Non-terminal progress is intentionally not posted to GitHub; use the operator UI, terminal, Telegram, or SSE surfaces for detailed progress.
 - GitHub is not a canonical artifact or run-history store. Completed-run reports remain derived read-only exports at `GET /runs/:runId/report.md`.
 
 ## Recommended follow-ups
 
-1. Add richer terminal outcome links once hosted operator run URLs are finalized.
-2. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
-3. Add admin-facing diagnostics for denied GitHub `/specrail` commands.
+1. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
+2. Add admin-facing diagnostics for denied GitHub `/specrail` commands.
+3. Add deployment documentation for publishing the hosted operator UI behind auth.


### PR DESCRIPTION
## Summary
- add SPECRAIL_OPERATOR_BASE_URL and hosted /operator?runId=... link generation for GitHub terminal outcome comments
- persist operator links through the durable GitHub relay queue and scheduled relay path
- allow the hosted operator UI to open a run detail from the runId query parameter
- update GitHub app setup docs

Closes #317

## Verification
- pnpm check
- pnpm test
- pnpm build