### PR TITLE
feat: improve terminal stream event formatting

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -455,6 +455,15 @@ test("renderAppShell renders run event monitor details", () => {
       },
       [
         {
+          id: "evt-0",
+          executionId: "run-1",
+          type: "message",
+          timestamp: "2026-04-10T12:03:00.000Z",
+          source: "claude_code",
+          summary: "STDERR run-1-claude",
+          payload: { stream: "stderr", text: "first line\nsecond line with detailed provider output that should stay bounded in the terminal tail" },
+        },
+        {
           id: "evt-1",
           executionId: "run-1",
           type: "task_status_changed",
@@ -475,13 +484,14 @@ test("renderAppShell renders run event monitor details", () => {
     },
   });
 
-  assert.match(rendered, /event summary: 1 event, last at 2026-04-10T12:04:00.000Z/);
+  assert.match(rendered, /event summary: 2 events, last at 2026-04-10T12:04:00.000Z/);
   assert.match(rendered, /failure focus: Failed Claude Code session run-1-claude \(exit 1\)/);
   assert.match(rendered, /Runs \(1\/1, filter=terminal\)/);
   assert.match(rendered, /stream: reconnecting \(attempt 2\)/);
   assert.match(rendered, /report: \/runs\/run-1\/report\.md/);
   assert.match(rendered, /operator actions: press e to resume this run, w to preview workspace cleanup, Space to pause tail/);
   assert.match(rendered, /recent activity:/);
+  assert.match(rendered, /message \| stream=stderr \| STDERR run-1-claude — first line second line with detailed provider output/);
   assert.match(rendered, /task_status_changed \| status=failed \| Failed Claude Code session run-1-claude/);
 });
 

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -1341,6 +1341,8 @@ function formatStreamStatus(feed: RunEventFeedState, terminal: boolean): string 
 
 function formatEventLine(event: ExecutionEvent): string {
   const status = readEventStatus(event);
+  const stream = readEventStream(event);
+  const text = readEventText(event);
   const parts = [event.timestamp, event.type];
   if (event.subtype) {
     parts.push(event.subtype);
@@ -1348,7 +1350,21 @@ function formatEventLine(event: ExecutionEvent): string {
   if (status) {
     parts.push(`status=${status}`);
   }
-  return `${parts.join(" | ")} | ${previewText(event.summary, 120)}`;
+  if (stream) {
+    parts.push(`stream=${stream}`);
+  }
+  const summary = previewText(event.summary, text ? 72 : 120);
+  return text ? `${parts.join(" | ")} | ${summary} — ${previewText(text, 96)}` : `${parts.join(" | ")} | ${summary}`;
+}
+
+function readEventStream(event: ExecutionEvent): string | null {
+  const stream = event.payload?.stream;
+  return stream === "stdout" || stream === "stderr" ? stream : null;
+}
+
+function readEventText(event: ExecutionEvent): string | null {
+  const text = event.payload?.text;
+  return typeof text === "string" && text.trim().length > 0 ? text : null;
 }
 
 function readEventStatus(event: ExecutionEvent): string | null {


### PR DESCRIPTION
## Summary
- surface stdout/stderr stream labels in terminal run event lines
- include bounded compact payload text previews when provider events include payload.text
- preserve existing timestamp/type/subtype/status formatting for non-stream events
- extend terminal render coverage for provider stream output

Closes #343

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check
- pnpm test
- pnpm build