### PR TITLE
feat: add ACP workspace read capability

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,7 +8,7 @@ import type { Execution, ExecutionEvent, SpecRailService, Track } from "@specrai
 
 import { SpecRailAcpServer } from "../server.js";
 
-function createFakeService() {
+function createFakeService(options: { workspaceRoot?: string } = {}) {
   const track: Track = {
     id: "track-1",
     projectId: "project-default",
@@ -65,7 +65,7 @@ function createFakeService() {
         trackId: input.trackId,
         backend: input.backend ?? "codex",
         profile: input.profile ?? "default",
-        workspacePath: path.join("/tmp", runId),
+        workspacePath: path.join(options.workspaceRoot ?? "/tmp", runId),
         branchName: `specrail/${runId}`,
         sessionRef: `session:${runId}`,
         planningSessionId: input.planningSessionId,
@@ -322,6 +322,64 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   );
   assert.equal(loadResponse?.error, undefined);
   assert.ok(loadNotifications.some((payload) => JSON.stringify(payload).includes("Started run-1")));
+});
+
+test("ACP server reads linked run workspace paths through scoped capability", async () => {
+  const stateDir = await mkdtemp(path.join(os.tmpdir(), "specrail-acp-state-"));
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "specrail-acp-workspace-"));
+  const server = new SpecRailAcpServer({
+    service: createFakeService({ workspaceRoot }) as unknown as SpecRailService,
+    stateDir,
+    now: () => "2026-04-13T12:00:00.000Z",
+    pollIntervalMs: 1,
+  });
+
+  const newResponse = await server.handleMessage(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "session/new",
+      params: { cwd: "/tmp/specrail", _meta: { specrail: { trackId: "track-1" } } },
+    },
+    () => {},
+  );
+  const sessionId = (newResponse?.result as { sessionId: string }).sessionId;
+  await server.handleMessage(
+    {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "session/prompt",
+      params: { sessionId, prompt: [{ type: "text", text: "Start workspace read test" }] },
+    },
+    () => {},
+  );
+
+  const runWorkspace = path.join(workspaceRoot, "run-1");
+  await mkdir(path.join(runWorkspace, "notes"), { recursive: true });
+  await writeFile(path.join(runWorkspace, "notes", "summary.md"), "# Summary\nDone.\n");
+
+  const fileResponse = await server.handleMessage(
+    { jsonrpc: "2.0", id: 3, method: "specrail/workspace/read", params: { sessionId, path: "notes/summary.md" } },
+    () => {},
+  );
+  assert.equal(fileResponse?.error, undefined);
+  assert.deepEqual((fileResponse?.result as { kind: string; path: string; content: string }).kind, "file");
+  assert.equal((fileResponse?.result as { path: string }).path, "notes/summary.md");
+  assert.match((fileResponse?.result as { content: string }).content, /# Summary/);
+  assert.ok(JSON.stringify(fileResponse?.result).includes('"workspaceCapability"'));
+
+  const directoryResponse = await server.handleMessage(
+    { jsonrpc: "2.0", id: 4, method: "specrail/workspace/read", params: { sessionId, path: "notes" } },
+    () => {},
+  );
+  assert.equal(directoryResponse?.error, undefined);
+  assert.ok(JSON.stringify(directoryResponse?.result).includes('"summary.md"'));
+
+  const outsideResponse = await server.handleMessage(
+    { jsonrpc: "2.0", id: 5, method: "specrail/workspace/read", params: { sessionId, path: "../secret.txt" } },
+    () => {},
+  );
+  assert.equal(outsideResponse?.error?.data && (outsideResponse.error.data as { reason?: string }).reason, "path_outside_workspace");
 });
 
 test("ACP server creates a project-scoped track when session/new omits trackId", async () => {

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -96,6 +96,11 @@ interface SessionCancelParams {
   sessionId?: string;
 }
 
+interface WorkspaceReadParams {
+  sessionId?: string;
+  path?: string;
+}
+
 export interface AcpServerOptions {
   service: SpecRailService;
   stateDir: string;
@@ -168,6 +173,8 @@ export class SpecRailAcpServer {
         case "session/cancel":
           await this.handleSessionCancel(message.params);
           return message.id === undefined ? null : this.ok(message.id, null);
+        case "specrail/workspace/read":
+          return this.ok(message.id, await this.handleWorkspaceRead(message.params));
         default:
           return this.error(message.id, -32601, `method not found: ${message.method}`);
       }
@@ -177,7 +184,7 @@ export class SpecRailAcpServer {
       }
 
       if (error instanceof ValidationError || error instanceof Error) {
-        return this.error(message.id, -32602, error.message);
+        return this.error(message.id, -32602, error.message, this.readErrorData(error));
       }
 
       return this.error(message.id, -32000, "unknown acp server error");
@@ -386,6 +393,80 @@ export class SpecRailAcpServer {
     if (session.runId) {
       await this.options.service.cancelRun({ runId: session.runId });
     }
+  }
+
+  private async handleWorkspaceRead(params: unknown): Promise<Record<string, unknown>> {
+    const body = (params ?? {}) as WorkspaceReadParams;
+    const sessionId = this.requireNonEmptyString(body.sessionId, "sessionId");
+    const requestedPath = this.optionalString(body.path) ?? ".";
+    const session = await this.readSession(sessionId);
+    if (!session.runId) {
+      throw this.workspaceRefusal("workspace read requires a linked run", { reason: "missing_run" });
+    }
+
+    const run = await this.options.service.getRun(session.runId);
+    if (!run) {
+      throw this.workspaceRefusal("workspace read requires an existing run", { reason: "missing_run", runId: session.runId });
+    }
+    if (!run.workspacePath) {
+      throw this.workspaceRefusal("workspace is unavailable for this run", { reason: "workspace_unavailable", runId: run.id });
+    }
+
+    const workspaceRoot = path.resolve(run.workspacePath);
+    const targetPath = path.resolve(workspaceRoot, requestedPath);
+    const relativePath = path.relative(workspaceRoot, targetPath);
+    if (path.isAbsolute(requestedPath) || relativePath.startsWith("..") || relativePath === ".." || path.isAbsolute(relativePath)) {
+      throw this.workspaceRefusal("workspace read path must stay inside the run workspace", {
+        reason: "path_outside_workspace",
+        runId: run.id,
+      });
+    }
+
+    let targetStat;
+    try {
+      targetStat = await stat(targetPath);
+    } catch {
+      throw this.workspaceRefusal("workspace path was not found", { reason: "path_not_found", runId: run.id, path: relativePath || "." });
+    }
+
+    const capability = {
+      runId: run.id,
+      workspacePath: run.workspacePath,
+      allowedOperations: ["read"],
+      cleanupBlocked: run.status === "created" || run.status === "queued" || run.status === "running" || run.status === "waiting_approval",
+    };
+
+    if (targetStat.isDirectory()) {
+      const entries = await readdir(targetPath, { withFileTypes: true });
+      return {
+        kind: "directory",
+        path: relativePath || ".",
+        entries: entries.slice(0, 100).map((entry) => ({
+          name: entry.name,
+          kind: entry.isDirectory() ? "directory" : "file",
+        })),
+        truncated: entries.length > 100,
+        _meta: { specrail: { workspaceCapability: capability } },
+      };
+    }
+
+    if (!targetStat.isFile()) {
+      throw this.workspaceRefusal("workspace path is not a readable file or directory", {
+        reason: "operation_not_allowed",
+        runId: run.id,
+        path: relativePath || ".",
+      });
+    }
+
+    const content = await readFile(targetPath, "utf8");
+    const truncated = content.length > 64_000;
+    return {
+      kind: "file",
+      path: relativePath || ".",
+      content: truncated ? content.slice(0, 64_000) : content,
+      truncated,
+      _meta: { specrail: { workspaceCapability: capability } },
+    };
   }
 
   private toSessionInfoUpdate(session: AcpSessionRecord, execution: Execution): Record<string, unknown> {
@@ -626,6 +707,14 @@ export class SpecRailAcpServer {
 
   private readString(value: unknown): string | undefined {
     return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  }
+
+  private readErrorData(error: unknown): unknown {
+    return typeof error === "object" && error !== null && "data" in error ? (error as { data?: unknown }).data : undefined;
+  }
+
+  private workspaceRefusal(message: string, data: Record<string, unknown>): ValidationError & { data: Record<string, unknown> } {
+    return Object.assign(new ValidationError(message), { data });
   }
 
   private readNumber(value: unknown): number | undefined {

--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -28,6 +28,10 @@ The initial adapter keeps the ACP surface intentionally narrow.
   - replays persisted SpecRail run events as ACP `session/update` notifications
 - ACP `session/list`
   - lists ACP session records and their linked SpecRail run ids when present
+- `specrail/workspace/read`
+  - reads an explicit file or directory under the linked run workspace
+  - rejects absolute paths and traversal outside the SpecRail-managed workspace root
+  - returns `_meta.specrail.workspaceCapability` metadata with the linked `runId`, workspace path, allowed operations, and cleanup block state
 
 ## Session identity
 
@@ -106,17 +110,22 @@ These rules keep ACP as a thin interactive edge while preserving SpecRail as the
 
 ## Scoped filesystem and terminal capability shape
 
-Filesystem and terminal ACP capabilities are future work, but their contract should be narrow before implementation:
+Filesystem and terminal ACP capabilities stay narrow. The current spike exposes read-only workspace inspection through `specrail/workspace/read`; terminal access and writes remain future work.
 
 - Capability grants are session-local and tied to a linked SpecRail `runId`; clients must not request arbitrary host paths.
 - The effective root is the SpecRail-managed `workspacePath` for that run. Relative paths resolve under that root and must be rejected if they escape it.
 - The adapter should expose capability metadata through `_meta.specrail.workspaceCapability`, including `runId`, `workspacePath`, allowed operations, and whether cleanup is currently blocked by active execution.
-- Filesystem reads should start as explicit file/directory reads, not broad recursive sync. Writes should require a separate operation grant and should record a SpecRail execution event or equivalent audit entry.
+- Filesystem reads start as explicit file/directory reads, not broad recursive sync. Writes require a separate future operation grant and should record a SpecRail execution event or equivalent audit entry.
 - Terminal access should run through a SpecRail-mediated command/session API, inherit the linked run workspace, and emit execution events for command start/output/exit rather than becoming an unmanaged client shell.
 - Refusals should be structured and non-sensitive, for example `missing_run`, `workspace_unavailable`, `path_outside_workspace`, `operation_not_allowed`, `cleanup_blocked`, or `active_run_required`.
 - Cleanup remains outside the ACP capability. Clients may surface cleanup status and links/actions, but deletion must still use the SpecRail cleanup preview/apply flow.
 
 This shape preserves the workspace ownership rules while leaving room for ACP-native clients to inspect and interact with a run workspace in a controlled way.
+
+Current `specrail/workspace/read` responses are intentionally bounded:
+- directory reads return up to 100 entries and a `truncated` flag
+- file reads return UTF-8 content up to 64,000 characters and a `truncated` flag
+- refusals use structured non-sensitive `error.data.reason` values such as `missing_run`, `workspace_unavailable`, `path_outside_workspace`, `path_not_found`, or `operation_not_allowed`
 
 ## Planning and admin boundary
 
@@ -146,7 +155,7 @@ This is intentionally an initial bridge, not a full ACP implementation.
 3. Runtime permission requests are translated into ACP-friendly updates; decisions are persisted through the core approval path and delivered to executors that implement `resolveRuntimeApproval`.
 4. Event updates include compact projections for common SpecRail event families, but many provider-specific details still remain in `session/update` plus raw `_meta` rather than a full ACP-native event taxonomy.
 5. The adapter stores ACP session records locally, but run state still lives in the normal SpecRail repositories.
-6. Terminal and filesystem ACP capabilities are not exposed yet; future versions should implement the scoped capability shape above before granting access.
+6. Terminal ACP capabilities and filesystem writes are not exposed yet; future versions should follow the scoped capability shape above before granting additional access.
 7. `approval_resolved` records the operator decision. Callback delivery may additionally append handled, unsupported, or failed callback events depending on the selected executor.
 
 ## Why this shape
@@ -161,6 +170,6 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 Good next steps from the current bridge:
 - replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
 - expand ACP-facing projections for provider-specific details that clients need to render natively
-- implement a small scoped ACP filesystem capability spike using the documented capability shape
+- extend the scoped ACP filesystem capability with audited write operations if a concrete ACP client needs them
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client
 - revisit the planning/admin boundary only when a concrete ACP client needs a narrowly scoped session-local interaction


### PR DESCRIPTION
## Summary
- add a scoped specrail/workspace/read JSON-RPC method to the ACP server
- require a linked run and resolve reads under the run workspace only
- support bounded file content and directory listing responses with workspaceCapability metadata
- return structured non-sensitive refusal data for missing run/workspace/path and outside-workspace attempts
- document the read capability and update the ACP follow-up list

Closes #379

## Verification
- pnpm --filter @specrail/acp-server check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/acp-server/src/__tests__/acp-server.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build