### PR TITLE
feat: add GitHub command metrics

### DIFF
--- a/apps/github/src/__tests__/github-app.test.ts
+++ b/apps/github/src/__tests__/github-app.test.ts
@@ -298,6 +298,7 @@ async function withGitHubWebhookServer(
   configOverrides: Partial<ReturnType<typeof loadGitHubAppConfig>> = {},
   authorization?: { isOrganizationMember(input: { organization: string; username: string }): Promise<boolean>; isTeamMember(input: { organization: string; teamSlug: string; username: string }): Promise<boolean> },
   diagnostics?: { log(input: { code: "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed"; repositoryFullName: string; issueNumber: number; senderLogin?: string; message?: string }): void },
+  metrics?: { increment(input: { reason: "accepted" | "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed" | "specrail_request_failed" | "github_relay_enqueue_failed" }): void },
 ): Promise<void> {
   const server = createGitHubWebhookHttpServer({
     config: {
@@ -317,6 +318,7 @@ async function withGitHubWebhookServer(
     specRail,
     authorization,
     diagnostics,
+    metrics,
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
@@ -1240,5 +1242,74 @@ test("GitHub webhook HTTP app emits safe diagnostics for denied commands", async
     { code: "unsupported_repository", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: undefined },
     { code: "unauthorized_actor", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: undefined },
     { code: "github_authorization_failed", repositoryFullName: "yoophi-a/specrail", issueNumber: 123, senderLogin: "octocat", message: "membership lookup failed" },
+  ]);
+});
+
+test("GitHub webhook HTTP app records command outcome metrics", async () => {
+  const metrics: Array<{ reason: string }> = [];
+  const sink = { increment(input: { reason: "accepted" | "unsupported_repository" | "unauthorized_actor" | "github_authorization_failed" | "specrail_request_failed" | "github_relay_enqueue_failed" }) { metrics.push(input); } };
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run accepted"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+    },
+    {},
+    undefined,
+    undefined,
+    sink,
+  );
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run unsupported"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+    },
+    { repositoryProjects: { "other/repo": "project-other" } },
+    undefined,
+    undefined,
+    sink,
+  );
+
+  await withGitHubWebhookServer(
+    createSpecRailPort().port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run unauthorized"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 202);
+    },
+    { allowedActors: ["hubot"] },
+    undefined,
+    undefined,
+    sink,
+  );
+
+  const specRailFailure = createSpecRailPort({
+    async createTrack() {
+      throw new Error("SpecRail unavailable");
+    },
+  });
+  await withGitHubWebhookServer(
+    specRailFailure.port,
+    async (baseUrl) => {
+      const body = JSON.stringify(payload("/specrail run fail"));
+      const response = await fetch(`${baseUrl}/github/webhook`, signedWebhookInit(body));
+      assert.equal(response.status, 502);
+    },
+    {},
+    undefined,
+    undefined,
+    sink,
+  );
+
+  assert.deepEqual(metrics, [
+    { reason: "accepted" },
+    { reason: "unsupported_repository" },
+    { reason: "unauthorized_actor" },
+    { reason: "specrail_request_failed" },
   ]);
 });

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -140,12 +140,25 @@ export interface GitHubDiagnosticLogger {
   }): void;
 }
 
+export type GitHubCommandMetricReason =
+  | "accepted"
+  | "unsupported_repository"
+  | "unauthorized_actor"
+  | "github_authorization_failed"
+  | "specrail_request_failed"
+  | "github_relay_enqueue_failed";
+
+export interface GitHubCommandMetricsSink {
+  increment(input: { reason: GitHubCommandMetricReason }): void;
+}
+
 export interface GitHubWebhookAppDeps {
   config: GitHubAppConfig;
   specRail: GitHubSpecRailPort;
   github?: GitHubIssueCommentPort;
   authorization?: GitHubAuthorizationPort;
   diagnostics?: GitHubDiagnosticLogger;
+  metrics?: GitHubCommandMetricsSink;
   scheduler?: GitHubBackgroundTaskScheduler;
   relayQueue?: GitHubRelayJobQueue;
 }
@@ -581,6 +594,12 @@ export const defaultGitHubDiagnosticLogger: GitHubDiagnosticLogger = {
   },
 };
 
+export const defaultGitHubCommandMetricsSink: GitHubCommandMetricsSink = {
+  increment() {
+    // Default local/dev sink is intentionally quiet; deployments can inject metrics exporters.
+  },
+};
+
 export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRail?: GitHubSpecRailPort; github?: GitHubIssueCommentPort } = {}): http.Server {
   const config = input.config ?? loadGitHubAppConfig();
   const specRail = input.specRail ?? createSpecRailHttpClient(config.apiBaseUrl);
@@ -594,6 +613,7 @@ export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRai
     github,
     authorization,
     diagnostics: defaultGitHubDiagnosticLogger,
+    metrics: defaultGitHubCommandMetricsSink,
     scheduler: defaultGitHubBackgroundTaskScheduler,
     relayQueue,
   });
@@ -1015,6 +1035,10 @@ function logGitHubCommandDiagnostic(
   });
 }
 
+function incrementGitHubCommandMetric(deps: GitHubWebhookAppDeps, reason: GitHubCommandMetricReason): void {
+  deps.metrics?.increment({ reason });
+}
+
 function normalizeWebhookPath(pathname: string | undefined): string {
   const trimmed = pathname?.trim() || "/github/webhook";
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
@@ -1060,6 +1084,7 @@ export async function handleGitHubWebhookHttpRequest(
     const projectId = resolveGitHubProjectId(deps.config, command.repositoryFullName);
     if (!projectId) {
       logGitHubCommandDiagnostic(deps, command, { code: "unsupported_repository" });
+      incrementGitHubCommandMetric(deps, "unsupported_repository");
       sendJson(response, 202, { accepted: false, reason: "unsupported_repository" });
       return;
     }
@@ -1069,11 +1094,13 @@ export async function handleGitHubWebhookHttpRequest(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logGitHubCommandDiagnostic(deps, command, { code: "github_authorization_failed", message });
+      incrementGitHubCommandMetric(deps, "github_authorization_failed");
       sendJson(response, 502, { error: "github_authorization_failed", message });
       return;
     }
     if (!authorized) {
       logGitHubCommandDiagnostic(deps, command, { code: "unauthorized_actor" });
+      incrementGitHubCommandMetric(deps, "unauthorized_actor");
       sendJson(response, 202, { accepted: false, reason: "unauthorized_actor" });
       return;
     }
@@ -1111,11 +1138,14 @@ export async function handleGitHubWebhookHttpRequest(
         });
       }
     } catch (error) {
+      incrementGitHubCommandMetric(deps, "github_relay_enqueue_failed");
       sendJson(response, 502, { error: "github_relay_enqueue_failed", message: error instanceof Error ? error.message : String(error), outcome });
       return;
     }
+    incrementGitHubCommandMetric(deps, "accepted");
     sendJson(response, 202, relay?.scheduled ? { accepted: true, outcome, relay } : { accepted: true, outcome });
   } catch (error) {
+    incrementGitHubCommandMetric(deps, "specrail_request_failed");
     sendJson(response, 502, { error: "specrail_request_failed", message: error instanceof Error ? error.message : String(error) });
   }
 }

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -95,6 +95,7 @@ The webhook endpoint returns JSON responses:
 - Durable terminal relay is JSON-file based when `GITHUB_RELAY_QUEUE_PATH` is set. Failed relay attempts are retained with `lastError`, attempt count, and retry timing; deployments should place this path on persistent storage.
 - Terminal outcome comment relay is available when `GITHUB_FOLLOW_TERMINAL_EVENTS=true`; the webhook response only waits for scheduling/enqueue, not for the run to reach a terminal state.
 - Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state.
+- GitHub command outcome metrics are exposed through an injectable metrics sink with coarse reason labels only: accepted, unsupported repository, unauthorized actor, GitHub authorization failure, SpecRail request failure, and relay enqueue failure.
 - Repository/project allowlists plus sender-login, organization, and team-based authorization are supported.
 - Non-terminal progress is intentionally not posted to GitHub; use the operator UI, terminal, Telegram, or SSE surfaces for detailed progress.
 - GitHub is not a canonical artifact or run-history store. Completed-run reports remain derived read-only exports at `GET /runs/:runId/report.md`.
@@ -103,4 +104,4 @@ The webhook endpoint returns JSON responses:
 
 1. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
 2. Add deployment documentation for publishing the hosted operator UI behind auth.
-3. Add metrics counters for GitHub command accept/deny outcomes.
+3. Add operator-facing troubleshooting examples for interpreting GitHub diagnostics and metrics together.


### PR DESCRIPTION
## Summary
- add an injectable GitHub command metrics sink with coarse reason labels
- increment accepted, unsupported repository, unauthorized actor, GitHub authorization failure, SpecRail request failure, and relay enqueue failure outcomes
- keep the default metrics sink quiet for local/dev use and preserve existing webhook responses
- document the metric reasons

Closes #321

## Verification
- pnpm check
- pnpm test
- pnpm build