### PR TITLE
test: stabilize report immutability assertion

### DIFF
--- a/apps/api/src/__tests__/api.test.ts
+++ b/apps/api/src/__tests__/api.test.ts
@@ -76,6 +76,28 @@ async function assertJsonResponseStatus(response: Response, expectedStatus: numb
   assert.equal(response.status, expectedStatus, `expected HTTP ${expectedStatus}, received HTTP ${response.status}: ${body}`);
 }
 
+async function waitForRunEvent(
+  baseUrl: string,
+  runId: string,
+  matches: (event: { type: string; summary: string }) => boolean,
+): Promise<void> {
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    const eventsResponse = await fetch(`${baseUrl}/runs/${runId}/events`);
+    assert.equal(eventsResponse.status, 200);
+    const eventsPayload = (await eventsResponse.json()) as { events: Array<{ type: string; summary: string }> };
+
+    if (eventsPayload.events.some(matches)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`timed out waiting for run event on ${runId}`);
+}
+
 function parseSseEvents(buffer: string): Array<{ id: string; summary: string }> {
   return buffer
     .split("\n\n")
@@ -620,6 +642,8 @@ test("API serves completed run Markdown reports without mutating artifacts or ev
       }),
     });
     const runPayload = (await createRunResponse.json()) as { run: { id: string } };
+
+    await waitForRunEvent(baseUrl, runPayload.run.id, (event) => event.type === "message" && /STDOUT/.test(event.summary));
 
     const eventsBeforeResponse = await fetch(`${baseUrl}/runs/${runPayload.run.id}/events`);
     const eventsBefore = await eventsBeforeResponse.text();


### PR DESCRIPTION
## Summary
- add a small API test helper that waits for expected run events before snapshotting event state
- update the completed run report immutability test to snapshot after the fake executor stdout event has arrived
- preserve the read-only report assertion while avoiding unrelated async event timing flake

Closes #329

## Verification
- pnpm --filter @specrail/api check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/api/src/__tests__/api.test.ts
- pnpm check
- pnpm test
- pnpm build