### PR TITLE
feat: render structured terminal events

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -455,6 +455,26 @@ test("renderAppShell renders run event monitor details", () => {
       },
       [
         {
+          id: "evt-tool",
+          executionId: "run-1",
+          type: "tool_call",
+          subtype: "claude_tool_call",
+          timestamp: "2026-04-10T12:02:30.000Z",
+          source: "claude_code",
+          summary: "Claude requested tool Bash",
+          payload: { toolName: "Bash", toolUseId: "toolu-1", toolInput: { command: "pnpm test -- --runInBand" } },
+        },
+        {
+          id: "evt-approval",
+          executionId: "run-1",
+          type: "approval_requested",
+          subtype: "claude_permission_denial",
+          timestamp: "2026-04-10T12:02:45.000Z",
+          source: "claude_code",
+          summary: "Claude requested approval for Bash",
+          payload: { requestId: "approval-1", toolName: "Bash" },
+        },
+        {
           id: "evt-0",
           executionId: "run-1",
           type: "message",
@@ -484,13 +504,15 @@ test("renderAppShell renders run event monitor details", () => {
     },
   });
 
-  assert.match(rendered, /event summary: 2 events, last at 2026-04-10T12:04:00.000Z/);
+  assert.match(rendered, /event summary: 4 events, last at 2026-04-10T12:04:00.000Z/);
   assert.match(rendered, /failure focus: Failed Claude Code session run-1-claude \(exit 1\)/);
   assert.match(rendered, /Runs \(1\/1, filter=terminal\)/);
   assert.match(rendered, /stream: reconnecting \(attempt 2\)/);
   assert.match(rendered, /report: \/runs\/run-1\/report\.md/);
   assert.match(rendered, /operator actions: press e to resume this run, w to preview workspace cleanup, Space to pause tail/);
   assert.match(rendered, /recent activity:/);
+  assert.match(rendered, /tool_call \| claude_tool_call \| Claude requested tool Bash — tool=Bash, id=toolu-1, input=\{\"command\":\"pnpm test -- --runInBand\"\}/);
+  assert.match(rendered, /approval_requested \| claude_permission_denial \| Claude requested approval for Bash — request=approval-1, tool=Bash/);
   assert.match(rendered, /message \| stream=stderr \| STDERR run-1-claude — first line second line with detailed provider output/);
   assert.match(rendered, /task_status_changed \| status=failed \| Failed Claude Code session run-1-claude/);
 });

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -1343,6 +1343,7 @@ function formatEventLine(event: ExecutionEvent): string {
   const status = readEventStatus(event);
   const stream = readEventStream(event);
   const text = readEventText(event);
+  const details = formatStructuredEventDetails(event);
   const parts = [event.timestamp, event.type];
   if (event.subtype) {
     parts.push(event.subtype);
@@ -1353,8 +1354,34 @@ function formatEventLine(event: ExecutionEvent): string {
   if (stream) {
     parts.push(`stream=${stream}`);
   }
-  const summary = previewText(event.summary, text ? 72 : 120);
-  return text ? `${parts.join(" | ")} | ${summary} — ${previewText(text, 96)}` : `${parts.join(" | ")} | ${summary}`;
+  const hasExtra = Boolean(text || details);
+  const summary = previewText(event.summary, hasExtra ? 72 : 120);
+  const suffix = [details, text ? previewText(text, 96) : null].filter(Boolean).join("; ");
+  return suffix ? `${parts.join(" | ")} | ${summary} — ${suffix}` : `${parts.join(" | ")} | ${summary}`;
+}
+
+function formatStructuredEventDetails(event: ExecutionEvent): string | null {
+  if (event.type === "tool_call") {
+    const toolName = readPayloadString(event, "toolName") ?? "unknown";
+    const toolUseId = readPayloadString(event, "toolUseId");
+    const toolInput = previewPayloadValue(event.payload?.toolInput, 72);
+    return [`tool=${toolName}`, toolUseId ? `id=${toolUseId}` : null, toolInput ? `input=${toolInput}` : null].filter(Boolean).join(", ");
+  }
+
+  if (event.type === "tool_result") {
+    const toolUseId = readPayloadString(event, "toolUseId");
+    const content = previewPayloadValue(event.payload?.content, 96);
+    return [toolUseId ? `id=${toolUseId}` : null, content ? `result=${content}` : null].filter(Boolean).join(", ") || null;
+  }
+
+  if (event.type === "approval_requested" || event.type === "approval_resolved") {
+    const requestId = readPayloadString(event, "requestId");
+    const outcome = readPayloadString(event, "outcome");
+    const toolName = readPayloadString(event, "toolName");
+    return [requestId ? `request=${requestId}` : null, outcome ? `outcome=${outcome}` : null, toolName ? `tool=${toolName}` : null].filter(Boolean).join(", ") || null;
+  }
+
+  return null;
 }
 
 function readEventStream(event: ExecutionEvent): string | null {
@@ -1365,6 +1392,20 @@ function readEventStream(event: ExecutionEvent): string | null {
 function readEventText(event: ExecutionEvent): string | null {
   const text = event.payload?.text;
   return typeof text === "string" && text.trim().length > 0 ? text : null;
+}
+
+function readPayloadString(event: ExecutionEvent, key: string): string | null {
+  const value = event.payload?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function previewPayloadValue(value: unknown, maxLength: number): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const raw = typeof value === "string" ? value : JSON.stringify(value);
+  return raw && raw.trim().length > 0 ? previewText(raw, maxLength) : null;
 }
 
 function readEventStatus(event: ExecutionEvent): string | null {


### PR DESCRIPTION
## Summary
- add compact structured details for terminal tool_call and tool_result event lines
- surface approval request/resolution identifiers and outcomes when available
- preserve existing status/stream/text-preview event formatting
- extend terminal render coverage for tool and approval events

Closes #347

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check
- pnpm test
- pnpm build