### PR TITLE
feat: expand ACP generic event projections

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -100,6 +100,39 @@ function createFakeService(options: { workspaceRoot?: string } = {}) {
         summary: `Tests passed for ${runId}`,
         payload: { toolName: "shell", toolUseId: `tool-call-${runId}`, exitCode: 0, status: "completed" },
       });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "shell_command",
+        timestamp: "2026-04-13T00:00:00.800Z",
+        source: "executor",
+        summary: `pnpm test for ${runId}`,
+        payload: { command: "pnpm test", exitCode: 0, status: "completed" },
+      });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "file_change",
+        timestamp: "2026-04-13T00:00:00.850Z",
+        source: "executor",
+        summary: `Updated README for ${runId}`,
+        payload: { path: "README.md", operation: "modified" },
+      });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "test_result",
+        timestamp: "2026-04-13T00:00:00.900Z",
+        source: "executor",
+        summary: `Tests passed for ${runId}`,
+        payload: { status: "passed", passed: 12, failed: 0 },
+      });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "message",
+        subtype: "assistant_text",
+        timestamp: "2026-04-13T00:00:00.950Z",
+        source: "executor",
+        summary: `Implementation note for ${runId}`,
+        payload: { role: "assistant" },
+      });
       if (requiresApproval) {
         pushEvent(runId, {
           id: `${runId}-approval-request`,
@@ -122,6 +155,7 @@ function createFakeService(options: { workspaceRoot?: string } = {}) {
           timestamp: "2026-04-13T00:00:01.000Z",
           source: "executor",
           summary: `Completed ${runId}`,
+          payload: { status: "completed" },
         });
       }
       return created;
@@ -304,6 +338,11 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"task_status_changed","status":"running"}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"tool_call","toolName":"shell","toolUseId":"tool-call-run-1"}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"tool_result","toolName":"shell","toolUseId":"tool-call-run-1","exitCode":0,"status":"completed"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"shell_command","command":"pnpm test","exitCode":0,"status":"completed"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"file_change","path":"README.md","operation":"modified"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"test_result","status":"passed","passed":12,"failed":0}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"message","subtype":"assistant_text","role":"assistant"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"summary","status":"completed"}'));
 
   const listResponse = await server.handleMessage(
     { jsonrpc: "2.0", id: 4, method: "session/list", params: { cwd: "/tmp/specrail" } },

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -630,6 +630,38 @@ export class SpecRailAcpServer {
           kind: "task_status_changed",
           status: this.readString(event.payload?.status),
         };
+      case "message":
+        return {
+          kind: "message",
+          subtype: event.subtype,
+          role: this.readString(event.payload?.role),
+        };
+      case "summary":
+        return {
+          kind: "summary",
+          subtype: event.subtype,
+          status: this.readString(event.payload?.status),
+        };
+      case "test_result":
+        return {
+          kind: "test_result",
+          status: this.readString(event.payload?.status),
+          passed: this.readNumber(event.payload?.passed),
+          failed: this.readNumber(event.payload?.failed),
+        };
+      case "file_change":
+        return {
+          kind: "file_change",
+          path: this.readString(event.payload?.path),
+          operation: this.readString(event.payload?.operation),
+        };
+      case "shell_command":
+        return {
+          kind: "shell_command",
+          command: this.readString(event.payload?.command),
+          exitCode: this.readNumber(event.payload?.exitCode),
+          status: this.readString(event.payload?.status),
+        };
       default:
         return undefined;
     }

--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -63,8 +63,13 @@ Known event families additionally include `_meta.specrail.eventProjection`, a co
 - `approval_requested`: `kind`, `requestId`, `toolName`, `toolUseId`
 - `approval_resolved`: `kind`, `requestId`, `outcome`, `decidedBy`
 - `task_status_changed`: `kind`, `status`
+- `message`: `kind`, `subtype`, `role`
+- `summary`: `kind`, `subtype`, `status`
+- `test_result`: `kind`, `status`, `passed`, `failed`
+- `file_change`: `kind`, `path`, `operation`
+- `shell_command`: `kind`, `command`, `exitCode`, `status`
 
-Clients should use these fields for common rendering, and fall back to `_meta.specrail.executionEvent` when they need provider-specific or not-yet-projected payload details.
+Clients should use these fields for common rendering, and fall back to `_meta.specrail.executionEvent` when they need provider-specific or not-yet-projected payload details. Projection fields are optional when the source payload does not provide the corresponding value.
 
 ### Permission round-trip
 
@@ -169,7 +174,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 
 Good next steps from the current bridge:
 - replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
-- expand ACP-facing projections for provider-specific details that clients need to render natively
+- expand ACP-facing projections for provider-specific details that clients need to render natively beyond the generic event families
 - extend the scoped ACP filesystem capability with audited write operations if a concrete ACP client needs them
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client
 - revisit the planning/admin boundary only when a concrete ACP client needs a narrowly scoped session-local interaction


### PR DESCRIPTION
## Summary
- expand ACP eventProjection support for message, summary, test_result, file_change, and shell_command events
- keep projection fields compact and optional when payload fields are absent
- preserve raw _meta.specrail.executionEvent fallback behavior
- document the expanded generic projection shape

Closes #381

## Verification
- pnpm --filter @specrail/acp-server check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/acp-server/src/__tests__/acp-server.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build