### PR TITLE
feat: add Codex ACP projection metadata

### DIFF
--- a/apps/acp-server/src/__tests__/acp-server.test.ts
+++ b/apps/acp-server/src/__tests__/acp-server.test.ts
@@ -135,6 +135,14 @@ function createFakeService(options: { workspaceRoot?: string } = {}) {
       });
       pushEvent(runId, {
         executionId: runId,
+        type: "message",
+        timestamp: "2026-04-13T00:00:00.970Z",
+        source: "codex",
+        summary: `STDOUT ${runId}`,
+        payload: { sessionRef: `codex-session-${runId}`, stream: "stdout" },
+      });
+      pushEvent(runId, {
+        executionId: runId,
         type: "summary",
         subtype: "claude_result_success",
         timestamp: "2026-04-13T00:00:00.980Z",
@@ -363,6 +371,7 @@ test("ACP server initializes and maps session/new + prompt to SpecRail run lifec
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"file_change","path":"README.md","operation":"modified"}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"test_result","status":"passed","passed":12,"failed":0}'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"message","subtype":"assistant_text","role":"assistant"}'));
+  assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"message","provider":{"kind":"codex","sessionRef":"codex-session-run-1","stream":"stdout"'));
   assert.ok(JSON.stringify(notifications).includes('"eventProjection":{"kind":"summary","subtype":"claude_result_success","status":"completed","provider":{"kind":"claude_code"'));
   assert.ok(JSON.stringify(notifications).includes('"providerSessionId":"claude-session-run-1"'));
   assert.ok(JSON.stringify(notifications).includes('"providerEventType":"result"'));

--- a/apps/acp-server/src/server.ts
+++ b/apps/acp-server/src/server.ts
@@ -674,6 +674,18 @@ export class SpecRailAcpServer {
   }
 
   private toProviderEventProjection(event: ExecutionEvent): Record<string, unknown> | undefined {
+    if (event.source === "codex") {
+      return {
+        kind: "codex",
+        sessionRef: this.readString(event.payload?.sessionRef),
+        stream: this.readString(event.payload?.stream),
+        lifecycleStatus: this.readString(event.payload?.status),
+        terminal: this.readBoolean(event.payload?.terminal),
+        exitCode: this.readNumber(event.payload?.exitCode),
+        signal: this.readString(event.payload?.signal),
+      };
+    }
+
     if (event.source !== "claude_code" && !event.subtype?.startsWith("claude_")) {
       return undefined;
     }

--- a/docs/acp-server-edge-adapter.md
+++ b/docs/acp-server-edge-adapter.md
@@ -71,7 +71,10 @@ Known event families additionally include `_meta.specrail.eventProjection`, a co
 
 Clients should use these fields for common rendering, and fall back to `_meta.specrail.executionEvent` when they need provider-specific or not-yet-projected payload details. Projection fields are optional when the source payload does not provide the corresponding value.
 
-Claude Code events additionally include `eventProjection.provider` when `event.source` is `claude_code` or the subtype starts with `claude_`. The nested provider projection is compact and may include `kind: "claude_code"`, `subtype`, `providerSessionId`, `providerInvocationId`, `providerEventType`, `providerEventSubtype`, `model`, `lifecycleStatus`, `durationMs`, `durationApiMs`, `totalCostUsd`, `numTurns`, and `isError`.
+Provider events additionally include compact `eventProjection.provider` metadata:
+
+- Claude Code events include this metadata when `event.source` is `claude_code` or the subtype starts with `claude_`. Fields may include `kind: "claude_code"`, `subtype`, `providerSessionId`, `providerInvocationId`, `providerEventType`, `providerEventSubtype`, `model`, `lifecycleStatus`, `durationMs`, `durationApiMs`, `totalCostUsd`, `numTurns`, and `isError`.
+- Codex events include this metadata when `event.source` is `codex`. Fields may include `kind: "codex"`, `sessionRef`, `stream`, `lifecycleStatus`, `terminal`, `exitCode`, and `signal`.
 
 ### Permission round-trip
 
@@ -176,7 +179,7 @@ This follows the ACP fit analysis in `docs/research/acp-fit-for-specrail.md`:
 
 Good next steps from the current bridge:
 - replace approved-permission resume fallbacks with narrower provider-native permission continuation when Codex or Claude Code expose a usable primitive
-- expand ACP-facing projections for additional provider-specific details when clients need them beyond the current Claude Code metadata
+- expand ACP-facing projections for additional provider-specific details when clients need them beyond the current Claude Code and Codex metadata
 - extend the scoped ACP filesystem capability with audited write operations if a concrete ACP client needs them
 - build an ACP-aware terminal or editor client spike against this adapter to validate the session/update and permission request shapes with a real client
 - revisit the planning/admin boundary only when a concrete ACP client needs a narrowly scoped session-local interaction


### PR DESCRIPTION
## Summary
- add nested Codex provider metadata to ACP event projections
- preserve generic projection fields and raw executionEvent fallback behavior
- document Codex provider projection fields alongside Claude metadata

Closes #385

## Verification
- pnpm --filter @specrail/acp-server check
- pnpm exec tsx --tsconfig tsconfig.base.json --test --test-force-exit apps/acp-server/src/__tests__/acp-server.test.ts
- pnpm check:links
- pnpm check
- pnpm test
- pnpm build