### PR TITLE
feat: add Claude ACP projection metadata

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -133,6 +133,27 @@ function createFakeService(options: { workspaceRoot?: string } = {}) {
         summary: `Implementation note for ${runId}`,
         payload: { role: "assistant" },
       });
+      pushEvent(runId, {
+        executionId: runId,
+        type: "summary",
+        subtype: "claude_result_success",
+        timestamp: "2026-04-13T00:00:00.980Z",
+        source: "claude_code",
+        summary: `Claude result ${runId}`,
+        payload: {
+          providerSessionId: `claude-session-${runId}`,
+          providerInvocationId: `claude-invocation-${runId}`,
+          providerEventType: "result",
+          providerEventSubtype: "success",
+          model: "sonnet",
+          status: "completed",
+          durationMs: 1200,
+          durationApiMs: 800,
+          totalCostUsd: 0.012,
+          numTurns: 2,
+          isError: false,
+        },
+      });
       if (requiresApproval) {
         pushEvent(runId, {
           id: `${runId}-approval-request`,
@@ -342,7 +363,10 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"file_change","path":"README.md","operation":"modified"}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"test_result","status":"passed","passed":12,"failed":0}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"message","subtype":"assistant_text","role":"assistant"}'));
-  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"summary","status":"completed"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"summary","subtype":"claude_result_success","status":"completed","provider":{"kind":"claude_code"'));
+  assert.ok(JSON.stringify(notifications).includes('"providerSessionId":"claude-session-run-1"'));
+  assert.ok(JSON.stringify(notifications).includes('"providerEventType":"result"'));
+  assert.ok(JSON.stringify(notifications).includes('"totalCostUsd":0.012'));
 
   const listResponse = await server.handleMessage(
     { jsonrpc: "2.0", id: 4, method: "session/list", params: { cwd: "/tmp/specrail" } },

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -596,75 +596,103 @@ export class SpecRailAcpServer {
   }
 
   private toEventProjection(event: ExecutionEvent): Record<string, unknown> | undefined {
+    const provider = this.toProviderEventProjection(event);
+    const withProvider = (projection: Record<string, unknown>) => ({
+      ...projection,
+      ...(provider ? { provider } : {}),
+    });
+
     switch (event.type) {
       case "tool_call":
-        return {
+        return withProvider({
           kind: "tool_call",
           toolName: this.readString(event.payload?.toolName),
           toolUseId: this.readString(event.payload?.toolUseId),
-        };
+        });
       case "tool_result":
-        return {
+        return withProvider({
           kind: "tool_result",
           toolName: this.readString(event.payload?.toolName),
           toolUseId: this.readString(event.payload?.toolUseId),
           exitCode: this.readNumber(event.payload?.exitCode),
           status: this.readString(event.payload?.status),
-        };
+        });
       case "approval_requested":
-        return {
+        return withProvider({
           kind: "approval_requested",
           requestId: event.id,
           toolName: this.readString(event.payload?.toolName),
           toolUseId: this.readString(event.payload?.toolUseId),
-        };
+        });
       case "approval_resolved":
-        return {
+        return withProvider({
           kind: "approval_resolved",
           requestId: this.readString(event.payload?.requestId),
           outcome: this.readString(event.payload?.outcome),
           decidedBy: this.readString(event.payload?.decidedBy),
-        };
+        });
       case "task_status_changed":
-        return {
+        return withProvider({
           kind: "task_status_changed",
           status: this.readString(event.payload?.status),
-        };
+        });
       case "message":
-        return {
+        return withProvider({
           kind: "message",
           subtype: event.subtype,
           role: this.readString(event.payload?.role),
-        };
+        });
       case "summary":
-        return {
+        return withProvider({
           kind: "summary",
           subtype: event.subtype,
           status: this.readString(event.payload?.status),
-        };
+        });
       case "test_result":
-        return {
+        return withProvider({
           kind: "test_result",
           status: this.readString(event.payload?.status),
           passed: this.readNumber(event.payload?.passed),
           failed: this.readNumber(event.payload?.failed),
-        };
+        });
       case "file_change":
-        return {
+        return withProvider({
           kind: "file_change",
           path: this.readString(event.payload?.path),
           operation: this.readString(event.payload?.operation),
-        };
+        });
       case "shell_command":
-        return {
+        return withProvider({
           kind: "shell_command",
           command: this.readString(event.payload?.command),
           exitCode: this.readNumber(event.payload?.exitCode),
           status: this.readString(event.payload?.status),
-        };
+        });
       default:
         return undefined;
     }
+  }
+
+  private toProviderEventProjection(event: ExecutionEvent): Record<string, unknown> | undefined {
+    if (event.source !== "claude_code" && !event.subtype?.startsWith("claude_")) {
+      return undefined;
+    }
+
+    return {
+      kind: "claude_code",
+      subtype: event.subtype,
+      providerSessionId: this.readString(event.payload?.providerSessionId),
+      providerInvocationId: this.readString(event.payload?.providerInvocationId),
+      providerEventType: this.readString(event.payload?.providerEventType),
+      providerEventSubtype: this.readString(event.payload?.providerEventSubtype),
+      model: this.readString(event.payload?.model),
+      lifecycleStatus: this.readString(event.payload?.status),
+      durationMs: this.readNumber(event.payload?.durationMs),
+      durationApiMs: this.readNumber(event.payload?.durationApiMs),
+      totalCostUsd: this.readNumber(event.payload?.totalCostUsd),
+      numTurns: this.readNumber(event.payload?.numTurns),
+      isError: this.readBoolean(event.payload?.isError),
+    };
   }
 
   private toSessionUpdate(sessionId: string, event: ExecutionEvent): Record<string, unknown> {
@@ -751,6 +779,10 @@ export class SpecRailAcpServer {
 
   private readNumber(value: unknown): number | undefined {
     return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  }
+
+  private readBoolean(value: unknown): boolean | undefined {
+    return typeof value === "boolean" ? value : undefined;
   }
 
   private readSessionStatus(event: ExecutionEvent): Execution["status"] | null {

--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -71,6 +71,8 @@ Known event families additionally include `_meta.specrail.eventProjection`, a co
 
 Clients should use these fields for common rendering, and fall back to `_meta.specrail.executionEvent` when they need provider-specific or not-yet-projected payload details. Projection fields are optional when the source payload does not provide the corresponding value.
 
+Claude Code events additionally include `eventProjection.provider` when `event.source` is `claude_code` or the subtype starts with `claude_`. The nested provider projection is compact and may include `kind: "claude_code"`, `subtype`, `providerSessionId`, `providerInvocationId`, `providerEventType`, `providerEventSubtype`, `model`, `lifecycleStatus`, `durationMs`, `durationApiMs`, `totalCostUsd`, `numTurns`, and `isError`.
+
 ### Permission round-trip
 
 Runtime approval decisions now use the same domain service/API path as non-ACP clients:
@@ -174,7 +176,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 
 Good next steps from the current bridge:
 - replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
-- expand ACP-facing projections for provider-specific details that clients need to render natively beyond the generic event families
+- expand ACP-facing projections for additional provider-specific details when clients need them beyond the current Claude Code metadata
 - extend the scoped ACP filesystem capability with audited write operations if a concrete ACP client needs them
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client
 - revisit the planning/admin boundary only when a concrete ACP client needs a narrowly scoped session-local interaction


### PR DESCRIPTION
## Summary
- add nested Claude Code provider metadata to ACP event projections
- preserve generic projection fields and raw executionEvent fallback behavior
- document the Claude provider projection shape

Closes #383

## Verification
- pnpm --filter @specrail/acp-server check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/acp-server/src/__tests__/acp-server.test.ts
- pnpm check:links
- pnpm check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/api/src/__tests__/api.test.ts
- pnpm test
- pnpm build