### PR TITLE
docs: refresh ACP approval callback behavior

### DIFF
--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -56,8 +56,8 @@ Runtime approval decisions now use the same domain service/API path as non-ACP c
 1. SpecRail emits `approval_requested`.
 2. The ACP adapter publishes `session/request_permission` with the original event attached in `_meta.specrail.executionEvent`.
 3. The client answers on the next `session/prompt` with `_meta.specrail.permissionResolution`.
-4. The adapter calls `SpecRailService.resolveRuntimeApprovalRequest(...)` to record the canonical `approval_resolved` event.
-5. The adapter resumes the linked SpecRail run after an approved decision; rejected decisions keep the run cancelled.
+4. The adapter calls `SpecRailService.resolveRuntimeApprovalRequest(...)` to record the canonical `approval_resolved` event and deliver the decision to executor callbacks when supported.
+5. If an approved decision is not handled by an executor callback, the adapter falls back to resuming the linked SpecRail run. Rejected decisions stay resolved without a resume fallback.
 
 Example client payload:
 
@@ -84,11 +84,11 @@ This is intentionally an initial bridge, not a full ACP implementation.
 
 1. `session/new` currently requires SpecRail-specific metadata, especially `_meta.specrail.trackId`.
 2. Planning artifacts, approvals, channel bindings, and attachment flows stay in the existing REST API.
-3. Runtime permission requests are translated into ACP-friendly updates; decisions are persisted through the core approval path, but active executor callback delivery is not implemented yet.
+3. Runtime permission requests are translated into ACP-friendly updates; decisions are persisted through the core approval path and delivered to executors that implement `resolveRuntimeApproval`.
 4. Event updates are richer than the initial bridge, but the mapping still collapses many provider-specific details into `session/update` plus `_meta` rather than a full ACP-native event taxonomy.
 5. The adapter stores ACP session records locally, but run state still lives in the normal SpecRail repositories.
 6. Terminal and filesystem ACP capabilities are not exposed yet, because SpecRail-managed workspaces need a clearer ownership model first.
-7. `approval_resolved` is persisted by the core service when the client sends `permissionResolution`, but the event does not yet prove that the underlying executor consumed a real callback.
+7. `approval_resolved` records the operator decision. Callback delivery may additionally append handled, unsupported, or failed callback events depending on the selected executor.
 
 ## Why this shape
 
@@ -100,7 +100,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 ## Near-term follow-up
 
 Good next steps from the current bridge:
-- replace provider resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
+- replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
 - expand the ACP-facing event taxonomy beyond readable `agent_message_chunk` fallbacks for provider-specific details that clients need to render natively
 - define workspace ownership rules before exposing filesystem or terminal ACP capabilities for SpecRail-managed workspaces
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client


### PR DESCRIPTION
## Summary
- update ACP permission round-trip docs to describe executor callback delivery
- clarify approved-decision resume fallback when callbacks are unsupported or fail to handle the decision
- remove stale limitation text claiming active callback delivery is not implemented

Closes #335

## Verification
- pnpm check:links