### PR TITLE
docs: remove stale GitHub setup follow-up

### DIFF
--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -94,7 +94,7 @@ The webhook endpoint returns JSON responses:
 - REST issue-comment posting supports static tokens and GitHub App installation-token refresh. Private keys must be supplied securely by deployment secret management.
 - Durable terminal relay is JSON-file based when `GITHUB_RELAY_QUEUE_PATH` is set. Failed relay attempts are retained with `lastError`, attempt count, and retry timing; deployments should place this path on persistent storage.
 - Terminal outcome comment relay is available when `GITHUB_FOLLOW_TERMINAL_EVENTS=true`; the webhook response only waits for scheduling/enqueue, not for the run to reach a terminal state.
-- Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state. Do not expose unauthenticated operator URLs in GitHub comments.
+- Hosted operator run links are included in terminal comments only when `SPECRAIL_OPERATOR_BASE_URL` is configured; GitHub remains a thin frontend over SpecRail state. Do not expose unauthenticated operator URLs in GitHub comments. See [Hosted Operator UI deployment](./operator-ui-deployment.md) for auth and reverse-proxy guidance.
 - GitHub command outcome metrics are exposed through an injectable metrics sink with coarse reason labels only: accepted, unsupported repository, unauthorized actor, GitHub authorization failure, SpecRail request failure, and relay enqueue failure. See [GitHub command troubleshooting](./github-command-troubleshooting.md) for safe diagnostics and metric interpretation.
 - Repository/project allowlists plus sender-login, organization, and team-based authorization are supported.
 - Non-terminal progress is intentionally not posted to GitHub; use the operator UI, terminal, Telegram, or SSE surfaces for detailed progress.
@@ -103,4 +103,4 @@ The webhook endpoint returns JSON responses:
 ## Recommended follow-ups
 
 1. Consider replacing the JSON-file relay queue with a database-backed queue if multi-process GitHub app deployments become necessary.
-2. Add an example reverse-proxy config for a concrete deployment target.
+2. Add deployment-specific examples for production process supervision and durable relay queue processing.


### PR DESCRIPTION
## Summary
- point GitHub setup readers to the hosted operator UI deployment guide for auth/reverse-proxy guidance
- replace the completed reverse-proxy follow-up with the remaining production supervision/relay queue documentation gap

Closes #337

## Verification
- pnpm check:links