### PR TITLE
docs: add operator UI deployment guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Use this index to find the right reference before changing SpecRail's core servi
 ## Client surfaces
 
 - [Terminal client](./terminal-client.md) — terminal UI behavior, run following, planning workspace, and controls.
+- [Hosted Operator UI deployment](./operator-ui-deployment.md) — authentication, reverse-proxy, and security guidance for publishing `/operator` links.
 - [GitHub App setup](./github-app-setup.md) — runnable webhook app configuration, command flow, binding semantics, and current limitations.
 - [Telegram bot interface strategy](./architecture/telegram-bot-interface-strategy.md) — Telegram-facing product and integration strategy.
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -38,7 +38,7 @@ The runnable app entrypoint reads these environment variables:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SPECRAIL_API_BASE_URL` | `http://127.0.0.1:4000` | Base URL for the SpecRail API. Also used to derive `/runs/:runId/report.md` links. |
-| `SPECRAIL_OPERATOR_BASE_URL` | unset | Optional hosted operator UI base URL. When set, terminal outcome comments include `/operator?runId=...` links. |
+| `SPECRAIL_OPERATOR_BASE_URL` | unset | Optional authenticated hosted operator UI base URL. When set, terminal outcome comments include `/operator?runId=...` links. See [Hosted Operator UI deployment](./operator-ui-deployment.md). |
 | `SPECRAIL_GITHUB_PROJECT_ID` | `SPECRAIL_PROJECT_ID` or `project-default` | Default project id used when creating tracks from GitHub issues/PRs. |
 | `SPECRAIL_PROJECT_ID` | `project-default` | Fallback project id when `SPECRAIL_GITHUB_PROJECT_ID` is not set. |
 | `SPECRAIL_GITHUB_REPOSITORY_PROJECTS` | unset | Optional comma-separated repository allowlist and project map, for example `yoophi-a/specrail=project-specrail,other/repo=project-other`. When set, unmapped repositories are ignored. |
@@ -94,7 +94,7 @@ The webhook endpoint returns JSON responses:
 - REST issue-comment posting supports static tokens and GitHub App installation-token refresh. Private keys must be supplied securely by deployment secret management.
 - Durable terminal relay is JSON-file based when `GITHUB_RELAY_QUEUE_PATH` is set. Failed relay attempts are retained with `lastError`, attempt count, and retry timing; deployments should place this path on persistent storage.
 - Terminal outcome comment relay is available when `GITHUB_FOLLOW_TERMINAL_EVENTS=true`; the webhook response only waits for scheduling/enqueue, not for the run to reach a terminal state.
-- Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state.
+- Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state. Do not expose unauthenticated operator URLs in GitHub comments.
 - GitHub command outcome metrics are exposed through an injectable metrics sink with coarse reason labels only: accepted, unsupported repository, unauthorized actor, GitHub authorization failure, SpecRail request failure, and relay enqueue failure.
 - Repository/project allowlists plus sender-login, organization, and team-based authorization are supported.
 - Non-terminal progress is intentionally not posted to GitHub; use the operator UI, terminal, Telegram, or SSE surfaces for detailed progress.
@@ -103,5 +103,5 @@ The webhook endpoint returns JSON responses:
 ## Recommended follow-ups
 
 1. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
-2. Add deployment documentation for publishing the hosted operator UI behind auth.
-3. Add operator-facing troubleshooting examples for interpreting GitHub diagnostics and metrics together.
+2. Add operator-facing troubleshooting examples for interpreting GitHub diagnostics and metrics together.
+3. Add an example reverse-proxy config for a concrete deployment target.

--- a/docs/operator-ui-deployment.md
+++ b/docs/operator-ui-deployment.md
@@ -1,0 +1,68 @@
+# Hosted Operator UI Deployment
+
+SpecRail serves a hosted operator UI at `GET /operator`. The UI is a thin frontend over the existing SpecRail HTTP/SSE API: it does not own canonical run state, artifacts, or GitHub history. Deploy it as an authenticated operational surface, not as a public website.
+
+## Recommended deployment shape
+
+Put the SpecRail API behind a reverse proxy that provides TLS and authentication before traffic reaches the app:
+
+```text
+operator browser
+  -> HTTPS reverse proxy / identity-aware proxy
+  -> SpecRail API server
+       - GET /operator
+       - /projects
+       - /tracks
+       - /runs
+       - /approval-requests
+```
+
+Use the authenticated public base URL as `SPECRAIL_OPERATOR_BASE_URL` for GitHub terminal comments. For example:
+
+```sh
+SPECRAIL_OPERATOR_BASE_URL=https://specrail.example.com
+```
+
+When this value is configured, GitHub terminal outcome comments can include links like:
+
+```text
+Operator: https://specrail.example.com/operator?runId=run-123
+```
+
+The linked page loads run details through the same protected API routes. Do not point `SPECRAIL_OPERATOR_BASE_URL` at an unauthenticated or internal-only URL that GitHub users cannot safely open.
+
+## Auth and routing requirements
+
+Protect at least these routes as one operator surface:
+
+- `GET /operator`
+- `GET /projects`, `POST /projects`, `PATCH /projects/:projectId`
+- `GET /tracks`, `POST /tracks`, `GET/PATCH /tracks/:trackId`
+- `POST /tracks/:trackId/planning-sessions`
+- `POST /planning-sessions/:planningSessionId/messages`
+- `GET/POST /tracks/:trackId/artifacts/:artifact`
+- `GET /runs`, `POST /runs`, `GET /runs/:runId`
+- `POST /runs/:runId/resume`, `POST /runs/:runId/cancel`
+- `GET /runs/:runId/events`, `GET /runs/:runId/events/stream`
+- `GET /runs/:runId/report.md`
+- `GET/POST /runs/:runId/workspace-cleanup/*`
+- `POST /approval-requests/:approvalRequestId/:decision`
+
+The UI uses browser `fetch` plus `EventSource`, so the proxy must allow normal HTTP methods and SSE streaming for `GET /runs/:runId/events/stream`.
+
+## Security checklist
+
+- Require HTTPS for the operator URL.
+- Require authentication before `/operator` and every API route the UI calls.
+- Prefer an identity-aware proxy, SSO gateway, VPN, or private network in front of the API.
+- Limit operator access to trusted maintainers; the UI can resume/cancel runs, decide approvals, and apply workspace cleanup after confirmation.
+- Do not expose provider credentials, GitHub App private keys, tokens, raw webhook bodies, or execution transcripts in proxy logs.
+- Treat Markdown report links as operational links. Reports are derived read-only exports, but they can still contain run summaries and metadata.
+- Keep GitHub as a thin entrypoint. GitHub comments may link to the operator UI, but SpecRail remains the canonical state and artifact source.
+- If the operator URL is not safely reachable by intended operators, leave `SPECRAIL_OPERATOR_BASE_URL` unset; GitHub comments will still include the read-only report URL when available.
+
+## Related docs
+
+- [GitHub App setup](./github-app-setup.md)
+- [MVP architecture](./architecture/mvp-architecture.md)
+- [GitHub entrypoint architecture slice](./architecture/github-entrypoint-slice.md)


### PR DESCRIPTION
## Summary
- document authenticated reverse-proxy deployment guidance for the hosted operator UI
- clarify how SPECRAIL_OPERATOR_BASE_URL should be used for GitHub terminal outcome links
- add a security checklist for TLS, auth, route protection, logs, report links, and canonical state boundaries
- link the new guide from docs index and GitHub app setup

Closes #323

## Verification
- pnpm check:links