### PR TITLE
feat: persist terminal run view toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Operator environment:
 - `SPECRAIL_TERMINAL_INITIAL_SCREEN` one of `home`, `tracks`, `runs`, `settings`
 - `SPECRAIL_TERMINAL_INITIAL_PROJECT_ID` optional project id for the initial track/run scope
 - `SPECRAIL_TERMINAL_INITIAL_RUN_FILTER` one of `all`, `active`, `terminal`; defaults to `all`
-- `SPECRAIL_TERMINAL_PREFERENCES_PATH` optional local JSON file for persisting project scope and run filter changes
+- `SPECRAIL_TERMINAL_PREFERENCES_PATH` optional local JSON file for persisting project scope, run filter, live-tail pause, and event-detail visibility changes
 
 Run it locally:
 

--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -297,9 +297,9 @@ test("terminal preferences load and save local UI defaults", async () => {
   try {
     assert.deepEqual(await loadTerminalPreferences(path), {});
 
-    await saveTerminalPreferences(path, { selectedProjectId: "project-1", runFilter: "terminal" });
-    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { selectedProjectId: "project-1", runFilter: "terminal" });
-    assert.deepEqual(await loadTerminalPreferences(path), { selectedProjectId: "project-1", runFilter: "terminal" });
+    await saveTerminalPreferences(path, { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
+    assert.deepEqual(await loadTerminalPreferences(path), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
 
     await writeFile(path, "{not json", "utf8");
     assert.deepEqual(await loadTerminalPreferences(path), {});
@@ -834,6 +834,8 @@ test("appendRunEvents deduplicates by event id and syncRunEventSelection resets 
 test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh through keypresses", async () => {
   const applyBodies: unknown[] = [];
   const requests: string[] = [];
+  const preferenceDir = await mkdtemp(join(tmpdir(), "specrail-terminal-run-view-prefs-"));
+  const preferencePath = join(preferenceDir, "preferences.json");
 
   const server = createServer(async (request, response) => {
     requests.push(`${request.method ?? "GET"} ${request.url ?? "/"}`);
@@ -945,12 +947,23 @@ test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh th
   const stdin = new FakeTerminalStdin();
   const stdout = new FakeTerminalStdout();
   const app = runTerminalApp(
-    { apiBaseUrl: `http://127.0.0.1:${port}`, refreshIntervalMs: 0, initialScreen: "runs", initialProjectId: null, initialRunFilter: "all", preferencePath: null },
+    { apiBaseUrl: `http://127.0.0.1:${port}`, refreshIntervalMs: 0, initialScreen: "runs", initialProjectId: null, initialRunFilter: "all", preferencePath },
     { stdin, stdout } as never,
   );
 
   try {
     await waitFor(() => stdout.output.includes("run-cleanup-a"));
+
+    stdin.key("d");
+    stdin.key(" ", "space");
+    await waitFor(async () => {
+      try {
+        const preferences = JSON.parse(await readFile(preferencePath, "utf8")) as Record<string, unknown>;
+        return preferences.liveTailPaused === true && preferences.showRunEventDetail === true;
+      } catch {
+        return false;
+      }
+    });
 
     stdin.key("w");
     await waitFor(() => stdout.output.includes("Cleanup preview ready for run-cleanup-a."));
@@ -969,6 +982,7 @@ test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh th
     stdin.key("q");
     await app;
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    await rm(preferenceDir, { recursive: true, force: true });
   }
 });
 
@@ -1016,14 +1030,14 @@ async function readRequestJson(request: IncomingMessage): Promise<unknown> {
   return body ? JSON.parse(body) : null;
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 1_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (predicate()) {
+    if (await predicate()) {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 
-  assert.equal(predicate(), true);
+  assert.equal(await predicate(), true);
 }

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -247,6 +247,8 @@ export interface PendingWorkspaceCleanupActionState {
 export interface TerminalPreferenceState {
   selectedProjectId: string | null;
   runFilter: RunFilterMode;
+  liveTailPaused: boolean;
+  showRunEventDetail: boolean;
 }
 
 export interface TerminalAppState {
@@ -1544,10 +1546,14 @@ export async function loadTerminalPreferences(path: string | null): Promise<Part
         ? null
         : undefined;
     const runFilter = parsed.runFilter === "active" || parsed.runFilter === "terminal" || parsed.runFilter === "all" ? parsed.runFilter : undefined;
+    const liveTailPaused = typeof parsed.liveTailPaused === "boolean" ? parsed.liveTailPaused : undefined;
+    const showRunEventDetail = typeof parsed.showRunEventDetail === "boolean" ? parsed.showRunEventDetail : undefined;
 
     return {
       ...(selectedProjectId !== undefined ? { selectedProjectId } : {}),
       ...(runFilter ? { runFilter } : {}),
+      ...(liveTailPaused !== undefined ? { liveTailPaused } : {}),
+      ...(showRunEventDetail !== undefined ? { showRunEventDetail } : {}),
     };
   } catch {
     return {};
@@ -1567,12 +1573,15 @@ export async function saveTerminalPreferences(path: string | null, preferences: 
   }
 }
 
-async function resolveTerminalClientConfig(config: SpecRailTerminalClientConfig): Promise<SpecRailTerminalClientConfig> {
+async function resolveTerminalClientStartup(config: SpecRailTerminalClientConfig): Promise<{ config: SpecRailTerminalClientConfig; preferences: Partial<TerminalPreferenceState> }> {
   const preferences = await loadTerminalPreferences(config.preferencePath);
   return {
-    ...config,
-    initialProjectId: preferences.selectedProjectId !== undefined ? preferences.selectedProjectId : config.initialProjectId,
-    initialRunFilter: preferences.runFilter ?? config.initialRunFilter,
+    config: {
+      ...config,
+      initialProjectId: preferences.selectedProjectId !== undefined ? preferences.selectedProjectId : config.initialProjectId,
+      initialRunFilter: preferences.runFilter ?? config.initialRunFilter,
+    },
+    preferences,
   };
 }
 
@@ -1580,9 +1589,14 @@ export async function runTerminalApp(
   config: SpecRailTerminalClientConfig = loadTerminalClientConfig(),
   io: { stdout: NodeJS.WriteStream; stdin: NodeJS.ReadStream } = { stdout: process.stdout, stdin: process.stdin },
 ): Promise<void> {
-  const effectiveConfig = await resolveTerminalClientConfig(config);
+  const startup = await resolveTerminalClientStartup(config);
+  const effectiveConfig = startup.config;
   const client = new SpecRailTerminalApiClient(effectiveConfig.apiBaseUrl);
-  let state = createEmptyTerminalState(effectiveConfig);
+  let state: TerminalAppState = {
+    ...createEmptyTerminalState(effectiveConfig),
+    runEvents: createEmptyRunEventFeedState(null, startup.preferences.liveTailPaused ?? false),
+    showRunEventDetail: startup.preferences.showRunEventDetail ?? false,
+  };
   let disposed = false;
   let monitorSerial = 0;
   let monitorAbort: AbortController | null = null;
@@ -1602,6 +1616,8 @@ export async function runTerminalApp(
     void saveTerminalPreferences(effectiveConfig.preferencePath, {
       selectedProjectId: nextState.selectedProjectId ?? null,
       runFilter: nextState.runFilter,
+      liveTailPaused: nextState.runEvents.paused,
+      showRunEventDetail: nextState.showRunEventDetail ?? false,
     });
   };
 
@@ -1972,17 +1988,20 @@ export async function runTerminalApp(
       return;
     }
 
-    updateState({
+    const nextPaused = !state.runEvents.paused;
+    const nextState: TerminalAppState = {
       ...state,
       runEvents: {
         ...state.runEvents,
         runId: state.runs.selectedId,
-        paused: !state.runEvents.paused,
-        connection: !state.runEvents.paused ? "paused" : "idle",
-        lastError: !state.runEvents.paused ? state.runEvents.lastError : null,
+        paused: nextPaused,
+        connection: nextPaused ? "paused" : "idle",
+        lastError: nextPaused ? state.runEvents.lastError : null,
       },
-      statusLine: !state.runEvents.paused ? `Paused live tail for ${state.runs.selectedId}.` : `Resumed live tail for ${state.runs.selectedId}.`,
-    });
+      statusLine: nextPaused ? `Paused live tail for ${state.runs.selectedId}.` : `Resumed live tail for ${state.runs.selectedId}.`,
+    };
+    updateState(nextState);
+    persistPreferences(nextState);
   };
 
   const editExecutionPrompt = (updater: (value: string) => string) => {
@@ -2409,11 +2428,13 @@ export async function runTerminalApp(
       }
 
       if (key.name === "d") {
-        updateState({
+        const nextState = {
           ...state,
           showRunEventDetail: !(state.showRunEventDetail ?? false),
           statusLine: state.showRunEventDetail ? "Run event detail hidden." : "Run event detail shown for the latest cached event.",
-        });
+        };
+        updateState(nextState);
+        persistPreferences(nextState);
         return;
       }
 

--- a/docs/terminal-client.md
+++ b/docs/terminal-client.md
@@ -47,7 +47,7 @@ The run detail pane also highlights:
 - planning-context staleness and last planning-context update timestamp
 - operator actions for starting runs from tracks, resuming terminal runs, cancelling active runs, and guarded workspace cleanup
 - contextual keyboard help for the active screen or currently open multi-step composer
-- startup defaults for initial project scope and run filter, plus optional local persistence for interactive preference changes
+- startup defaults for initial project scope and run filter, plus optional local persistence for project scope, run filter, live-tail pause, and event-detail visibility changes
 
 ## Planning and approval workflow support
 
@@ -74,4 +74,4 @@ This is intentionally still lightweight:
 Good next steps after the live monitor baseline:
 - richer planning interaction beyond the current focused revision selector and lightweight proposal authoring
 - provider-specific rendering inside the event detail pane for payloads that need custom terminal layouts
-- optional persistence for refresh interval and live-tail pause behavior if operators need those to survive restarts
+- optional persistence for refresh interval if operators need custom refresh cadence to survive restarts


### PR DESCRIPTION
## Summary
- extend terminal local preferences with liveTailPaused and showRunEventDetail
- apply persisted run-view toggles during terminal startup without changing canonical SpecRail state
- save Space live-tail pause and d event-detail changes best-effort when a preference path is configured
- keep malformed preference files non-fatal
- update README and terminal docs for the expanded preference scope

Closes #363

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build