### PR TITLE
feat: add ACP event projections

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -84,6 +84,22 @@ function createFakeService() {
         summary: `Started ${runId}`,
         payload: { status: "running" },
       });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "tool_call",
+        timestamp: "2026-04-13T00:00:00.500Z",
+        source: "executor",
+        summary: `Running tests for ${runId}`,
+        payload: { toolName: "shell", toolUseId: `tool-call-${runId}` },
+      });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "tool_result",
+        timestamp: "2026-04-13T00:00:00.750Z",
+        source: "executor",
+        summary: `Tests passed for ${runId}`,
+        payload: { toolName: "shell", toolUseId: `tool-call-${runId}`, exitCode: 0, status: "completed" },
+      });
       if (requiresApproval) {
         pushEvent(runId, {
           id: `${runId}-approval-request`,
@@ -285,6 +301,9 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   assert.ok(
     notifications.some((payload) => JSON.stringify(payload).includes("Completed run-1")),
   );
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"task_status_changed","status":"running"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"tool_call","toolName":"shell","toolUseId":"tool-call-run-1"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"tool_result","toolName":"shell","toolUseId":"tool-call-run-1","exitCode":0,"status":"completed"}'));
 
   const listResponse = await server.handleMessage(
     { jsonrpc: "2.0", id: 4, method: "session/list", params: { cwd: "/tmp/specrail" } },
@@ -411,6 +430,7 @@ test("ACP server emits richer permission request and resolution updates", async 
 
   const infoUpdates = startNotifications.filter((payload) => payload.method === "session/update");
   assert.ok(infoUpdates.some((payload) => JSON.stringify(payload).includes('"status":"waiting_approval"')));
+  assert.ok(JSON.stringify(startNotifications).includes('"eventProjection":{"kind":"approval_requested","requestId":"run-1-approval-request","toolName":"Bash","toolUseId":"tool-run-1"}'));
 
   const permissionRequest = startNotifications.find((payload) => payload.method === "session/request_permission") as
     | { params?: { toolName?: string; requestId?: string } }
@@ -446,6 +466,7 @@ test("ACP server emits richer permission request and resolution updates", async 
 
   assert.deepEqual(resumeResponse?.result, { stopReason: "end_turn" });
   assert.ok(resumeNotifications.some((payload) => JSON.stringify(payload).includes("approval_resolved")));
+  assert.ok(JSON.stringify(resumeNotifications).includes('"eventProjection":{"kind":"approval_resolved","requestId":"run-1-approval-request","outcome":"approved","decidedBy":"user"}'));
   assert.ok(resumeNotifications.some((payload) => JSON.stringify(payload).includes('"status":"running"')));
   assert.ok(resumeNotifications.some((payload) => JSON.stringify(payload).includes('"status":"completed"')));
 });

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -514,6 +514,46 @@ export class SpecRailAcpServer {
     };
   }
 
+  private toEventProjection(event: ExecutionEvent): Record<string, unknown> | undefined {
+    switch (event.type) {
+      case "tool_call":
+        return {
+          kind: "tool_call",
+          toolName: this.readString(event.payload?.toolName),
+          toolUseId: this.readString(event.payload?.toolUseId),
+        };
+      case "tool_result":
+        return {
+          kind: "tool_result",
+          toolName: this.readString(event.payload?.toolName),
+          toolUseId: this.readString(event.payload?.toolUseId),
+          exitCode: this.readNumber(event.payload?.exitCode),
+          status: this.readString(event.payload?.status),
+        };
+      case "approval_requested":
+        return {
+          kind: "approval_requested",
+          requestId: event.id,
+          toolName: this.readString(event.payload?.toolName),
+          toolUseId: this.readString(event.payload?.toolUseId),
+        };
+      case "approval_resolved":
+        return {
+          kind: "approval_resolved",
+          requestId: this.readString(event.payload?.requestId),
+          outcome: this.readString(event.payload?.outcome),
+          decidedBy: this.readString(event.payload?.decidedBy),
+        };
+      case "task_status_changed":
+        return {
+          kind: "task_status_changed",
+          status: this.readString(event.payload?.status),
+        };
+      default:
+        return undefined;
+    }
+  }
+
   private toSessionUpdate(sessionId: string, event: ExecutionEvent): Record<string, unknown> {
     return {
       jsonrpc: "2.0",
@@ -529,6 +569,7 @@ export class SpecRailAcpServer {
           _meta: {
             specrail: {
               executionEvent: event,
+              eventProjection: this.toEventProjection(event),
             },
           },
         },
@@ -585,6 +626,10 @@ export class SpecRailAcpServer {
 
   private readString(value: unknown): string | undefined {
     return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  }
+
+  private readNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
   }
 
   private readSessionStatus(event: ExecutionEvent): Execution["status"] | null {

--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -39,15 +39,28 @@ The initial adapter keeps the ACP surface intentionally narrow.
 ## Event mapping
 
 The adapter now keeps the raw SpecRail event payload in `_meta.specrail.executionEvent`, but it also adds a few ACP-facing projections so clients can render session state with less guesswork.
+Known event families additionally include `_meta.specrail.eventProjection`, a compact stable summary intended for display logic. Unknown event types still include the raw execution event and readable message chunk without a projection.
 
 ### Session update mapping
 
 | SpecRail signal | ACP projection | Notes |
 | --- | --- | --- |
 | `task_status_changed` with `payload.status` | `session/update` with `session_info_update` | Mirrors the current run status into `_meta.specrail.status`. |
-| any persisted execution event | `session/update` with `agent_message_chunk` | Still emits a readable text chunk like `[tool_call] ...` and includes the full event in `_meta`. |
+| any persisted execution event | `session/update` with `agent_message_chunk` | Still emits a readable text chunk like `[tool_call] ...` and includes the full event in `_meta`. Known event families also include `_meta.specrail.eventProjection`. |
 | `approval_requested` | `session/update` + `session/request_permission` | Session status is promoted to `waiting_approval`, and the permission request carries request/tool metadata when present. |
 | `approval_resolved` | `session/update` with `session_info_update` + `agent_message_chunk` | Clears the pending permission marker and surfaces the resolution outcome back to ACP clients. |
+
+### Event projection shape
+
+`_meta.specrail.eventProjection` is intentionally compact and additive. Current projections cover:
+
+- `tool_call`: `kind`, `toolName`, `toolUseId`
+- `tool_result`: `kind`, `toolName`, `toolUseId`, `exitCode`, `status`
+- `approval_requested`: `kind`, `requestId`, `toolName`, `toolUseId`
+- `approval_resolved`: `kind`, `requestId`, `outcome`, `decidedBy`
+- `task_status_changed`: `kind`, `status`
+
+Clients should use these fields for common rendering, and fall back to `_meta.specrail.executionEvent` when they need provider-specific or not-yet-projected payload details.
 
 ### Permission round-trip
 
@@ -98,7 +111,7 @@ This is intentionally an initial bridge, not a full ACP implementation.
 1. `session/new` currently requires SpecRail-specific metadata, especially `_meta.specrail.trackId`.
 2. Planning artifacts, approvals, channel bindings, and attachment flows stay in the existing REST API.
 3. Runtime permission requests are translated into ACP-friendly updates; decisions are persisted through the core approval path and delivered to executors that implement `resolveRuntimeApproval`.
-4. Event updates are richer than the initial bridge, but the mapping still collapses many provider-specific details into `session/update` plus `_meta` rather than a full ACP-native event taxonomy.
+4. Event updates include compact projections for common SpecRail event families, but many provider-specific details still remain in `session/update` plus raw `_meta` rather than a full ACP-native event taxonomy.
 5. The adapter stores ACP session records locally, but run state still lives in the normal SpecRail repositories.
 6. Terminal and filesystem ACP capabilities are not exposed yet; future versions must apply the workspace ownership rules above before granting scoped access.
 7. `approval_resolved` records the operator decision. Callback delivery may additionally append handled, unsupported, or failed callback events depending on the selected executor.
@@ -114,7 +127,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 
 Good next steps from the current bridge:
 - replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
-- expand the ACP-facing event taxonomy beyond readable `agent_message_chunk` fallbacks for provider-specific details that clients need to render natively
+- expand ACP-facing projections for provider-specific details that clients need to render natively
 - design the scoped ACP filesystem/terminal capability shape that applies the documented workspace ownership rules
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client
 - decide which planning/admin flows, if any, should become ACP-native versus staying in the REST API


### PR DESCRIPTION
## Summary
- add compact _meta.specrail.eventProjection objects to ACP session/update notifications for common event families
- cover tool_call, tool_result, approval_requested, approval_resolved, and task_status_changed events
- preserve the existing raw _meta.specrail.executionEvent payload for compatibility and fallback rendering
- document projection shape and narrow the ACP event taxonomy follow-up

Closes #373

## Verification
- pnpm --filter @specrail/acp-server check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/acp-server/src/__tests__/acp-server.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build