### PR TITLE
feat: add terminal event detail navigation

### DIFF
--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -524,6 +524,7 @@ test("renderAppShell renders run event monitor details", () => {
       ],
     ),
     showRunEventDetail: true,
+    runEventDetailIndex: 0,
     pendingTrackAction: null,
     pendingExecutionAction: null,
     pendingProposalAction: null,
@@ -540,19 +541,19 @@ test("renderAppShell renders run event monitor details", () => {
   assert.match(rendered, /stream: reconnecting \(attempt 2\)/);
   assert.match(rendered, /report: \/runs\/run-1\/report\.md/);
   assert.match(rendered, /operator actions: press e to resume this run, w to preview workspace cleanup, Space to pause tail/);
-  assert.match(rendered, /Help: runs — f cycles filters, Space pauses live tail, d toggles event detail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup\./);
+  assert.match(rendered, /Help: runs — f cycles filters, Space pauses live tail, d toggles event detail, p\/n selects event detail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup\./);
   assert.match(rendered, /recent activity:/);
   assert.match(rendered, /tool_call \| claude_tool_call \| Claude requested tool Bash — tool=Bash, id=toolu-1, input=\{\"command\":\"pnpm test -- --runInBand\"\}/);
   assert.match(rendered, /approval_requested \| claude_permission_denial \| Claude requested approval for Bash — request=approval-1, tool=Bash/);
   assert.match(rendered, /message \| stream=stderr \| STDERR run-1-claude — first line second line with detailed provider output/);
   assert.match(rendered, /task_status_changed \| status=failed \| Failed Claude Code session run-1-claude/);
-  assert.match(rendered, /event detail:/);
-  assert.match(rendered, /id: evt-1/);
-  assert.match(rendered, /type: task_status_changed/);
+  assert.match(rendered, /event detail \(1\/4\):/);
+  assert.match(rendered, /id: evt-tool/);
+  assert.match(rendered, /type: tool_call \/ claude_tool_call/);
   assert.match(rendered, /highlights:/);
-  assert.match(rendered, /status: failed/);
-  assert.match(rendered, /exit code: 1/);
-  assert.match(rendered, /"exitCode": 1/);
+  assert.match(rendered, /tool call: Bash \(toolu-1\)/);
+  assert.match(rendered, /input: \{"command":"pnpm test -- --runInBand"\}/);
+  assert.match(rendered, /"toolUseId": "toolu-1"/);
 });
 
 test("renderAppShell renders guarded workspace cleanup preview and confirmation state", () => {

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -265,6 +265,7 @@ export interface TerminalAppState {
   runFilter: RunFilterMode;
   runEvents: RunEventFeedState;
   showRunEventDetail?: boolean;
+  runEventDetailIndex?: number | null;
   pendingTrackAction: PendingTrackActionState | null;
   pendingExecutionAction: PendingExecutionActionState | null;
   pendingProposalAction: PendingProposalActionState | null;
@@ -606,6 +607,7 @@ export function createEmptyTerminalState(config: SpecRailTerminalClientConfig): 
     runFilter: config.initialRunFilter,
     runEvents: createEmptyRunEventFeedState(),
     showRunEventDetail: false,
+    runEventDetailIndex: null,
     pendingTrackAction: null,
     pendingExecutionAction: null,
     pendingProposalAction: null,
@@ -687,6 +689,7 @@ export async function bootstrapTerminalState(
     runFilter: config.initialRunFilter,
     runEvents: createEmptyRunEventFeedState(runs.selectedId),
     showRunEventDetail: false,
+    runEventDetailIndex: null,
     pendingTrackAction: null,
     pendingExecutionAction: null,
     pendingProposalAction: null,
@@ -854,6 +857,7 @@ export function syncRunEventSelection(state: TerminalAppState): TerminalAppState
   return {
     ...state,
     runEvents: createEmptyRunEventFeedState(selectedId, state.runEvents.paused),
+    runEventDetailIndex: null,
   };
 }
 
@@ -949,7 +953,7 @@ function renderContextualHelp(state: TerminalAppState): string[] {
     case "runs":
       return [
         ...lines,
-        "Help: runs — f cycles filters, Space pauses live tail, d toggles event detail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup.",
+        "Help: runs — f cycles filters, Space pauses live tail, d toggles event detail, p/n selects event detail, e resumes terminal runs, c cancels active runs, w previews workspace cleanup.",
       ];
     case "settings":
       return [
@@ -1134,7 +1138,7 @@ function renderRunsScreen(state: TerminalAppState): string[] {
     ),
     "",
     "Run detail",
-    ...renderRunDetail(detail, state.runs, selectedRun?.id ?? null, state.runEvents, state.showRunEventDetail ?? false),
+    ...renderRunDetail(detail, state.runs, selectedRun?.id ?? null, state.runEvents, state.showRunEventDetail ?? false, state.runEventDetailIndex ?? null),
   ];
 }
 
@@ -1292,6 +1296,7 @@ function renderRunDetail(
   selectedId: string | null,
   feed: RunEventFeedState,
   showEventDetail: boolean,
+  eventDetailIndex: number | null,
 ): string[] {
   if (!selectedId) {
     return ["- No run selected."];
@@ -1308,6 +1313,8 @@ function renderRunDetail(
   const run = detail.run;
   const terminal = isTerminalRunStatus(run.status);
   const lastEvent = feed.runId === run.id ? feed.items.at(-1) ?? null : null;
+  const detailEventIndex = showEventDetail && feed.runId === run.id ? resolveRunEventDetailIndex(feed.items, eventDetailIndex) : null;
+  const detailEvent = detailEventIndex !== null ? feed.items[detailEventIndex] ?? null : null;
   const recentFailure = feed.runId === run.id ? [...feed.items].reverse().find((event) => isFailureEvent(event)) ?? null : null;
 
   return [
@@ -1332,17 +1339,25 @@ function renderRunDetail(
     `- operator actions: ${formatRunOperatorActions(run, feed)}`,
     "- recent activity:",
     ...renderRecentRunEvents(feed, run.id),
-    ...renderRunEventDetailLines(showEventDetail ? lastEvent : null),
-  ];
+    ...renderRunEventDetailLines(detailEvent, detailEventIndex, feed.items.length),
+   ];
 }
 
-function renderRunEventDetailLines(event: ExecutionEvent | null): string[] {
-  if (!event) {
+function resolveRunEventDetailIndex(events: ExecutionEvent[], requestedIndex: number | null): number | null {
+  if (events.length === 0) {
+    return null;
+  }
+
+  return requestedIndex === null ? events.length - 1 : clampIndex(requestedIndex, events.length);
+}
+
+function renderRunEventDetailLines(event: ExecutionEvent | null, eventIndex: number | null, eventCount: number): string[] {
+  if (!event || eventIndex === null) {
     return [];
   }
 
   return [
-    "- event detail:",
+    `- event detail (${eventIndex + 1}/${eventCount}):`,
     `  - id: ${event.id}`,
     `  - type: ${event.type}${event.subtype ? ` / ${event.subtype}` : ""}`,
     `  - source: ${event.source}`,
@@ -2038,6 +2053,29 @@ export async function runTerminalApp(
     }
   };
 
+  const moveRunEventDetailSelection = (delta: number) => {
+    if (state.screen !== "runs") {
+      updateState({ ...state, statusLine: "Switch to the runs screen to select event detail." });
+      return;
+    }
+
+    const eventCount = state.runEvents.items.length;
+    if (eventCount === 0) {
+      updateState({ ...state, statusLine: "No cached run events to inspect yet." });
+      return;
+    }
+
+    const currentIndex = resolveRunEventDetailIndex(state.runEvents.items, state.runEventDetailIndex ?? null) ?? eventCount - 1;
+    const nextIndex = clampIndex(currentIndex + delta, eventCount);
+    const event = state.runEvents.items[nextIndex];
+    updateState({
+      ...state,
+      showRunEventDetail: true,
+      runEventDetailIndex: nextIndex,
+      statusLine: event ? `Selected event detail ${nextIndex + 1}/${eventCount}: ${event.type}.` : `Selected event detail ${nextIndex + 1}/${eventCount}.`,
+    });
+  };
+
   const toggleRunTailPause = () => {
     if (state.screen !== "runs") {
       updateState({ ...state, statusLine: "Switch to the runs screen to control the live tail." });
@@ -2492,10 +2530,21 @@ export async function runTerminalApp(
         const nextState = {
           ...state,
           showRunEventDetail: !(state.showRunEventDetail ?? false),
+          runEventDetailIndex: null,
           statusLine: state.showRunEventDetail ? "Run event detail hidden." : "Run event detail shown for the latest cached event.",
         };
         updateState(nextState);
         persistPreferences(nextState);
+        return;
+      }
+
+      if (key.name === "p") {
+        moveRunEventDetailSelection(-1);
+        return;
+      }
+
+      if (key.name === "n") {
+        moveRunEventDetailSelection(1);
         return;
       }
 

--- a/docs/terminal-client.md
+++ b/docs/terminal-client.md
@@ -31,7 +31,7 @@ The runs screen now does more than snapshot inspection:
 - keeps the selected run detail panel in sync with periodic refreshes
 - opens an SSE stream against `/runs/:id/events/stream` for the selected run
 - caches the most recent run events in-memory for a tail-style activity view
-- toggles a focused latest-event detail block with `d`, including metadata, provider-aware highlights for known payloads, and a bounded pretty JSON payload preview
+- toggles a focused event detail block with `d` and moves across cached events with `p` / `n`, including metadata, provider-aware highlights for known payloads, and a bounded pretty JSON payload preview
 - surfaces provider `stdout`/`stderr` stream labels and bounded text previews when run events include stream payloads
 - adds compact structured details for tool calls, tool results, and runtime approval events when payload fields are available
 - lets operators pause and resume the live tail without changing selection
@@ -73,5 +73,4 @@ This is intentionally still lightweight:
 
 Good next steps after the live monitor baseline:
 - richer planning interaction beyond the current focused revision selector and lightweight proposal authoring
-- richer event detail navigation for selecting older cached events instead of only the latest event
 - optional persistence for refresh interval if operators need custom refresh cadence to survive restarts


### PR DESCRIPTION
## Summary
- add cached event detail selection state for terminal runs
- let operators move the event detail pane with p/n while keeping d as latest-event toggle
- render detail position as index/count and clamp selection safely
- update runs contextual help and terminal docs
- extend terminal render coverage for older cached event detail output

Closes #367

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build