### PR TITLE
refactor: extract GitHub relay queue backend factory

### DIFF
--- a/apps/github/src/__tests__/github-app.test.ts
+++ b/apps/github/src/__tests__/github-app.test.ts
@@ -12,6 +12,7 @@ import {
   buildGitHubSignature256,
   createGitHubAppInstallationTokenProvider,
   createGitHubAppJwt,
+  createGitHubRelayJobQueueFromConfig,
   createGitHubRestAuthorizationClient,
   createGitHubRestIssueCommentClient,
   createGitHubWebhookHttpServer,
@@ -28,6 +29,7 @@ import {
   postGitHubTerminalOutcomeComment,
   processGitHubRelayQueue,
   relayGitHubRunTerminalOutcome,
+  resolveGitHubRelayQueueBackend,
   resolveGitHubProjectId,
   startGitHubWebhookApp,
   verifyGitHubSignature256,
@@ -856,6 +858,39 @@ test("loadGitHubAppConfig parses repository project mappings and actor allowlist
   assert.equal(isGitHubActorAuthorized(config, "octocat"), true);
   assert.equal(isGitHubActorAuthorized(config, "hubot"), true);
   assert.equal(isGitHubActorAuthorized(config, "mallory"), false);
+});
+
+test("loadGitHubAppConfig reads explicit relay queue backend settings", () => {
+  assert.equal(loadGitHubAppConfig({ GITHUB_RELAY_QUEUE_BACKEND: "json_file" }).githubRelayQueueBackend, "json-file");
+  assert.throws(() => loadGitHubAppConfig({ GITHUB_RELAY_QUEUE_BACKEND: "redis" }), /invalid GITHUB_RELAY_QUEUE_BACKEND: redis/u);
+});
+
+test("resolveGitHubRelayQueueBackend preserves existing env precedence", () => {
+  assert.equal(resolveGitHubRelayQueueBackend({ githubRelayQueueDir: "/tmp/relay", githubRelayQueuePath: "/tmp/relay.json" }), "directory");
+  assert.equal(resolveGitHubRelayQueueBackend({ githubRelayQueuePath: "/tmp/relay.json" }), "json-file");
+  assert.equal(resolveGitHubRelayQueueBackend({}), "none");
+  assert.equal(
+    resolveGitHubRelayQueueBackend({
+      githubRelayQueueBackend: "json-file",
+      githubRelayQueueDir: "/tmp/relay",
+      githubRelayQueuePath: "/tmp/relay.json",
+    }),
+    "json-file",
+  );
+});
+
+test("createGitHubRelayJobQueueFromConfig creates configured durable backends", () => {
+  assert.equal(createGitHubRelayJobQueueFromConfig({}), undefined);
+  assert.ok(createGitHubRelayJobQueueFromConfig({ githubRelayQueueDir: "/tmp/relay" }) instanceof DirectoryGitHubRelayJobQueue);
+  assert.ok(createGitHubRelayJobQueueFromConfig({ githubRelayQueuePath: "/tmp/relay.json" }) instanceof JsonFileGitHubRelayJobQueue);
+  assert.throws(
+    () => createGitHubRelayJobQueueFromConfig({ githubRelayQueueBackend: "directory" }),
+    /GITHUB_RELAY_QUEUE_DIR is required/u,
+  );
+  assert.throws(
+    () => createGitHubRelayJobQueueFromConfig({ githubRelayQueueBackend: "json-file" }),
+    /GITHUB_RELAY_QUEUE_PATH is required/u,
+  );
 });
 
 test("GitHub webhook HTTP app uses mapped repository project ids", async () => {

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -24,6 +24,7 @@ export interface GitHubAppConfig {
   githubInstallationId?: string;
   githubPrivateKey?: string;
   followTerminalEvents: boolean;
+  githubRelayQueueBackend?: GitHubRelayQueueBackend;
   githubRelayQueuePath?: string;
   githubRelayQueueDir?: string;
   repositoryProjects: Record<string, string>;
@@ -180,6 +181,8 @@ export interface GitHubTerminalRelayJob {
   lastError?: string;
 }
 
+export type GitHubRelayQueueBackend = "none" | "directory" | "json-file";
+
 export interface GitHubRelayJobQueue {
   enqueue(input: { repositoryFullName: string; issueNumber: number; runId: string; reportUrl?: string; operatorUrl?: string }): Promise<GitHubTerminalRelayJob>;
   claimNext(now?: Date): Promise<GitHubTerminalRelayJob | undefined>;
@@ -235,6 +238,17 @@ function parseCsvList(value: string | undefined): string[] {
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function parseGitHubRelayQueueBackend(value: string | undefined): GitHubRelayQueueBackend | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase().replace(/_/gu, "-");
+  if (normalized === "none" || normalized === "directory" || normalized === "json-file") {
+    return normalized;
+  }
+  throw new Error(`invalid GITHUB_RELAY_QUEUE_BACKEND: ${value}`);
 }
 
 function normalizePrivateKey(value: string | undefined): string | undefined {
@@ -314,6 +328,7 @@ export function loadGitHubAppConfig(env: NodeJS.ProcessEnv = process.env): GitHu
     githubInstallationId: env.GITHUB_INSTALLATION_ID,
     githubPrivateKey: normalizePrivateKey(env.GITHUB_PRIVATE_KEY),
     followTerminalEvents: env.GITHUB_FOLLOW_TERMINAL_EVENTS === "true",
+    githubRelayQueueBackend: parseGitHubRelayQueueBackend(env.GITHUB_RELAY_QUEUE_BACKEND),
     githubRelayQueuePath: env.GITHUB_RELAY_QUEUE_PATH,
     githubRelayQueueDir: env.GITHUB_RELAY_QUEUE_DIR,
     repositoryProjects: parseRepositoryProjectMap(env.SPECRAIL_GITHUB_REPOSITORY_PROJECTS),
@@ -603,17 +618,47 @@ export const defaultGitHubCommandMetricsSink: GitHubCommandMetricsSink = {
   },
 };
 
+export function resolveGitHubRelayQueueBackend(
+  config: Pick<GitHubAppConfig, "githubRelayQueueBackend" | "githubRelayQueueDir" | "githubRelayQueuePath">,
+): GitHubRelayQueueBackend {
+  if (config.githubRelayQueueBackend) {
+    return config.githubRelayQueueBackend;
+  }
+  if (config.githubRelayQueueDir) {
+    return "directory";
+  }
+  if (config.githubRelayQueuePath) {
+    return "json-file";
+  }
+  return "none";
+}
+
+export function createGitHubRelayJobQueueFromConfig(
+  config: Pick<GitHubAppConfig, "githubRelayQueueBackend" | "githubRelayQueueDir" | "githubRelayQueuePath">,
+): GitHubRelayJobQueue | undefined {
+  const backend = resolveGitHubRelayQueueBackend(config);
+  if (backend === "none") {
+    return undefined;
+  }
+  if (backend === "directory") {
+    if (!config.githubRelayQueueDir) {
+      throw new Error("GITHUB_RELAY_QUEUE_DIR is required when GITHUB_RELAY_QUEUE_BACKEND=directory");
+    }
+    return new DirectoryGitHubRelayJobQueue(config.githubRelayQueueDir);
+  }
+  if (!config.githubRelayQueuePath) {
+    throw new Error("GITHUB_RELAY_QUEUE_PATH is required when GITHUB_RELAY_QUEUE_BACKEND=json-file");
+  }
+  return new JsonFileGitHubRelayJobQueue(config.githubRelayQueuePath);
+}
+
 export function startGitHubWebhookApp(input: { config?: GitHubAppConfig; specRail?: GitHubSpecRailPort; github?: GitHubIssueCommentPort } = {}): http.Server {
   const config = input.config ?? loadGitHubAppConfig();
   const specRail = input.specRail ?? createSpecRailHttpClient(config.apiBaseUrl);
   const tokenProvider = createGitHubTokenProviderFromConfig(config);
   const github = input.github ?? (tokenProvider ? createGitHubRestIssueCommentClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined);
   const authorization = tokenProvider ? createGitHubRestAuthorizationClient({ tokenProvider, apiBaseUrl: config.githubApiBaseUrl }) : undefined;
-  const relayQueue = config.githubRelayQueueDir
-    ? new DirectoryGitHubRelayJobQueue(config.githubRelayQueueDir)
-    : config.githubRelayQueuePath
-      ? new JsonFileGitHubRelayJobQueue(config.githubRelayQueuePath)
-      : undefined;
+  const relayQueue = createGitHubRelayJobQueueFromConfig(config);
   const server = createGitHubWebhookHttpServer({
     config,
     specRail,

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -55,6 +55,7 @@ The runnable app entrypoint reads these environment variables:
 | `GITHUB_INSTALLATION_ID` | unset | GitHub App installation id used for installation-token exchange. |
 | `GITHUB_PRIVATE_KEY` | unset | GitHub App private key PEM. Escaped newlines (`\\n`) are normalized at startup. |
 | `GITHUB_FOLLOW_TERMINAL_EVENTS` | `false` | When `true` and a GitHub comment client is supplied, schedule background following of the created run event stream and post one terminal outcome comment. |
+| `GITHUB_RELAY_QUEUE_BACKEND` | inferred | Optional explicit terminal relay queue backend: `directory`, `json-file`, or `none`. When unset, `GITHUB_RELAY_QUEUE_DIR` selects `directory`, `GITHUB_RELAY_QUEUE_PATH` selects `json-file`, and no queue config selects `none`. |
 | `GITHUB_RELAY_QUEUE_DIR` | unset | Preferred durable queue directory for terminal outcome relay jobs. Uses per-job JSON files and atomic claim renames for multi-process workers on the same POSIX-compatible filesystem. Takes precedence over `GITHUB_RELAY_QUEUE_PATH`. |
 | `GITHUB_RELAY_QUEUE_PATH` | unset | Legacy optional JSON-file durable queue path for terminal outcome relay jobs. Use only for local development or single-process deployments. When no durable queue is configured, the app uses the in-process scheduler fallback. |
 

--- a/docs/github-command-troubleshooting.md
+++ b/docs/github-command-troubleshooting.md
@@ -58,10 +58,11 @@ Webhook-level rejections such as invalid signatures, unsupported events, unsuppo
 ### Terminal comment relay does not post
 
 1. Confirm `GITHUB_FOLLOW_TERMINAL_EVENTS=true`.
-2. If `GITHUB_RELAY_QUEUE_DIR` is configured, check the durable queue directory exists, has `pending/`, `running/`, `completed/`, or `failed/` job files as expected, and is writable by the app. If using legacy `GITHUB_RELAY_QUEUE_PATH`, check the queue file exists and is writable.
-3. Confirm the run reached a terminal state: `completed`, `failed`, or `cancelled`.
-4. Confirm GitHub issue comment credentials are configured and can post to the repository.
-5. Non-terminal statuses are intentionally no-ops.
+2. Confirm the selected relay queue backend. `GITHUB_RELAY_QUEUE_BACKEND=directory` requires `GITHUB_RELAY_QUEUE_DIR`, `json-file` requires `GITHUB_RELAY_QUEUE_PATH`, and `none` uses only the in-process scheduler fallback.
+3. If `GITHUB_RELAY_QUEUE_DIR` is configured, check the durable queue directory exists, has `pending/`, `running/`, `completed/`, or `failed/` job files as expected, and is writable by the app. If using legacy `GITHUB_RELAY_QUEUE_PATH`, check the queue file exists and is writable.
+4. Confirm the run reached a terminal state: `completed`, `failed`, or `cancelled`.
+5. Confirm GitHub issue comment credentials are configured and can post to the repository.
+6. Non-terminal statuses are intentionally no-ops.
 
 ## Safe diagnostics policy
 


### PR DESCRIPTION
## Summary

- Extracted GitHub relay queue backend selection into resolveGitHubRelayQueueBackend and createGitHubRelayJobQueueFromConfig.
- Added explicit GITHUB_RELAY_QUEUE_BACKEND parsing while preserving existing GITHUB_RELAY_QUEUE_DIR > GITHUB_RELAY_QUEUE_PATH inferred behavior.
- Updated GitHub app setup and troubleshooting docs for backend selection.

## Validation

- pnpm test
- pnpm check
- pnpm build
- pnpm check:links

Closes #437
Refs #434