### PR TITLE
feat: persist terminal refresh interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Operator environment:
 - `SPECRAIL_TERMINAL_INITIAL_SCREEN` one of `home`, `tracks`, `runs`, `settings`
 - `SPECRAIL_TERMINAL_INITIAL_PROJECT_ID` optional project id for the initial track/run scope
 - `SPECRAIL_TERMINAL_INITIAL_RUN_FILTER` one of `all`, `active`, `terminal`; defaults to `all`
-- `SPECRAIL_TERMINAL_PREFERENCES_PATH` optional local JSON file for persisting project scope, run filter, live-tail pause, and event-detail visibility changes
+- `SPECRAIL_TERMINAL_PREFERENCES_PATH` optional local JSON file for persisting project scope, run filter, refresh interval, live-tail pause, and event-detail visibility changes
 
 Run it locally:
 

--- a/apps/terminal/src/__tests__/terminal-app.test.ts
+++ b/apps/terminal/src/__tests__/terminal-app.test.ts
@@ -297,9 +297,9 @@ test("terminal preferences load and save local UI defaults", async () => {
   try {
     assert.deepEqual(await loadTerminalPreferences(path), {});
 
-    await saveTerminalPreferences(path, { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
-    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
-    assert.deepEqual(await loadTerminalPreferences(path), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true });
+    await saveTerminalPreferences(path, { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true, refreshIntervalMs: 15000 });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true, refreshIntervalMs: 15000 });
+    assert.deepEqual(await loadTerminalPreferences(path), { selectedProjectId: "project-1", runFilter: "terminal", liveTailPaused: true, showRunEventDetail: true, refreshIntervalMs: 15000 });
 
     await writeFile(path, "{not json", "utf8");
     assert.deepEqual(await loadTerminalPreferences(path), {});
@@ -435,7 +435,7 @@ test("renderAppShell renders track list and selected detail preview", () => {
   assert.match(rendered, /press a to approve or x to reject selected pending request/);
   assert.match(rendered, /execution actions: press s to start a run for this track/);
   assert.match(rendered, /spec preview: # Spec Terminal shell/);
-  assert.match(rendered, /Keys: 1 home, 2 tracks, 3 runs, 4 settings, j\/k or ↑\/↓ select, P project scope, h\/l artifact, \[\/\] revision, v propose, f run filter, d event detail, Space tail pause\/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit/);
+  assert.match(rendered, /Keys: 1 home, 2 tracks, 3 runs, 4 settings, j\/k or ↑\/↓ select, P project scope, \+\/- refresh, h\/l artifact, \[\/\] revision, v propose, f run filter, d event detail, Space tail pause\/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit/);
   assert.match(rendered, /Help: tracks — P cycles project scope, h\/l switches artifact, \[\/\] cycles revisions, v proposes, a\/x approves or rejects pending revisions, s starts a run\./);
 });
 
@@ -961,10 +961,11 @@ test("runTerminalApp drives cleanup preview, confirmation, apply, and refresh th
 
     stdin.key("d");
     stdin.key(" ", "space");
+    stdin.key("+");
     await waitFor(async () => {
       try {
         const preferences = JSON.parse(await readFile(preferencePath, "utf8")) as Record<string, unknown>;
-        return preferences.liveTailPaused === true && preferences.showRunEventDetail === true;
+        return preferences.liveTailPaused === true && preferences.showRunEventDetail === true && preferences.refreshIntervalMs === 1000;
       } catch {
         return false;
       }

--- a/apps/terminal/src/index.ts
+++ b/apps/terminal/src/index.ts
@@ -15,6 +15,8 @@ const EXECUTION_PROFILE_OPTIONS: Record<string, string[]> = {
   codex: ["default", "gpt-5.4", "gpt-5.4-mini"],
   claude_code: ["default", "sonnet", "opus"],
 };
+const REFRESH_INTERVAL_STEP_MS = 1_000;
+const MAX_REFRESH_INTERVAL_MS = 60_000;
 
 export interface TrackListItem {
   id: string;
@@ -249,6 +251,7 @@ export interface TerminalPreferenceState {
   runFilter: RunFilterMode;
   liveTailPaused: boolean;
   showRunEventDetail: boolean;
+  refreshIntervalMs: number;
 }
 
 export interface TerminalAppState {
@@ -909,7 +912,7 @@ export function renderAppShell(state: TerminalAppState): string {
     ...body,
     "",
     `Status: ${state.statusLine}`,
-    `Keys: 1 home, 2 tracks, 3 runs, 4 settings, j/k or ↑/↓ select, P project scope, h/l artifact, [/] revision, v propose, f run filter, d event detail, Space tail pause/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit | Refresh ${state.refreshIntervalMs}ms`,
+    `Keys: 1 home, 2 tracks, 3 runs, 4 settings, j/k or ↑/↓ select, P project scope, +/- refresh, h/l artifact, [/] revision, v propose, f run filter, d event detail, Space tail pause/resume, s start, e resume, c cancel, w cleanup, a approve, x reject, r refresh, q quit | Refresh ${state.refreshIntervalMs}ms`,
     ...renderContextualHelp(state),
     ...renderExecutionActionComposer(state.pendingExecutionAction),
     ...renderProposalActionComposer(state.pendingProposalAction),
@@ -1071,6 +1074,7 @@ function renderScreenBody(state: TerminalAppState): string[] {
         `- API base URL: ${state.apiBaseUrl}`,
         `- Refresh interval: ${state.refreshIntervalMs}ms`,
         "- Navigation: use j/k or arrow keys to move through track/run selections.",
+        "- Press + / - to adjust automatic refresh cadence; set to 0ms to disable automatic refresh.",
         "- Press P to cycle project scope for track listings.",
         "- Tracks view surfaces planning sessions, revision history, and pending approvals.",
         "- Press a/x on the tracks screen to approve or reject the next pending request.",
@@ -1624,12 +1628,16 @@ export async function loadTerminalPreferences(path: string | null): Promise<Part
     const runFilter = parsed.runFilter === "active" || parsed.runFilter === "terminal" || parsed.runFilter === "all" ? parsed.runFilter : undefined;
     const liveTailPaused = typeof parsed.liveTailPaused === "boolean" ? parsed.liveTailPaused : undefined;
     const showRunEventDetail = typeof parsed.showRunEventDetail === "boolean" ? parsed.showRunEventDetail : undefined;
+    const refreshIntervalMs = typeof parsed.refreshIntervalMs === "number" && Number.isFinite(parsed.refreshIntervalMs) && parsed.refreshIntervalMs >= 0
+      ? Math.round(parsed.refreshIntervalMs)
+      : undefined;
 
     return {
       ...(selectedProjectId !== undefined ? { selectedProjectId } : {}),
       ...(runFilter ? { runFilter } : {}),
       ...(liveTailPaused !== undefined ? { liveTailPaused } : {}),
       ...(showRunEventDetail !== undefined ? { showRunEventDetail } : {}),
+      ...(refreshIntervalMs !== undefined ? { refreshIntervalMs } : {}),
     };
   } catch {
     return {};
@@ -1656,6 +1664,7 @@ async function resolveTerminalClientStartup(config: SpecRailTerminalClientConfig
       ...config,
       initialProjectId: preferences.selectedProjectId !== undefined ? preferences.selectedProjectId : config.initialProjectId,
       initialRunFilter: preferences.runFilter ?? config.initialRunFilter,
+      refreshIntervalMs: preferences.refreshIntervalMs ?? config.refreshIntervalMs,
     },
     preferences,
   };
@@ -1676,6 +1685,8 @@ export async function runTerminalApp(
   let disposed = false;
   let monitorSerial = 0;
   let monitorAbort: AbortController | null = null;
+  let refreshTimer: NodeJS.Timeout | null = null;
+  let preferenceSaveQueue: Promise<void> = Promise.resolve();
 
   const render = () => {
     io.stdout.write("\u001Bc");
@@ -1689,12 +1700,25 @@ export async function runTerminalApp(
   };
 
   const persistPreferences = (nextState: TerminalAppState) => {
-    void saveTerminalPreferences(effectiveConfig.preferencePath, {
+    preferenceSaveQueue = preferenceSaveQueue.then(() => saveTerminalPreferences(effectiveConfig.preferencePath, {
       selectedProjectId: nextState.selectedProjectId ?? null,
       runFilter: nextState.runFilter,
       liveTailPaused: nextState.runEvents.paused,
       showRunEventDetail: nextState.showRunEventDetail ?? false,
-    });
+      refreshIntervalMs: nextState.refreshIntervalMs,
+    }));
+    void preferenceSaveQueue;
+  };
+
+  const restartRefreshTimer = () => {
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+
+    if (state.refreshIntervalMs > 0) {
+      refreshTimer = setInterval(() => void refresh(), state.refreshIntervalMs);
+    }
   };
 
   const patchRunFeed = (patch: Partial<RunEventFeedState>) => {
@@ -2053,6 +2077,18 @@ export async function runTerminalApp(
     }
   };
 
+  const adjustRefreshInterval = (deltaMs: number) => {
+    const nextInterval = clampIndex(state.refreshIntervalMs + deltaMs, MAX_REFRESH_INTERVAL_MS + 1);
+    const nextState: TerminalAppState = {
+      ...state,
+      refreshIntervalMs: nextInterval,
+      statusLine: nextInterval > 0 ? `Refresh interval set to ${nextInterval}ms.` : "Automatic refresh disabled; press r to refresh manually.",
+    };
+    updateState(nextState);
+    persistPreferences(nextState);
+    restartRefreshTimer();
+  };
+
   const moveRunEventDetailSelection = (delta: number) => {
     if (state.screen !== "runs") {
       updateState({ ...state, statusLine: "Switch to the runs screen to select event detail." });
@@ -2384,7 +2420,7 @@ export async function runTerminalApp(
   io.stdin.setRawMode(true);
   io.stdin.resume();
 
-  const interval = config.refreshIntervalMs > 0 ? setInterval(() => void refresh(), config.refreshIntervalMs) : null;
+  restartRefreshTimer();
 
   await new Promise<void>((resolve) => {
     const cleanup = () => {
@@ -2392,8 +2428,9 @@ export async function runTerminalApp(
       if (monitorAbort) {
         monitorAbort.abort();
       }
-      if (interval) {
-        clearInterval(interval);
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+        refreshTimer = null;
       }
 
       io.stdin.off("keypress", onKeypress);
@@ -2545,6 +2582,16 @@ export async function runTerminalApp(
 
       if (key.name === "n") {
         moveRunEventDetailSelection(1);
+        return;
+      }
+
+      if (input === "+" || input === "=") {
+        adjustRefreshInterval(REFRESH_INTERVAL_STEP_MS);
+        return;
+      }
+
+      if (input === "-") {
+        adjustRefreshInterval(-REFRESH_INTERVAL_STEP_MS);
         return;
       }
 

--- a/docs/terminal-client.md
+++ b/docs/terminal-client.md
@@ -47,7 +47,7 @@ The run detail pane also highlights:
 - planning-context staleness and last planning-context update timestamp
 - operator actions for starting runs from tracks, resuming terminal runs, cancelling active runs, and guarded workspace cleanup
 - contextual keyboard help for the active screen or currently open multi-step composer
-- startup defaults for initial project scope and run filter, plus optional local persistence for project scope, run filter, live-tail pause, and event-detail visibility changes
+- startup defaults for initial project scope and run filter, plus optional local persistence for project scope, run filter, refresh interval, live-tail pause, and event-detail visibility changes
 
 ## Planning and approval workflow support
 
@@ -73,4 +73,3 @@ This is intentionally still lightweight:
 
 Good next steps after the live monitor baseline:
 - richer planning interaction beyond the current focused revision selector and lightweight proposal authoring
-- optional persistence for refresh interval if operators need custom refresh cadence to survive restarts


### PR DESCRIPTION
## Summary
- extend terminal local preferences with refreshIntervalMs
- load valid saved refresh cadence during startup
- add + / - shortcuts to adjust automatic refresh cadence at runtime
- restart the refresh timer after cadence changes
- serialize best-effort preference saves so rapid toggles do not overwrite newer values
- document expanded preference scope and refresh controls

Closes #369

## Verification
- pnpm --filter @specrail/terminal check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/terminal/src/__tests__/terminal-app.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build