### PR TITLE
docs: refresh terminal client current capabilities

### DIFF
--- a/docs/terminal-client.md
+++ b/docs/terminal-client.md
@@ -32,6 +32,7 @@ The runs screen now does more than snapshot inspection:
 - opens an SSE stream against `/runs/:id/events/stream` for the selected run
 - caches the most recent run events in-memory for a tail-style activity view
 - surfaces provider `stdout`/`stderr` stream labels and bounded text previews when run events include stream payloads
+- adds compact structured details for tool calls, tool results, and runtime approval events when payload fields are available
 - lets operators pause and resume the live tail without changing selection
 - deduplicates replayed events after reconnect because the API replays prior history on each SSE connection
 - retries dropped streams with bounded backoff for non-terminal runs
@@ -44,6 +45,7 @@ The run detail pane also highlights:
 - failure focus, including exit code or signal when present in event payloads
 - planning-context staleness and last planning-context update timestamp
 - operator actions for starting runs from tracks, resuming terminal runs, cancelling active runs, and guarded workspace cleanup
+- contextual keyboard help for the active screen or currently open multi-step composer
 
 ## Planning and approval workflow support
 
@@ -69,5 +71,5 @@ This is intentionally still lightweight:
 
 Good next steps after the live monitor baseline:
 - richer planning interaction beyond the current focused revision selector and lightweight proposal authoring
-- deeper provider-specific rendering for structured tool calls, permission requests, and result payloads
-- broader keyboard help and discoverability for multi-step operator workflows
+- provider-specific detail panes for large structured payloads that should not fit in the compact activity tail
+- persisted terminal preferences for project scope, filters, and refresh/tail settings


### PR DESCRIPTION
## Summary
- document structured tool/result/approval event details in the terminal run activity tail
- document contextual keyboard help for active screens and composers
- remove stale follow-up bullets for work completed by #347 and #349
- refocus terminal follow-ups on planning interaction, large payload detail panes, and persisted preferences

Closes #351

## Verification
- pnpm check:links