### PR TITLE
feat: add terminal event detail highlights

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -549,6 +549,9 @@ test("renderAppShell renders run event monitor details", () => {
   assert.match(rendered, /event detail:/);
   assert.match(rendered, /id: evt-1/);
   assert.match(rendered, /type: task_status_changed/);
+  assert.match(rendered, /highlights:/);
+  assert.match(rendered, /status: failed/);
+  assert.match(rendered, /exit code: 1/);
   assert.match(rendered, /"exitCode": 1/);
 });
 
@@ -953,6 +956,7 @@ test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh th
 
   try {
     await waitFor(() => stdout.output.includes("run-cleanup-a"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     stdin.key("d");
     stdin.key(" ", "space");

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -1348,9 +1348,65 @@ function renderRunEventDetailLines(event: ExecutionEvent | null): string[] {
     `  - source: ${event.source}`,
     `  - timestamp: ${event.timestamp}`,
     `  - summary: ${previewText(event.summary, 160)}`,
+    ...formatEventDetailHighlightLines(event),
     "  - payload:",
     ...formatEventPayloadPreview(event.payload),
   ];
+}
+
+function formatEventDetailHighlightLines(event: ExecutionEvent): string[] {
+  const highlights = formatEventDetailHighlights(event);
+  if (highlights.length === 0) {
+    return [];
+  }
+
+  return ["  - highlights:", ...highlights.map((highlight) => `    - ${highlight}`)];
+}
+
+function formatEventDetailHighlights(event: ExecutionEvent): string[] {
+  const stream = readEventStream(event);
+  const text = readEventText(event);
+  const status = readEventStatus(event);
+  const exitCode = readPayloadNumber(event, "exitCode");
+  const signal = readPayloadString(event, "signal");
+
+  if (event.type === "tool_call") {
+    const toolName = readPayloadString(event, "toolName") ?? "unknown";
+    const toolUseId = readPayloadString(event, "toolUseId");
+    const toolInput = previewPayloadValue(event.payload?.toolInput, 220);
+    return [
+      `tool call: ${toolName}${toolUseId ? ` (${toolUseId})` : ""}`,
+      toolInput ? `input: ${toolInput}` : null,
+    ].filter((line): line is string => Boolean(line));
+  }
+
+  if (event.type === "tool_result") {
+    const toolUseId = readPayloadString(event, "toolUseId");
+    const content = previewPayloadValue(event.payload?.content, 260);
+    return [
+      `tool result${toolUseId ? ` (${toolUseId})` : ""}`,
+      content ? `content: ${content}` : null,
+    ].filter((line): line is string => Boolean(line));
+  }
+
+  if (event.type === "approval_requested" || event.type === "approval_resolved") {
+    const requestId = readPayloadString(event, "requestId");
+    const outcome = readPayloadString(event, "outcome");
+    const toolName = readPayloadString(event, "toolName");
+    return [
+      `${event.type === "approval_requested" ? "approval requested" : "approval resolved"}${requestId ? `: ${requestId}` : ""}`,
+      toolName ? `tool: ${toolName}` : null,
+      outcome ? `outcome: ${outcome}` : null,
+    ].filter((line): line is string => Boolean(line));
+  }
+
+  return [
+    status ? `status: ${status}` : null,
+    exitCode !== null ? `exit code: ${exitCode}` : null,
+    signal ? `signal: ${signal}` : null,
+    stream ? `stream: ${stream}` : null,
+    text ? `text: ${previewText(text, 220)}` : null,
+  ].filter((line): line is string => Boolean(line));
 }
 
 function formatEventPayloadPreview(payload: Record<string, unknown> | undefined): string[] {
@@ -1490,6 +1546,11 @@ function readEventText(event: ExecutionEvent): string | null {
 function readPayloadString(event: ExecutionEvent, key: string): string | null {
   const value = event.payload?.[key];
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readPayloadNumber(event: ExecutionEvent, key: string): number | null {
+  const value = event.payload?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function previewPayloadValue(value: unknown, maxLength: number): string | null {

--- a/docs/terminal-client.md
+++ b/docs/terminal-client.md
@@ -31,7 +31,7 @@ The runs screen now does more than snapshot inspection:
 - keeps the selected run detail panel in sync with periodic refreshes
 - opens an SSE stream against `/runs/:id/events/stream` for the selected run
 - caches the most recent run events in-memory for a tail-style activity view
-- toggles a focused latest-event detail block with `d`, including metadata and a bounded pretty JSON payload preview
+- toggles a focused latest-event detail block with `d`, including metadata, provider-aware highlights for known payloads, and a bounded pretty JSON payload preview
 - surfaces provider `stdout`/`stderr` stream labels and bounded text previews when run events include stream payloads
 - adds compact structured details for tool calls, tool results, and runtime approval events when payload fields are available
 - lets operators pause and resume the live tail without changing selection
@@ -73,5 +73,5 @@ This is intentionally still lightweight:
 
 Good next steps after the live monitor baseline:
 - richer planning interaction beyond the current focused revision selector and lightweight proposal authoring
-- provider-specific rendering inside the event detail pane for payloads that need custom terminal layouts
+- richer event detail navigation for selecting older cached events instead of only the latest event
 - optional persistence for refresh interval if operators need custom refresh cadence to survive restarts


### PR DESCRIPTION
## Summary
- add provider-aware highlight lines to the terminal run event detail pane
- highlight tool calls, tool results, approval events, status/exit details, and stream text
- keep bounded pretty JSON payload previews for raw debugging
- preserve compact activity tail behavior
- update terminal docs and render test coverage

Closes #365

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build