### PR TITLE
feat: add GitHub denial diagnostics

### DIFF
--- a/apps/github/src/__tests__/github-app.test.ts
+++ b/apps/github/src/__tests__/github-app.test.ts
@@ -297,6 +297,7 @@ async function withGitHubWebhookServer(
   fn: (baseUrl: string) => Promise<void>,
   configOverrides: Partial<ReturnType<typeof loadGitHubAppConfig>> = {},
   authorization?: { isOrganizationMember(input: { organization: string; username: string }): Promise<boolean>; isTeamMember(input: { organization: string; teamSlug: string; username: string }): Promise<boolean> },
+  diagnostics?: { log(input: { code: "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed"; repositoryFullName: string; issueNumber: number; senderLogin?: string; message?: string }): void },
 ): Promise<void> {
   const server = createGitHubWebhookHttpServer({
     config: {
@@ -315,6 +316,7 @@ async function withGitHubWebhookServer(
     },
     specRail,
     authorization,
+    diagnostics,
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -1182,4 +1184,61 @@ test("GitHub webhook HTTP app accepts org-authorized actors and rejects authoriz
     },
   );
   assert.deepEqual(rejected.calls, []);
+});
+
+test("GitHub webhook HTTP app emits safe diagnostics for denied commands", async () => {
+  const diagnostics: Array<{ code: string; repositoryFullName: string; issueNumber: number; senderLogin?: string; message?: string }> = [];
+  const logger = { log(input: { code: "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed"; repositoryFullName: string; issueNumber: number; senderLogin?: string; message?: string }) { diagnostics.push(input); } };
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run unsupported"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+      assert.deepEqual(await response.json(), { accepted: false, reason: "unsupported_repository" });
+    },
+    { repositoryProjects: { "other/repo": "project-other" } },
+    undefined,
+    logger,
+  );
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run unauthorized"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+      assert.deepEqual(await response.json(), { accepted: false, reason: "unauthorized_actor" });
+    },
+    { allowedActors: ["hubot"] },
+    undefined,
+    logger,
+  );
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run auth failure"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 502);
+      assert.deepEqual(await response.json(), { error: "github_authorization_failed", message: "membership lookup failed" });
+    },
+    { allowedOrganizations: ["yoophi-a"] },
+    {
+      async isOrganizationMember() {
+        throw new Error("membership lookup failed");
+      },
+      async isTeamMember() {
+        return false;
+      },
+    },
+    logger,
+  );
+
+  assert.deepEqual(diagnostics, [
+    { code: "unsupported_repository", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: undefined },
+    { code: "unauthorized_actor", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: undefined },
+    { code: "github_authorization_failed", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: "membership lookup failed" },
+  ]);
 });

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -130,11 +130,22 @@ export interface GitHubBackgroundTaskScheduler {
   schedule(task: () => Promise<void>): void;
 }
 
+export interface GitHubDiagnosticLogger {
+  log(input: {
+    code: "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed";
+    repositoryFullName: string;
+    issueNumber: number;
+    senderLogin?: string;
+    message?: string;
+  }): void;
+}
+
 export interface GitHubWebhookAppDeps {
   config: GitHubAppConfig;
   specRail: GitHubSpecRailPort;
   github?: GitHubIssueCommentPort;
   authorization?: GitHubAuthorizationPort;
+  diagnostics?: GitHubDiagnosticLogger;
   scheduler?: GitHubBackgroundTaskScheduler;
   relayQueue?: GitHubRelayJobQueue;
 }
@@ -564,6 +575,12 @@ export const defaultGitHubBackgroundTaskScheduler: GitHubBackgroundTaskScheduler
   },
 };
 
+export const defaultGitHubDiagnosticLogger: GitHubDiagnosticLogger = {
+  log(input) {
+    console.warn("GitHub /specrail command diagnostic", JSON.stringify(input));
+  },
+};
+
 export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRail?: GitHubSpecRailPort; github?: GitHubIssueCommentPort } = {}): http.Server {
   const config = input.config ?? loadGitHubAppConfig();
   const specRail = input.specRail ?? createSpecRailHttpClient(config.apiBaseUrl);
@@ -571,7 +588,15 @@ export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRai
   const github = input.github ?? (tokenProvider ? createGitHubRestIssueCommentClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined);
   const authorization = tokenProvider ? createGitHubRestAuthorizationClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined;
   const relayQueue = config.githubRelayQueuePath ? new JsonFileGitHubRelayJobQueue(config.githubRelayQueuePath) : undefined;
-  const server = createGitHubWebhookHttpServer({ config, specRail, github, authorization, scheduler: defaultGitHubBackgroundTaskScheduler, relayQueue });
+  const server = createGitHubWebhookHttpServer({
+    config,
+    specRail,
+    github,
+    authorization,
+    diagnostics: defaultGitHubDiagnosticLogger,
+    scheduler: defaultGitHubBackgroundTaskScheduler,
+    relayQueue,
+  });
   if (relayQueue && github) {
     const interval = setInterval(() => {
       processGitHubRelayQueue({ queue: relayQueue, specRail, github }).catch((error: unknown) => {
@@ -976,6 +1001,20 @@ function sendJson(response: ServerResponse, statusCode: number, body: unknown): 
   response.end(`${JSON.stringify(body)}\n`);
 }
 
+function logGitHubCommandDiagnostic(
+  deps: GitHubWebhookAppDeps,
+  command: GitHubAcceptedRunCommandContext,
+  input: { code: "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed"; message?: string },
+): void {
+  deps.diagnostics?.log({
+    code: input.code,
+    repositoryFullName: command.repositoryFullName,
+    issueNumber: command.issueNumber,
+    senderLogin: command.senderLogin,
+    message: input.message,
+  });
+}
+
 function normalizeWebhookPath(pathname: string | undefined): string {
   const trimmed = pathname?.trim() || "/github/webhook";
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
@@ -1020,6 +1059,7 @@ export async function handleGitHubWebhookHttpRequest(
   try {
     const projectId = resolveGitHubProjectId(deps.config, command.repositoryFullName);
     if (!projectId) {
+      logGitHubCommandDiagnostic(deps, command, { code: "unsupported_repository" });
       sendJson(response, 202, { accepted: false, reason: "unsupported_repository" });
       return;
     }
@@ -1027,10 +1067,13 @@ export async function handleGitHubWebhookHttpRequest(
     try {
       authorized = await authorizeGitHubActor({ config: deps.config, senderLogin: command.senderLogin, authorization: deps.authorization });
     } catch (error) {
-      sendJson(response, 502, { error: "github_authorization_failed", message: error instanceof Error ? error.message : String(error) });
+      const message = error instanceof Error ? error.message : String(error);
+      logGitHubCommandDiagnostic(deps, command, { code: "github_authorization_failed", message });
+      sendJson(response, 502, { error: "github_authorization_failed", message });
       return;
     }
     if (!authorized) {
+      logGitHubCommandDiagnostic(deps, command, { code: "unauthorized_actor" });
       sendJson(response, 202, { accepted: false, reason: "unauthorized_actor" });
       return;
     }

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -82,11 +82,12 @@ The webhook endpoint returns JSON responses:
 
 - `202 { accepted: true, outcome }` when a `/specrail run` command starts orchestration.
 - `202 { accepted: true, outcome, relay: { scheduled: true } }` when terminal outcome relay is enabled and successfully scheduled.
-- `202 { accepted: false, reason }` for ignored events, unsupported actions, unsupported commands, missing context, unsupported repositories, or unauthorized actors.
+- `202 { accepted: false, reason }` for ignored events, unsupported actions, unsupported commands, missing context, unsupported repositories, or unauthorized actors. Unsupported repositories and unauthorized actors also emit safe internal diagnostics.
 - `401 { accepted: false, reason: "invalid_signature" }` for signature failures.
 - `400 { error: "invalid_json" }` for malformed JSON payloads.
 - `502 { error: "specrail_request_failed", message }` when the SpecRail API call fails.
 - `502 { error: "github_relay_enqueue_failed", message, outcome }` when run creation succeeds but the terminal relay scheduler rejects the background task.
+- `502 { error: "github_authorization_failed", message }` when GitHub org/team membership checks fail before run creation. This also emits a safe internal diagnostic.
 
 ## Current limitations
 
@@ -101,5 +102,5 @@ The webhook endpoint returns JSON responses:
 ## Recommended follow-ups
 
 1. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
-2. Add admin-facing diagnostics for denied GitHub `/specrail` commands.
-3. Add deployment documentation for publishing the hosted operator UI behind auth.
+2. Add deployment documentation for publishing the hosted operator UI behind auth.
+3. Add metrics counters for GitHub command accept/deny outcomes.


### PR DESCRIPTION
## Summary
- add safe diagnostic logging for unsupported repository, unauthorized actor, and GitHub authorization failure paths
- wire a default production logger for the GitHub app entrypoint while keeping webhook responses unchanged
- cover diagnostic records in webhook tests and document the new behavior

Closes #319

## Verification
- pnpm check
- pnpm test
- pnpm build