### PR TITLE
feat: add terminal contextual help

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -408,6 +408,7 @@ test("renderAppShell renders track list and selected detail preview", () => {
   assert.match(rendered, /execution actions: press s to start a run for this track/);
   assert.match(rendered, /spec preview: # Spec Terminal shell/);
   assert.match(rendered, /Keys: 1 home, 2 tracks, 3 runs, 4 settings, j\/k or ↑\/↓ select, P project scope, h\/l artifact, \[\/\] revision, v propose, f run filter, Space tail pause\/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit/);
+  assert.match(rendered, /Help: tracks — P cycles project scope, h\/l switches artifact, \[\/\] cycles revisions, v proposes, a\/x approves or rejects pending revisions, s starts a run\./);
 });
 
 test("renderAppShell renders run event monitor details", () => {
@@ -510,6 +511,7 @@ test("renderAppShell renders run event monitor details", () => {
   assert.match(rendered, /stream: reconnecting \(attempt 2\)/);
   assert.match(rendered, /report: \/runs\/run-1\/report\.md/);
   assert.match(rendered, /operator actions: press e to resume this run, w to preview workspace cleanup, Space to pause tail/);
+  assert.match(rendered, /Help: runs — f cycles filters, Space pauses live tail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup\./);
   assert.match(rendered, /recent activity:/);
   assert.match(rendered, /tool_call \| claude_tool_call \| Claude requested tool Bash — tool=Bash, id=toolu-1, input=\{\"command\":\"pnpm test -- --runInBand\"\}/);
   assert.match(rendered, /approval_requested \| claude_permission_denial \| Claude requested approval for Bash — request=approval-1, tool=Bash/);
@@ -582,6 +584,7 @@ test("renderAppShell renders guarded workspace cleanup preview and confirmation 
   assert.match(rendered, /server confirmation: apply workspace cleanup for run-cleanup-a/);
   assert.match(rendered, /result: refused/);
   assert.match(rendered, /Press Enter again to apply cleanup with that exact phrase/);
+  assert.match(rendered, /Help: workspace cleanup — Enter requests confirmation\/applies when ready, Esc aborts, r refreshes selected run\./);
 });
 
 test("selectNextItem advances run selection on runs screen", () => {

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -894,10 +894,63 @@ export function renderAppShell(state: TerminalAppState): string {
     "",
     `Status: ${state.statusLine}`,
     `Keys: 1 home, 2 tracks, 3 runs, 4 settings, j/k or ↑/↓ select, P project scope, h/l artifact, [/] revision, v propose, f run filter, Space tail pause/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit | Refresh ${state.refreshIntervalMs}ms`,
+    ...renderContextualHelp(state),
     ...renderExecutionActionComposer(state.pendingExecutionAction),
     ...renderProposalActionComposer(state.pendingProposalAction),
     ...renderWorkspaceCleanupComposer(state.pendingWorkspaceCleanupAction ?? null),
   ].join("\n");
+}
+
+function renderContextualHelp(state: TerminalAppState): string[] {
+  const lines = [""];
+
+  if (state.pendingWorkspaceCleanupAction) {
+    return [
+      ...lines,
+      "Help: workspace cleanup — Enter requests confirmation/applies when ready, Esc aborts, r refreshes selected run.",
+    ];
+  }
+
+  if (state.pendingProposalAction) {
+    return [
+      ...lines,
+      "Help: proposal composer — type edits the active field, Tab switches summary/content, g cycles author, Enter submits, Esc aborts.",
+    ];
+  }
+
+  if (state.pendingExecutionAction) {
+    const promptHelp = state.pendingExecutionAction.kind === "cancel"
+      ? "Enter confirms cancellation, Esc aborts."
+      : "type edits prompt, p cycles profile, b cycles backend when unlocked, Enter submits, Esc aborts.";
+    return [
+      ...lines,
+      `Help: ${state.pendingExecutionAction.kind} composer — ${promptHelp}`,
+    ];
+  }
+
+  switch (state.screen) {
+    case "tracks":
+      return [
+        ...lines,
+        "Help: tracks — P cycles project scope, h/l switches artifact, [/] cycles revisions, v proposes, a/x approves or rejects pending revisions, s starts a run.",
+      ];
+    case "runs":
+      return [
+        ...lines,
+        "Help: runs — f cycles filters, Space pauses live tail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup.",
+      ];
+    case "settings":
+      return [
+        ...lines,
+        "Help: settings — review API/refresh configuration, use 1/2/3 to jump back to active work, r refreshes data.",
+      ];
+    case "home":
+    default:
+      return [
+        ...lines,
+        "Help: home — use 2 for tracks, 3 for runs, P to narrow project scope, r to refresh the snapshot.",
+      ];
+  }
 }
 
 function renderWorkspaceCleanupComposer(action: PendingWorkspaceCleanupActionState | null): string[] {


### PR DESCRIPTION
## Summary
- add contextual help lines for home/tracks/runs/settings terminal screens
- surface focused composer guidance for execution, proposal, and workspace cleanup workflows
- keep existing global key line while improving discoverability for multi-step operator actions
- extend terminal render tests for contextual help

Closes #349

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check
- pnpm test
- pnpm build